### PR TITLE
Refactor templating to set up for mirroring

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,19 +33,7 @@ end
 
 task default: :test
 
-TEMPLATES = [
-  "ext/yarp/node.c",
-  "include/yarp/ast.h",
-  "java/org/yarp/Loader.java",
-  "java/org/yarp/Nodes.java",
-  "java/org/yarp/AbstractNodeVisitor.java",
-  "lib/yarp/node.rb",
-  "lib/yarp/serialize.rb",
-  "src/node.c",
-  "src/prettyprint.c",
-  "src/serialize.c",
-  "src/token_type.c"
-]
+require_relative "bin/template"
 
 desc "Generate all ERB template based files"
 task templates: TEMPLATES
@@ -76,7 +64,6 @@ CLOBBER << "lib/yarp.#{dylib_extension}"
 TEMPLATES.each do |filepath|
   desc "Template #{filepath}"
   file filepath => ["bin/templates/#{filepath}.erb", "bin/template.rb", "config.yml"] do |t|
-    require_relative "bin/template"
     template(t.name, locals)
   end
 end

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -210,3 +210,21 @@ def locals
     tokens: config.fetch("tokens").map { |token| Token.new(token) }
   }
 end
+
+TEMPLATES = [
+  "ext/yarp/node.c",
+  "include/yarp/ast.h",
+  "java/org/yarp/Loader.java",
+  "java/org/yarp/Nodes.java",
+  "java/org/yarp/AbstractNodeVisitor.java",
+  "lib/yarp/node.rb",
+  "lib/yarp/serialize.rb",
+  "src/node.c",
+  "src/prettyprint.c",
+  "src/serialize.c",
+  "src/token_type.c"
+]
+
+if __FILE__ == $0
+  TEMPLATES.each { |f| template f, locals }
+end


### PR DESCRIPTION
Slight templating refactor to allow us to run the template script directly via `ruby bin/template.rb` which will let us easily run this script and generate the templated files when we mirror to ruby/ruby