### PR TITLE
Add length() and endOffset() to migrate to (startOffset, length) in a compatible way

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -136,7 +136,7 @@ class NodeType
 
   # Should emit serialized length of node so implementations can skip
   # the node to enable lazy parsing.
-  def needs_length?
+  def needs_serialized_length?
     @name == "DefNode"
   end
 end

--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -135,7 +135,7 @@ public class Loader {
             <%- nodes.each_with_index do |node, index| -%>
             case <%= index + 1 %>:
             <%-
-            params = node.needs_length? ? ["buffer.getInt()"] : []
+            params = node.needs_serialized_length? ? ["buffer.getInt()"] : []
             params.concat node.params.map { |param|
               case param
               when NodeParam then "#{param.java_cast}loadNode()"

--- a/bin/templates/java/org/yarp/Nodes.java.erb
+++ b/bin/templates/java/org/yarp/Nodes.java.erb
@@ -29,6 +29,14 @@ public abstract class Nodes {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
         }
+
+        public int length() {
+            return endOffset - startOffset;
+        }
+
+        public int endOffset() {
+            return endOffset;
+        }
     }
 
     public static final class Location {
@@ -38,6 +46,14 @@ public abstract class Nodes {
         public Location(int startOffset, int endOffset) {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
+        }
+
+        public int length() {
+            return endOffset - startOffset;
+        }
+
+        public int endOffset() {
+            return endOffset;
         }
     }
 
@@ -51,6 +67,14 @@ public abstract class Nodes {
         public Node(int startOffset, int endOffset) {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
+        }
+
+        public int length() {
+            return endOffset - startOffset;
+        }
+
+        public int endOffset() {
+            return endOffset;
         }
 
         public abstract <T> T accept(AbstractNodeVisitor<T> visitor);

--- a/bin/templates/java/org/yarp/Nodes.java.erb
+++ b/bin/templates/java/org/yarp/Nodes.java.erb
@@ -102,22 +102,22 @@ public abstract class Nodes {
 
     <%= "#{node.comment.split("\n").map { |line| "// #{line}" }.join("\n    ")}\n" if node.comment -%>
     public static final class <%= node.name -%> extends Node {
-        <%- if node.needs_length? -%>
-        public final int length;
+        <%- if node.needs_serialized_length? -%>
+        public final int serializedLength;
         <%- end -%>
         <%- node.params.each do |param| -%>
         public final <%= param.java_type %> <%= param.name %>;<%= ' // optional' if param.class.name.start_with?('Optional') %>
         <%- end -%>
 
         <%-
-          params = node.needs_length? ? ["int length"] : []
+          params = node.needs_serialized_length? ? ["int serializedLength"] : []
           params.concat node.params.map { "#{_1.java_type} #{_1.name}" }
           params.concat ["int startOffset", "int endOffset"]
         -%>
         public <%=node.name -%>(<%= params.join(", ") %>) {
             super(startOffset, endOffset);
-        <%- if node.needs_length? -%>
-            this.length = length;
+        <%- if node.needs_serialized_length? -%>
+            this.serializedLength = serializedLength;
         <%- end -%>
         <%- node.params.each do |param| -%>
             this.<%= param.name %> = <%= param.name %>;

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -100,7 +100,7 @@ module YARP
         case type
         <%- nodes.each_with_index do |node, index| -%>
         when <%= index + 1 %> then
-        <%- if node.needs_length? -%>
+        <%- if node.needs_serialized_length? -%>
           load_serialized_length
         <%- end -%>
         <%= node.name %>.new(<%= (node.params.map { |param|

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -35,7 +35,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
   switch (node->type) {
     <%- nodes.each do |node| -%>
     case <%= node.type %>: {
-    <%- if node.needs_length? -%>
+    <%- if node.needs_serialized_length? -%>
         // serialize length
         // encoding of location u32s make us need to save this offset.
         size_t length_offset = buffer->length;
@@ -91,7 +91,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       <%- raise -%>
       <%- end -%>
       <%- end -%>
-      <%- if node.needs_length? -%>
+      <%- if node.needs_serialized_length? -%>
         // serialize length
         uint32_t length = yp_ulong_to_u32(buffer->length - offset - sizeof(uint32_t));
         memcpy(buffer->value + length_offset, &length, sizeof(uint32_t));      


### PR DESCRIPTION
For https://github.com/ruby/yarp/issues/872
By adding these methods, and TruffleRuby migrating to them, we can avoid breaking the `Test Loader.java with TruffleRuby` CI job.