### PR TITLE
Introduce flags, parse regular expression options

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -32,7 +32,6 @@ module KindTypes
   end
 end
 
-
 # This represents a parameter to a node that is itself a node. We pass them as
 # references and store them as references.
 class NodeParam < Param
@@ -162,6 +161,17 @@ class Token
   end
 end
 
+# Represents a set of flags that should be internally represented with an enum.
+class Flags
+  attr_reader :name, :human, :values
+
+  def initialize(config)
+    @name = config.fetch("name")
+    @human = @name.gsub(/(?<=.)[A-Z]/, "_\\0").downcase
+    @values = config.fetch("values")
+  end
+end
+
 # This templates out a file using ERB with the given locals. The locals are
 # derived from the config.yml file.
 def template(name, locals)
@@ -205,9 +215,11 @@ end
 
 def locals
   config = YAML.load_file(File.expand_path("../config.yml", __dir__))
+
   {
     nodes: config.fetch("nodes").map { |node| NodeType.new(node) }.sort_by(&:name),
-    tokens: config.fetch("tokens").map { |token| Token.new(token) }
+    tokens: config.fetch("tokens").map { |token| Token.new(token) },
+    flags: config.fetch("flags").map { |flags| Flags.new(flags) }
   }
 end
 

--- a/bin/templates/include/yarp/ast.h.erb
+++ b/bin/templates/include/yarp/ast.h.erb
@@ -62,8 +62,8 @@ typedef struct yp_node {
   // containing a start and an end.
   yp_location_t location;
 } yp_node_t;
-
 <%- nodes.each do |node| -%>
+
 // <%= node.name %>
 typedef struct yp_<%= node.human %> {
   yp_node_t base;
@@ -80,6 +80,15 @@ typedef struct yp_<%= node.human %> {
   %>;
 <%- end -%>
 } yp_<%= node.human %>_t;
-
 <%- end -%>
+<%- flags.each do |flag| -%>
+
+// <%= flag.name %>
+typedef enum {
+  <%- flag.values.each_with_index do |value, index| -%>
+  YP_<%= flag.human.upcase %>_<%= value %> = 1 << <%= index %>,
+  <%- end -%>
+} yp_<%= flag.human %>_t;
+<%- end -%>
+
 #endif // YARP_AST_H

--- a/bin/templates/java/org/yarp/Nodes.java.erb
+++ b/bin/templates/java/org/yarp/Nodes.java.erb
@@ -18,6 +18,12 @@ public abstract class Nodes {
     }
 
     static final TokenType[] TOKEN_TYPES = TokenType.values();
+<%- flags.each do |flag| -%>
+
+    <%- flag.values.each_with_index do |value, index| -%>
+    static final int <%= flag.human.upcase %>_<%= value.upcase %> = 1 << <%= index %>;
+    <%- end -%>
+<%- end -%>
 
     public static final class Token {
         public final TokenType type;

--- a/bin/templates/lib/yarp/node.rb.erb
+++ b/bin/templates/lib/yarp/node.rb.erb
@@ -6,7 +6,6 @@ module YARP
     attr_reader :<%= param.name %>
 
     <%- end -%>
-
     # def initialize: (<%= (node.params.map { |param| "#{param.name}: #{param.rbs_class}" } + ["start_offset: Integer", "length: Integer"]).join(", ") %>) -> void
     def initialize(<%= (node.params.map(&:name) + ["start_offset", "length"]).join(", ") %>)
       <%- node.params.each do |param| -%>
@@ -38,6 +37,14 @@ module YARP
     def deconstruct_keys(keys)
       { <%= (node.params.map { |param| "#{param.name}: #{param.name}" } + ["location: location"]).join(", ") %> }
     end
+  end
+
+  <%- end -%>
+  <%- flags.each do |flag| -%>
+  module <%= flag.name %>
+    <%- flag.values.each_with_index do |value, index| -%>
+    <%= value %> = 1 << <%= index %>
+    <%- end -%>
   end
 
   <%- end -%>

--- a/config.yml
+++ b/config.yml
@@ -316,6 +316,17 @@ tokens:
     comment: "a separator between words in a list"
   - name: __END__
     comment: "marker for the point in the file at which the parser should stop"
+flags:
+  - name: RegularExpressionFlags
+    values:
+      - IGNORECASE # i - ignores the case of characters when matching
+      - MULTILINE  # m - allows $ to match the end of lines within strings
+      - EXTEND     # x - ignores whitespace and allows comments in regular expressions
+      - EUCJP      # e - forces the EUC-JP encoding
+      - ASCII8BIT  # n - forces the ASCII-8BIT encoding
+      - WINDOWS31J # s - forces the Windows-31J encoding
+      - UTF8       # u - forces the UTF-8 encoding
+      - ONCE       # o - only interpolates values into the regular expression once
 nodes:
   - name: AliasNode
     child_nodes:
@@ -976,6 +987,8 @@ nodes:
         type: node[]
       - name: closing
         type: token
+      - name: flags
+        type: uint32
     comment: |
       Represents a regular expression literal that contains interpolation.
 
@@ -1405,6 +1418,8 @@ nodes:
         type: token
       - name: unescaped
         type: string
+      - name: flags
+        type: uint32
     comment: |
       Represents a regular expression literal with no interpolation.
 

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -151,7 +151,8 @@ ProgramNode(0...3725)(
          REGEXP_BEGIN(99...100)("/"),
          STRING_CONTENT(100...103)("foo"),
          REGEXP_END(103...104)("/"),
-         "foo"
+         "foo",
+         0
        ),
        (96...98)
      ),
@@ -639,13 +640,15 @@ ProgramNode(0...3725)(
            REGEXP_BEGIN(496...497)("/"),
            STRING_CONTENT(497...500)("foo"),
            REGEXP_END(500...501)("/"),
-           "foo"
+           "foo",
+           0
          ),
          RegularExpressionNode(505...510)(
            REGEXP_BEGIN(505...506)("/"),
            STRING_CONTENT(506...509)("foo"),
            REGEXP_END(509...510)("/"),
-           "foo"
+           "foo",
+           0
          ),
          (502...504)
        ),
@@ -2103,7 +2106,8 @@ ProgramNode(0...3725)(
          REGEXP_BEGIN(1729...1730)("/"),
          STRING_CONTENT(1730...1733)("foo"),
          REGEXP_END(1733...1734)("/"),
-         "foo"
+         "foo",
+         0
        ),
        (1726...1728)
      ),
@@ -2614,7 +2618,8 @@ ProgramNode(0...3725)(
             REGEXP_BEGIN(2210...2211)("/"),
             STRING_CONTENT(2211...2214)("foo"),
             REGEXP_END(2214...2215)("/"),
-            "foo"
+            "foo",
+            0
           ),
           nil,
           (2207...2209),
@@ -3316,7 +3321,8 @@ ProgramNode(0...3725)(
                  REGEXP_BEGIN(3011...3012)("/"),
                  STRING_CONTENT(3012...3015)("foo"),
                  REGEXP_END(3015...3016)("/"),
-                 "foo"
+                 "foo",
+                 0
                )]
             ),
             nil,

--- a/test/snapshots/regex.rb
+++ b/test/snapshots/regex.rb
@@ -11,7 +11,8 @@ ProgramNode(0...278)(
             REGEXP_BEGIN(4...5)("/"),
             STRING_CONTENT(5...8)("bar"),
             REGEXP_END(8...9)("/"),
-            "bar"
+            "bar",
+            0
           )]
        ),
        nil,
@@ -22,19 +23,22 @@ ProgramNode(0...278)(
        REGEXP_BEGIN(11...14)("%r{"),
        STRING_CONTENT(14...17)("abc"),
        REGEXP_END(17...19)("}i"),
-       "abc"
+       "abc",
+       1
      ),
      RegularExpressionNode(21...26)(
        REGEXP_BEGIN(21...22)("/"),
        STRING_CONTENT(22...25)("a\\b"),
        REGEXP_END(25...26)("/"),
-       "a\b"
+       "a\b",
+       0
      ),
      InterpolatedRegularExpressionNode(28...39)(
        REGEXP_BEGIN(28...29)("/"),
        [StringNode(29...33)(nil, STRING_CONTENT(29...33)("aaa "), nil, "aaa "),
         GlobalVariableReadNode(34...38)(GLOBAL_VARIABLE(34...38)("$bbb"))],
-       REGEXP_END(38...39)("/")
+       REGEXP_END(38...39)("/"),
+       0
      ),
      InterpolatedRegularExpressionNode(41...57)(
        REGEXP_BEGIN(41...42)("/"),
@@ -61,7 +65,8 @@ ProgramNode(0...278)(
           nil,
           " ccc"
         )],
-       REGEXP_END(56...57)("/")
+       REGEXP_END(56...57)("/"),
+       0
      ),
      ArrayNode(59...86)(
        [CallNode(60...80)(
@@ -69,7 +74,8 @@ ProgramNode(0...278)(
             REGEXP_BEGIN(60...61)("/"),
             STRING_CONTENT(61...72)("(?<foo>bar)"),
             REGEXP_END(72...73)("/"),
-            "(?<foo>bar)"
+            "(?<foo>bar)",
+            0
           ),
           nil,
           EQUAL_TILDE(74...76)("=~"),
@@ -98,25 +104,29 @@ ProgramNode(0...278)(
        REGEXP_BEGIN(88...89)("/"),
        STRING_CONTENT(89...92)("abc"),
        REGEXP_END(92...94)("/i"),
-       "abc"
+       "abc",
+       1
      ),
      RegularExpressionNode(96...122)(
        REGEXP_BEGIN(96...99)("%r/"),
        STRING_CONTENT(99...120)("[a-z$._?][\\w$.?\#@~]*:"),
        REGEXP_END(120...122)("/i"),
-       "[a-z$._?][w$.?\#@~]*:"
+       "[a-z$._?][w$.?\#@~]*:",
+       1
      ),
      RegularExpressionNode(124...161)(
        REGEXP_BEGIN(124...127)("%r/"),
        STRING_CONTENT(127...159)("([a-z$._?][\\w$.?\#@~]*)(\\s+)(equ)"),
        REGEXP_END(159...161)("/i"),
-       "([a-z$._?][w$.?\#@~]*)( +)(equ)"
+       "([a-z$._?][w$.?\#@~]*)( +)(equ)",
+       1
      ),
      RegularExpressionNode(163...188)(
        REGEXP_BEGIN(163...166)("%r/"),
        STRING_CONTENT(166...186)("[a-z$._?][\\w$.?\#@~]*"),
        REGEXP_END(186...188)("/i"),
-       "[a-z$._?][w$.?\#@~]*"
+       "[a-z$._?][w$.?\#@~]*",
+       1
      ),
      RegularExpressionNode(190...249)(
        REGEXP_BEGIN(190...193)("%r("),
@@ -126,14 +136,16 @@ ProgramNode(0...278)(
          "  (?:[\\w\#$%_']+)\n"
        ),
        REGEXP_END(248...249)(")"),
-       "\n" + "(?:[w\#$%_']|()|(,)|[]|[0-9])*\n" + "  (?:[w\#$%_']+)\n"
+       "\n" + "(?:[w\#$%_']|()|(,)|[]|[0-9])*\n" + "  (?:[w\#$%_']+)\n",
+       0
      ),
      CallNode(251...267)(
        RegularExpressionNode(251...259)(
          REGEXP_BEGIN(251...252)("/"),
          STRING_CONTENT(252...258)("(?#\\))"),
          REGEXP_END(258...259)("/"),
-         "(?#))"
+         "(?#))",
+         0
        ),
        nil,
        EQUAL_TILDE(260...262)("=~"),
@@ -154,7 +166,8 @@ ProgramNode(0...278)(
        REGEXP_BEGIN(269...272)("%r#"),
        STRING_CONTENT(272...277)("pound"),
        REGEXP_END(277...278)("#"),
-       "pound"
+       "pound",
+       0
      )]
   )
 )

--- a/test/snapshots/seattlerb/bug190.rb
+++ b/test/snapshots/seattlerb/bug190.rb
@@ -5,7 +5,8 @@ ProgramNode(0...6)(
        REGEXP_BEGIN(0...3)("%r'"),
        STRING_CONTENT(3...5)("\\'"),
        REGEXP_END(5...6)("'"),
-       "'"
+       "'",
+       0
      )]
   )
 )

--- a/test/snapshots/seattlerb/bug_case_when_regexp.rb
+++ b/test/snapshots/seattlerb/bug_case_when_regexp.rb
@@ -14,7 +14,8 @@ ProgramNode(0...26)(
              REGEXP_BEGIN(14...15)("/"),
              STRING_CONTENT(15...16)("x"),
              REGEXP_END(16...17)("/"),
-             "x"
+             "x",
+             0
            )],
           nil
         )],

--- a/test/snapshots/seattlerb/bug_cond_pct.rb
+++ b/test/snapshots/seattlerb/bug_cond_pct.rb
@@ -9,7 +9,8 @@ ProgramNode(0...28)(
              REGEXP_BEGIN(11...14)("%r%"),
              STRING_CONTENT(14...22)("blahblah"),
              REGEXP_END(22...23)("%"),
-             "blahblah"
+             "blahblah",
+             0
            )],
           nil
         )],

--- a/test/snapshots/seattlerb/case_in.rb
+++ b/test/snapshots/seattlerb/case_in.rb
@@ -256,7 +256,8 @@ ProgramNode(0...747)(
             REGEXP_BEGIN(267...268)("/"),
             STRING_CONTENT(268...274)("regexp"),
             REGEXP_END(274...275)("/"),
-            "regexp"
+            "regexp",
+            0
           ),
           nil,
           (264...266),

--- a/test/snapshots/seattlerb/regexp.rb
+++ b/test/snapshots/seattlerb/regexp.rb
@@ -5,31 +5,36 @@ ProgramNode(0...45)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...4)("wtf"),
        REGEXP_END(4...5)("/"),
-       "wtf"
+       "wtf",
+       0
      ),
      RegularExpressionNode(7...13)(
        REGEXP_BEGIN(7...8)("/"),
        STRING_CONTENT(8...11)("wtf"),
        REGEXP_END(11...13)("/m"),
-       "wtf"
+       "wtf",
+       2
      ),
      RegularExpressionNode(15...21)(
        REGEXP_BEGIN(15...16)("/"),
        STRING_CONTENT(16...19)("wtf"),
        REGEXP_END(19...21)("/n"),
-       "wtf"
+       "wtf",
+       16
      ),
      RegularExpressionNode(23...30)(
        REGEXP_BEGIN(23...24)("/"),
        STRING_CONTENT(24...27)("wtf"),
        REGEXP_END(27...30)("/nm"),
-       "wtf"
+       "wtf",
+       18
      ),
      RegularExpressionNode(32...45)(
        REGEXP_BEGIN(32...33)("/"),
        STRING_CONTENT(33...36)("wtf"),
        REGEXP_END(36...45)("/nmnmnmnm"),
-       "wtf"
+       "wtf",
+       18
      )]
   )
 )

--- a/test/snapshots/seattlerb/regexp_esc_C_slash.rb
+++ b/test/snapshots/seattlerb/regexp_esc_C_slash.rb
@@ -5,7 +5,8 @@ ProgramNode(0...7)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...6)("\\cC\\d"),
        REGEXP_END(6...7)("/"),
-       "\u0003d"
+       "\u0003d",
+       0
      )]
   )
 )

--- a/test/snapshots/seattlerb/regexp_esc_u.rb
+++ b/test/snapshots/seattlerb/regexp_esc_u.rb
@@ -5,7 +5,8 @@ ProgramNode(0...17)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...16)("[\\u0021-\\u0027]"),
        REGEXP_END(16...17)("/"),
-       "[!-']"
+       "[!-']",
+       0
      )]
   )
 )

--- a/test/snapshots/seattlerb/regexp_escape_extended.rb
+++ b/test/snapshots/seattlerb/regexp_escape_extended.rb
@@ -5,7 +5,8 @@ ProgramNode(0...6)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...5)("\\“"),
        REGEXP_END(5...6)("/"),
-       "“"
+       "“",
+       0
      )]
   )
 )

--- a/test/snapshots/seattlerb/regexp_unicode_curlies.rb
+++ b/test/snapshots/seattlerb/regexp_unicode_curlies.rb
@@ -5,13 +5,15 @@ ProgramNode(0...25)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...14)("\\u{c0de babe}"),
        REGEXP_END(14...15)("/"),
-       "샞몾"
+       "샞몾",
+       0
      ),
      RegularExpressionNode(17...25)(
        REGEXP_BEGIN(17...18)("/"),
        STRING_CONTENT(18...24)("\\u{df}"),
        REGEXP_END(24...25)("/"),
-       "ß"
+       "ß",
+       0
      )]
   )
 )

--- a/test/snapshots/unescaping.rb
+++ b/test/snapshots/unescaping.rb
@@ -15,7 +15,8 @@ ProgramNode(0...55)(
        REGEXP_BEGIN(12...13)("/"),
        STRING_CONTENT(13...19)("\\c\#{1}"),
        REGEXP_END(19...20)("/"),
-       "\u0003{1}"
+       "\u0003{1}",
+       0
      ),
      StringNode(22...30)(
        STRING_BEGIN(22...23)("\""),

--- a/test/snapshots/unparser/corpus/literal/if.rb
+++ b/test/snapshots/unparser/corpus/literal/if.rb
@@ -7,7 +7,8 @@ ProgramNode(0...246)(
          REGEXP_BEGIN(3...4)("/"),
          STRING_CONTENT(4...7)("foo"),
          REGEXP_END(7...8)("/"),
-         "foo"
+         "foo",
+         0
        ),
        StatementsNode(11...14)(
          [CallNode(11...14)(

--- a/test/snapshots/unparser/corpus/literal/literal.rb
+++ b/test/snapshots/unparser/corpus/literal/literal.rb
@@ -517,13 +517,15 @@ ProgramNode(0...916)(
        REGEXP_BEGIN(480...481)("/"),
        STRING_CONTENT(481...484)("foo"),
        REGEXP_END(484...485)("/"),
-       "foo"
+       "foo",
+       0
      ),
      RegularExpressionNode(486...514)(
        REGEXP_BEGIN(486...487)("/"),
        STRING_CONTENT(487...513)("[^-+',.\\/:@[:alnum:]\\[\\]]+"),
        REGEXP_END(513...514)("/"),
-       "[^-+',./:@[:alnum:][]]+"
+       "[^-+',./:@[:alnum:][]]+",
+       0
      ),
      InterpolatedRegularExpressionNode(515...527)(
        REGEXP_BEGIN(515...516)("/"),
@@ -538,7 +540,8 @@ ProgramNode(0...916)(
           StatementsNode(521...525)([InstanceVariableReadNode(521...525)()]),
           EMBEXPR_END(525...526)("}")
         )],
-       REGEXP_END(526...527)("/")
+       REGEXP_END(526...527)("/"),
+       0
      ),
      InterpolatedRegularExpressionNode(528...543)(
        REGEXP_BEGIN(528...529)("/"),
@@ -553,7 +556,8 @@ ProgramNode(0...916)(
           StatementsNode(534...538)([InstanceVariableReadNode(534...538)()]),
           EMBEXPR_END(538...539)("}")
         )],
-       REGEXP_END(539...543)("/imx")
+       REGEXP_END(539...543)("/imx"),
+       7
      ),
      InterpolatedRegularExpressionNode(544...557)(
        REGEXP_BEGIN(544...545)("/"),
@@ -569,31 +573,36 @@ ProgramNode(0...916)(
           ),
           EMBEXPR_END(555...556)("}")
         )],
-       REGEXP_END(556...557)("/")
+       REGEXP_END(556...557)("/"),
+       0
      ),
      RegularExpressionNode(558...562)(
        REGEXP_BEGIN(558...559)("/"),
        STRING_CONTENT(559...561)("\\n"),
        REGEXP_END(561...562)("/"),
-       "\n"
+       "\n",
+       0
      ),
      RegularExpressionNode(563...567)(
        REGEXP_BEGIN(563...564)("/"),
        STRING_CONTENT(564...566)("\\n"),
        REGEXP_END(566...567)("/"),
-       "\n"
+       "\n",
+       0
      ),
      RegularExpressionNode(568...573)(
        REGEXP_BEGIN(568...569)("/"),
        STRING_CONTENT(569...571)("\\n"),
        REGEXP_END(571...573)("/x"),
-       "\n"
+       "\n",
+       4
      ),
      RegularExpressionNode(574...581)(
        REGEXP_BEGIN(574...575)("/"),
        STRING_CONTENT(575...579)("\\/\\/"),
        REGEXP_END(579...581)("/x"),
-       "//"
+       "//",
+       4
      ),
      InterpolatedSymbolNode(582...597)(
        SYMBOL_BEGIN(582...584)(":\""),

--- a/test/snapshots/unparser/corpus/literal/send.rb
+++ b/test/snapshots/unparser/corpus/literal/send.rb
@@ -370,7 +370,8 @@ ProgramNode(0...991)(
                 REGEXP_BEGIN(320...321)("/"),
                 STRING_CONTENT(321...324)("bar"),
                 REGEXP_END(324...325)("/"),
-                "bar"
+                "bar",
+                0
               ),
               nil,
               EQUAL_TILDE(326...328)("=~"),
@@ -441,7 +442,8 @@ ProgramNode(0...991)(
                    REGEXP_BEGIN(358...359)("/"),
                    STRING_CONTENT(359...362)("bar"),
                    REGEXP_END(362...363)("/"),
-                   "bar"
+                   "bar",
+                   0
                  )]
               ),
               nil,
@@ -465,7 +467,8 @@ ProgramNode(0...991)(
          REGEXP_BEGIN(369...370)("/"),
          STRING_CONTENT(370...373)("bar"),
          REGEXP_END(373...374)("/"),
-         "bar"
+         "bar",
+         0
        ),
        nil,
        EQUAL_TILDE(375...377)("=~"),
@@ -487,7 +490,8 @@ ProgramNode(0...991)(
          REGEXP_BEGIN(383...384)("/"),
          STRING_CONTENT(384...387)("bar"),
          REGEXP_END(387...388)("/"),
-         "bar"
+         "bar",
+         0
        ),
        nil,
        EQUAL_TILDE(389...391)("=~"),
@@ -665,7 +669,8 @@ ProgramNode(0...991)(
             REGEXP_BEGIN(458...459)("/"),
             STRING_CONTENT(459...462)("bar"),
             REGEXP_END(462...463)("/"),
-            "bar"
+            "bar",
+            0
           )]
        ),
        nil,
@@ -892,7 +897,8 @@ ProgramNode(0...991)(
                  REGEXP_BEGIN(576...577)("/"),
                  STRING_CONTENT(577...580)("bar"),
                  REGEXP_END(580...581)("/"),
-                 "bar"
+                 "bar",
+                 0
                )]
             ),
             nil,

--- a/test/snapshots/unparser/corpus/semantic/literal.rb
+++ b/test/snapshots/unparser/corpus/semantic/literal.rb
@@ -36,13 +36,15 @@ ProgramNode(0...131)(
        REGEXP_BEGIN(58...61)("%r("),
        STRING_CONTENT(61...62)("/"),
        REGEXP_END(62...63)(")"),
-       "/"
+       "/",
+       0
      ),
      RegularExpressionNode(64...70)(
        REGEXP_BEGIN(64...67)("%r("),
        STRING_CONTENT(67...69)("\\)"),
        REGEXP_END(69...70)(")"),
-       ")"
+       ")",
+       0
      ),
      InterpolatedRegularExpressionNode(71...85)(
        REGEXP_BEGIN(71...74)("%r("),
@@ -52,7 +54,8 @@ ProgramNode(0...131)(
           EMBEXPR_END(80...81)("}")
         ),
         StringNode(81...84)(nil, STRING_CONTENT(81...84)("baz"), nil, "baz")],
-       REGEXP_END(84...85)(")")
+       REGEXP_END(84...85)(")"),
+       0
      ),
      FloatNode(86...102)(),
      CallNode(103...120)(

--- a/test/snapshots/whitequark/bug_regex_verification.rb
+++ b/test/snapshots/whitequark/bug_regex_verification.rb
@@ -5,7 +5,8 @@ ProgramNode(0...5)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...3)("#)"),
        REGEXP_END(3...5)("/x"),
-       "#)"
+       "#)",
+       4
      )]
   )
 )

--- a/test/snapshots/whitequark/cond_match_current_line.rb
+++ b/test/snapshots/whitequark/cond_match_current_line.rb
@@ -6,7 +6,8 @@ ProgramNode(0...21)(
          REGEXP_BEGIN(1...2)("/"),
          STRING_CONTENT(2...5)("wat"),
          REGEXP_END(5...6)("/"),
-         "wat"
+         "wat",
+         0
        ),
        nil,
        BANG(0...1)("!"),
@@ -22,7 +23,8 @@ ProgramNode(0...21)(
          REGEXP_BEGIN(11...12)("/"),
          STRING_CONTENT(12...15)("wat"),
          REGEXP_END(15...16)("/"),
-         "wat"
+         "wat",
+         0
        ),
        nil,
        nil,

--- a/test/snapshots/whitequark/interp_digit_var.rb
+++ b/test/snapshots/whitequark/interp_digit_var.rb
@@ -101,13 +101,15 @@ ProgramNode(1...476)(
        REGEXP_BEGIN(139...142)("%r{"),
        STRING_CONTENT(142...145)("\#@1"),
        REGEXP_END(145...146)("}"),
-       "\#@1"
+       "\#@1",
+       0
      ),
      RegularExpressionNode(150...158)(
        REGEXP_BEGIN(150...153)("%r{"),
        STRING_CONTENT(153...157)("\#@@1"),
        REGEXP_END(157...158)("}"),
-       "\#@@1"
+       "\#@@1",
+       0
      ),
      SymbolNode(162...169)(
        SYMBOL_BEGIN(162...165)("%s{"),
@@ -181,13 +183,15 @@ ProgramNode(1...476)(
        REGEXP_BEGIN(275...276)("/"),
        STRING_CONTENT(276...279)("\#@1"),
        REGEXP_END(279...280)("/"),
-       "\#@1"
+       "\#@1",
+       0
      ),
      RegularExpressionNode(284...290)(
        REGEXP_BEGIN(284...285)("/"),
        STRING_CONTENT(285...289)("\#@@1"),
        REGEXP_END(289...290)("/"),
-       "\#@@1"
+       "\#@@1",
+       0
      ),
      InterpolatedSymbolNode(294...300)(
        SYMBOL_BEGIN(294...296)(":\""),

--- a/test/snapshots/whitequark/lvar_injecting_match.rb
+++ b/test/snapshots/whitequark/lvar_injecting_match.rb
@@ -6,7 +6,8 @@ ProgramNode(0...31)(
          REGEXP_BEGIN(0...1)("/"),
          STRING_CONTENT(1...14)("(?<match>bar)"),
          REGEXP_END(14...15)("/"),
-         "(?<match>bar)"
+         "(?<match>bar)",
+         0
        ),
        nil,
        EQUAL_TILDE(16...18)("=~"),

--- a/test/snapshots/whitequark/non_lvar_injecting_match.rb
+++ b/test/snapshots/whitequark/non_lvar_injecting_match.rb
@@ -15,7 +15,8 @@ ProgramNode(0...28)(
             nil,
             "(?<match>bar)"
           )],
-         REGEXP_END(18...19)("/")
+         REGEXP_END(18...19)("/"),
+         0
        ),
        nil,
        EQUAL_TILDE(20...22)("=~"),

--- a/test/snapshots/whitequark/parser_bug_830.rb
+++ b/test/snapshots/whitequark/parser_bug_830.rb
@@ -5,7 +5,8 @@ ProgramNode(0...4)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...3)("\\("),
        REGEXP_END(3...4)("/"),
-       "("
+       "(",
+       0
      )]
   )
 )

--- a/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
+++ b/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
@@ -53,7 +53,8 @@ ProgramNode(0...210)(
        REGEXP_BEGIN(58...61)("%r{"),
        STRING_CONTENT(61...65)("a\\\n" + "b"),
        REGEXP_END(65...66)("}"),
-       "a\n" + "b"
+       "a\n" + "b",
+       0
      ),
      SymbolNode(68...76)(
        SYMBOL_BEGIN(68...71)("%s{"),
@@ -93,7 +94,8 @@ ProgramNode(0...210)(
        REGEXP_BEGIN(115...116)("/"),
        STRING_CONTENT(116...120)("a\\\n" + "b"),
        REGEXP_END(120...121)("/"),
-       "a\n" + "b"
+       "a\n" + "b",
+       0
      ),
      InterpolatedSymbolNode(123...130)(
        SYMBOL_BEGIN(123...125)(":\""),

--- a/test/snapshots/whitequark/regex_interp.rb
+++ b/test/snapshots/whitequark/regex_interp.rb
@@ -21,7 +21,8 @@ ProgramNode(0...14)(
           EMBEXPR_END(9...10)("}")
         ),
         StringNode(10...13)(nil, STRING_CONTENT(10...13)("baz"), nil, "baz")],
-       REGEXP_END(13...14)("/")
+       REGEXP_END(13...14)("/"),
+       0
      )]
   )
 )

--- a/test/snapshots/whitequark/regex_plain.rb
+++ b/test/snapshots/whitequark/regex_plain.rb
@@ -5,7 +5,8 @@ ProgramNode(0...10)(
        REGEXP_BEGIN(0...1)("/"),
        STRING_CONTENT(1...7)("source"),
        REGEXP_END(7...10)("/im"),
-       "source"
+       "source",
+       3
      )]
   )
 )

--- a/test/snapshots/whitequark/ruby_bug_11873.rb
+++ b/test/snapshots/whitequark/ruby_bug_11873.rb
@@ -92,7 +92,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(32...33)("/"),
             STRING_CONTENT(33...34)("x"),
             REGEXP_END(34...35)("/"),
-            "x"
+            "x",
+            0
           )]
        ),
        nil,
@@ -141,7 +142,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(54...55)("/"),
             STRING_CONTENT(55...56)("x"),
             REGEXP_END(56...58)("/m"),
-            "x"
+            "x",
+            2
           )]
        ),
        nil,
@@ -239,7 +241,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(101...102)("/"),
             STRING_CONTENT(102...103)("x"),
             REGEXP_END(103...104)("/"),
-            "x"
+            "x",
+            0
           )]
        ),
        nil,
@@ -288,7 +291,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(124...125)("/"),
             STRING_CONTENT(125...126)("x"),
             REGEXP_END(126...128)("/m"),
-            "x"
+            "x",
+            2
           )]
        ),
        nil,
@@ -398,7 +402,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(169...170)("/"),
             STRING_CONTENT(170...171)("x"),
             REGEXP_END(171...172)("/"),
-            "x"
+            "x",
+            0
           )]
        ),
        nil,
@@ -453,7 +458,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(191...192)("/"),
             STRING_CONTENT(192...193)("x"),
             REGEXP_END(193...195)("/m"),
-            "x"
+            "x",
+            2
           )]
        ),
        nil,
@@ -563,7 +569,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(238...239)("/"),
             STRING_CONTENT(239...240)("x"),
             REGEXP_END(240...241)("/"),
-            "x"
+            "x",
+            0
           )]
        ),
        nil,
@@ -618,7 +625,8 @@ ProgramNode(0...272)(
             REGEXP_BEGIN(261...262)("/"),
             STRING_CONTENT(262...263)("x"),
             REGEXP_END(263...265)("/m"),
-            "x"
+            "x",
+            2
           )]
        ),
        nil,


### PR DESCRIPTION
Fixes #760.

This introduces a new concept to `config.yml` which is sets of flags. Flags are meant to be used in conjunction with `uint32_t` parameters and function as bitfields.

The first place we introduce this is for regular expressions and interpolated regular expressions. We now parse each of the options given on the end of the string into a bitfield. Since we're now serializing variable-length integers, for the most part this only adds a single byte per regular expression to the serialized output.

It does add 4 bytes to each regular expression in memory on the C side, but I think it's worth it to make it easier on the consumer. Future optimizations could recognize the maximum value of the integer and shrink to fit.

Since I'm just using `uint32_t` parameters to hold the actual bitfields, there's no direct link from the enum to the value. So I tried to be nice and add an enum in Java and constants in Ruby to make it more obvious to the consumer how to interact with it. I don't really know what I'm doing on the Java side so @eregon or @enebo let me know if there's a better way to express that.