### PR TITLE
Serialize length instead of end offset

### DIFF
--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -85,7 +85,8 @@ public class Loader {
     private Nodes.Token loadToken() {
         int type = buffer.get() & 0xFF;
         int startOffset = buffer.getInt();
-        int endOffset = buffer.getInt();
+        int length = buffer.getInt();
+        int endOffset = startOffset + length;
 
         final Nodes.TokenType tokenType = Nodes.TOKEN_TYPES[type];
         return new Nodes.Token(tokenType, startOffset, endOffset);
@@ -93,7 +94,8 @@ public class Loader {
 
     private Nodes.Location loadLocation() {
         int startOffset = buffer.getInt();
-        int endOffset = buffer.getInt();
+        int length = buffer.getInt();
+        int endOffset = startOffset + length;
         return new Nodes.Location(startOffset, endOffset);
     }
 
@@ -112,7 +114,8 @@ public class Loader {
     private Nodes.Node loadNode() {
         int type = buffer.get() & 0xFF;
         int startOffset = buffer.getInt();
-        int endOffset = buffer.getInt();
+        int length = buffer.getInt();
+        int endOffset = startOffset + length;
 
         switch (type) {
             <%- nodes.each_with_index do |node, index| -%>

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -62,7 +62,8 @@ module YARP
       end
 
       def load_location
-        start_offset, end_offset = io.read(8).unpack("LL")
+        start_offset, length = io.read(8).unpack("LL")
+        end_offset = start_offset + length
         Location.new(start_offset, end_offset)
       end
 

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -7,19 +7,21 @@ static void
 serialize_token(yp_parser_t *parser, yp_token_t *token, yp_buffer_t *buffer) {
   assert(token->start);
   assert(token->end);
+  assert(token->start <= token->end);
 
   yp_buffer_append_u8(buffer, token->type);
   yp_buffer_append_u32(buffer, yp_long_to_u32(token->start - parser->start));
-  yp_buffer_append_u32(buffer, yp_long_to_u32(token->end - parser->start));
+  yp_buffer_append_u32(buffer, yp_long_to_u32(token->end - token->start));
 }
 
 static void
 serialize_location(yp_parser_t *parser, yp_location_t *location, yp_buffer_t *buffer) {
   assert(location->start);
   assert(location->end);
+  assert(location->start <= location->end);
 
   yp_buffer_append_u32(buffer, yp_long_to_u32(location->start - parser->start));
-  yp_buffer_append_u32(buffer, yp_long_to_u32(location->end - parser->start));
+  yp_buffer_append_u32(buffer, yp_long_to_u32(location->end - location->start));
 }
 
 void
@@ -28,11 +30,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
 
   size_t offset = buffer->length;
 
-  assert(node->location.start);
-  assert(node->location.end);
-
-  yp_buffer_append_u32(buffer, yp_long_to_u32(node->location.start - parser->start));
-  yp_buffer_append_u32(buffer, yp_long_to_u32(node->location.end - parser->start));
+  serialize_location(parser, &node->location, buffer);
 
   switch (node->type) {
     <%- nodes.each do |node| -%>

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -18,7 +18,7 @@ After the header comes the body of the serialized string. The body consistents o
 | `1` | node type |
 | `4` | byte offset into the serialized string where this node ends |
 | `4` | byte offset into the source string where this node begins |
-| `4` | byte offset into the source string where this node ends |
+| `4` | length of the node in bytes in the source string |
 
 Each node's child is then appended to the serialized string. The child node types can be determined by referencing `config.yml`. Depending on the type of child node, it could take a couple of different forms, described below:
 


### PR DESCRIPTION
* See #872.

This currently fails the added assert:
```
..............................................................................................................................
.....ruby: src/serialize.c:28: serialize_location: Assertion `location->start <= location->end' failed.
rake aborted!
SignalException: SIGABRT
```

I found with `gdb --args ruby -Ilib -Itest $f test/parse_test.rb`:
```
(gdb) bt
#0  0x00007ffff76afe5c in __pthread_kill_implementation () from /lib64/libc.so.6
#1  0x00007ffff765fa76 in raise () from /lib64/libc.so.6
#2  0x00007ffff76497fc in abort () from /lib64/libc.so.6
#3  0x00007ffff764971b in __assert_fail_base.cold () from /lib64/libc.so.6
#4  0x00007ffff7658656 in __assert_fail () from /lib64/libc.so.6
#5  0x00007fffe57a2d5a in serialize_location (parser=0x7fffffffc520, location=0x859848, buffer=0x7fffffffc500) at src/serialize.c:28
#6  0x00007fffe57a2e3f in yp_serialize_node (parser=0x7fffffffc520, node=0x859840, buffer=0x7fffffffc500) at src/serialize.c:41
#7  0x00007fffe57a6d9b in yp_serialize_node (parser=0x7fffffffc520, node=0x7378e0, buffer=0x7fffffffc500) at src/serialize.c:1104
#8  0x00007fffe57a6513 in yp_serialize_node (parser=0x7fffffffc520, node=0x735060, buffer=0x7fffffffc500) at src/serialize.c:953
#9  0x00007fffe57da796 in yp_serialize (parser=0x7fffffffc520, node=0x735060, buffer=0x7fffffffc500) at src/yarp.c:11802
#10 0x00007ffff75c3277 in dump_source (filepath=<optimized out>, source=0x7fffffffc750) at ../../../../ext/yarp/extension.c:79
#11 0x00007ffff75c3a29 in dump (self=<optimized out>, string=<optimized out>, filepath=<optimized out>) at ../../../../ext/yarp/extension.c:100
...

(gdb) up
#1  0x00007ffff765fa76 in raise () from /lib64/libc.so.6
(gdb) 
#2  0x00007ffff76497fc in abort () from /lib64/libc.so.6
(gdb) 
#3  0x00007ffff764971b in __assert_fail_base.cold () from /lib64/libc.so.6
(gdb) 
#4  0x00007ffff7658656 in __assert_fail () from /lib64/libc.so.6
(gdb) 
#5  0x00007fffe57a2d5a in serialize_location (parser=0x7fffffffc520, location=0x859848, buffer=0x7fffffffc500) at src/serialize.c:28
28	  assert(location->start <= location->end);
(gdb) p location
$1 = (yp_location_t *) 0x859848
(gdb) p *location
$2 = {
  start = 0x7fffe593503e "foo[bar, baz] = 1, 2, 3\n\n[a: [:b, :c]]\n\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d,\n]\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d\n\n\n]\n\n[foo => bar]\n\nfoo[bar][baz] = qux\n\nfoo[bar][baz]\n\n[\n]\n\nfoo[bar, baz]\n\nfoo[bar, baz] = qux\n\nfoo[0], bar[0] "..., 
  end = 0x7fffe5935038 "[*a]\n\nfoo[bar, baz] = 1, 2, 3\n\n[a: [:b, :c]]\n\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d,\n]\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d\n\n\n]\n\n[foo => bar]\n\nfoo[bar][baz] = qux\n\nfoo[bar][baz]\n\n[\n]\n\nfoo[bar, baz]\n\nfoo[bar, baz] = qux\n\nfoo[0], b"...}
(gdb) p node
No symbol "node" in current context.
(gdb) up
#6  0x00007fffe57a2e3f in yp_serialize_node (parser=0x7fffffffc520, node=0x859840, buffer=0x7fffffffc500) at src/serialize.c:41
41	  serialize_location(parser, &node->location, buffer);
(gdb) p node
$3 = (yp_node_t *) 0x859840
(gdb) p *node
$4 = {type = YP_NODE_CALL_NODE, location = {
    start = 0x7fffe593503e "foo[bar, baz] = 1, 2, 3\n\n[a: [:b, :c]]\n\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d,\n]\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d\n\n\n]\n\n[foo => bar]\n\nfoo[bar][baz] = qux\n\nfoo[bar][baz]\n\n[\n]\n\nfoo[bar, baz]\n\nfoo[bar, baz] = qux\n\nfoo[0], bar[0] "..., 
    end = 0x7fffe5935038 "[*a]\n\nfoo[bar, baz] = 1, 2, 3\n\n[a: [:b, :c]]\n\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d,\n]\n\n\n[:a, :b,\n:c,1,\n\n\n\n:d\n\n\n]\n\n[foo => bar]\n\nfoo[bar][baz] = qux\n\nfoo[bar][baz]\n\n[\n]\n\nfoo[bar, baz]\n\nfoo[bar, baz] = qux\n\nfoo[0], b"...}}
```
i.e. that call node has a start > end.