### PR TITLE
Refactor default visibility attribute into a macro

### DIFF
--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -82,7 +82,7 @@ yp_node_list_append(yp_node_list_t *list, yp_node_t *node) {
   list->nodes[list->size++] = node;
 }
 
-__attribute__((__visibility__("default"))) void
+EXPORTED void
 yp_node_destroy(yp_parser_t *parser, yp_node_t *node);
 
 // Deallocate the inner memory of a list of nodes. The parser argument is not
@@ -100,7 +100,7 @@ yp_node_list_free(yp_parser_t *parser, yp_node_list_t *list) {
 // Deallocate the space for a yp_node_t. Similarly to yp_node_alloc, we're not
 // using the parser argument, but it's there to allow for the future possibility
 // of pre-allocating larger memory pools.
-__attribute__((__visibility__("default"))) void
+EXPORTED void
 yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
   switch (node->type) {
     <%- nodes.each do |node| -%>
@@ -171,7 +171,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
 }
 
 // Calculates the memory footprint of a given node.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize) {
   *memsize = (yp_memsize_t) { .memsize = 0, .node_count = 0 };
   yp_node_memsize_node(node, memsize);

--- a/bin/templates/src/prettyprint.c.erb
+++ b/bin/templates/src/prettyprint.c.erb
@@ -92,7 +92,7 @@ yp_print_node(yp_parser_t *parser, yp_node_t *node) {
 }
 
 // Pretty-prints the AST represented by the given node to the given buffer.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_prettyprint(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
   prettyprint_node(buffer, parser, node);
 }

--- a/bin/templates/src/token_type.c.erb
+++ b/bin/templates/src/token_type.c.erb
@@ -3,7 +3,7 @@
 #include "yarp/ast.h"
 
 // Returns a string representation of the given token type.
-__attribute__((__visibility__("default"))) const char *
+EXPORTED const char *
 yp_token_type_to_str(yp_token_type_t token_type)
 {
   switch (token_type) {

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -72,7 +72,7 @@ typedef yp_encoding_t *(*yp_encoding_decode_callback_t)(yp_parser_t *parser, con
 // return NULL if it also doesn't understand the encoding or it should return a
 // pointer to a yp_encoding_t struct that contains the functions necessary to
 // parse identifiers.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback);
 ```
 
@@ -87,6 +87,6 @@ typedef void (*yp_encoding_changed_callback_t)(yp_parser_t *parser);
 
 // Register a callback that will be called whenever YARP changes the encoding it
 // is using to parse based on the magic comment.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
 ```

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -35,16 +35,16 @@ void
 yp_print_node(yp_parser_t *parser, yp_node_t *node);
 
 // Returns the YARP version and notably the serialization format
-__attribute__((__visibility__("default"))) extern const char *
+EXPORTED extern const char *
 yp_version(void);
 
 // Initialize a parser with the given start and end pointers.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char *filepath);
 
 // Register a callback that will be called whenever YARP changes the encoding it
 // is using to parse based on the magic comment.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
 
 // Register a callback that will be called when YARP encounters a magic comment
@@ -52,19 +52,19 @@ yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_ch
 // return NULL if it also doesn't understand the encoding or it should return a
 // pointer to a yp_encoding_t struct that contains the functions necessary to
 // parse identifiers.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback);
 
 // Free any memory associated with the given parser.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_free(yp_parser_t *parser);
 
 // Parse the Ruby source associated with the given parser and return the tree.
-__attribute__((__visibility__("default"))) extern yp_node_t *
+EXPORTED extern yp_node_t *
 yp_parse(yp_parser_t *parser);
 
 // Deallocate a node and all of its children.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_node_destroy(yp_parser_t *parser, struct yp_node *node);
 
 // This struct stores the information gathered by the yp_node_memsize function.
@@ -76,24 +76,24 @@ typedef struct {
 } yp_memsize_t;
 
 // Calculates the memory footprint of a given node.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize);
 
 // Pretty-prints the AST represented by the given node to the given buffer.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_prettyprint(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
 // Serialize the AST represented by the given node to the given buffer.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_serialize(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
 // Parse and serialize the AST represented by the given source to the given
 // buffer.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parse_serialize(const char *source, size_t size, yp_buffer_t *buffer);
 
 // Returns a string representation of the given token type.
-__attribute__((__visibility__("default"))) extern const char *
+EXPORTED extern const char *
 yp_token_type_to_str(yp_token_type_t token_type);
 
 #endif

--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -9,4 +9,8 @@
 #define _XOPEN_SOURCE 700
 #endif
 
+#ifndef EXPORTED
+#define EXPORTED __attribute__((__visibility__("default")))
+#endif
+
 #endif

--- a/include/yarp/pack.h
+++ b/include/yarp/pack.h
@@ -120,7 +120,7 @@ typedef enum yp_pack_result {
 //
 // Notes:
 //   Consult Ruby documentation for the meaning of directives.
-__attribute__((__visibility__("default"))) extern yp_pack_result
+EXPORTED extern yp_pack_result
 yp_pack_parse(
   __attribute__((unused)) yp_pack_version version,
   yp_pack_variant variant,
@@ -137,7 +137,7 @@ yp_pack_parse(
 
 // YARP abstracts sizes away from the native system - this converts an abstract
 // size to a native size.
-__attribute__((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_size_to_native(yp_pack_size size);
 
 #endif

--- a/include/yarp/regexp.h
+++ b/include/yarp/regexp.h
@@ -13,7 +13,7 @@
 
 // Parse a regular expression and extract the names of all of the named capture
 // groups.
-__attribute__((__visibility__("default"))) extern bool
+EXPORTED extern bool
 yp_regexp_named_capture_group_names(const char *source, size_t size,
                                     yp_string_list_t *named_captures);
 

--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -30,10 +30,10 @@ typedef enum {
 
 // Unescape the contents of the given token into the given string using the
 // given unescape mode.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list);
 
-__attribute__((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list);
 
 #endif

--- a/include/yarp/util/yp_buffer.h
+++ b/include/yarp/util/yp_buffer.h
@@ -18,11 +18,11 @@ typedef struct {
 } yp_buffer_t;
 
 // Allocate a new yp_buffer_t.
-__attribute__ ((__visibility__("default"))) extern yp_buffer_t *
+EXPORTED extern yp_buffer_t *
 yp_buffer_alloc(void);
 
 // Initialize a yp_buffer_t with its default values.
-__attribute__ ((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_buffer_init(yp_buffer_t *buffer);
 
 // Append a string to the buffer.
@@ -38,7 +38,7 @@ void
 yp_buffer_append_u32(yp_buffer_t *buffer, uint32_t value);
 
 // Free the memory associated with the buffer.
-__attribute__ ((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_buffer_free(yp_buffer_t *buffer);
 
 #endif

--- a/include/yarp/util/yp_list.h
+++ b/include/yarp/util/yp_list.h
@@ -54,11 +54,11 @@ yp_list_t *
 yp_list_alloc(void);
 
 // Initializes a new list.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_list_init(yp_list_t *list);
 
 // Returns true if the given list is empty.
-__attribute__((__visibility__("default"))) extern bool
+EXPORTED extern bool
 yp_list_empty_p(yp_list_t *list);
 
 // Append a node to the given list.
@@ -66,7 +66,7 @@ void
 yp_list_append(yp_list_t *list, yp_list_node_t *node);
 
 // Deallocate the internal state of the given list.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_list_free(yp_list_t *list);
 
 #endif

--- a/include/yarp/util/yp_string.h
+++ b/include/yarp/util/yp_string.h
@@ -55,15 +55,15 @@ void
 yp_string_ensure_owned(yp_string_t *string);
 
 // Returns the length associated with the string.
-__attribute__ ((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_string_length(const yp_string_t *string);
 
 // Returns the start pointer associated with the string.
-__attribute__ ((__visibility__("default"))) extern const char *
+EXPORTED extern const char *
 yp_string_source(const yp_string_t *string);
 
 // Free the associated memory of the given string.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_string_free(yp_string_t *string);
 
 #endif // YARP_STRING_H

--- a/include/yarp/util/yp_string_list.h
+++ b/include/yarp/util/yp_string_list.h
@@ -19,7 +19,7 @@ yp_string_list_t *
 yp_string_list_alloc(void);
 
 // Initialize a yp_string_list_t with its default values.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_string_list_init(yp_string_list_t *string_list);
 
 // Append a yp_string_t to the given string list.
@@ -27,7 +27,7 @@ void
 yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string);
 
 // Free the memory associated with the string list.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_string_list_free(yp_string_list_t *string_list);
 
 #endif

--- a/src/pack.c
+++ b/src/pack.c
@@ -6,7 +6,7 @@
 static uintmax_t
 strtoumaxc(const char **format);
 
-__attribute__((__visibility__("default"))) extern yp_pack_result
+EXPORTED extern yp_pack_result
 yp_pack_parse(__attribute__((unused)) yp_pack_version version, yp_pack_variant variant, const char **format, const char *format_end,
               yp_pack_type *type, yp_pack_signed *signed_type, yp_pack_endian *endian, yp_pack_size *size,
               yp_pack_length_type *length_type, uint64_t *length, yp_pack_encoding *encoding) {
@@ -453,7 +453,7 @@ exit_modifier_loop:
   return YP_PACK_OK;
 }
 
-__attribute__((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_size_to_native(yp_pack_size size) {
   switch (size) {
     case YP_PACK_SIZE_SHORT:

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -510,7 +510,7 @@ yp_regexp_parse_pattern(yp_regexp_parser_t *parser) {
 
 // Parse a regular expression and extract the names of all of the named capture
 // groups.
-__attribute__((__visibility__("default"))) extern bool
+EXPORTED extern bool
 yp_regexp_named_capture_group_names(const char *source, size_t size, yp_string_list_t *named_captures) {
   yp_regexp_parser_t parser;
   yp_regexp_parser_init(&parser, source, source + size, named_captures);

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -435,7 +435,7 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 // \c\M-x         same as above
 // \c? or \C-?    delete, ASCII 7Fh (DEL)
 //
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list) {
   if (unescape_type == YP_UNESCAPE_NONE) {
     // If we're not unescaping then we can reference the source directly.
@@ -523,7 +523,7 @@ yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *str
 // This function is similar to yp_unescape_manipulate_string, except it doesn't
 // actually perform any string manipulations. Instead, it calculates how long
 // the unescaped character is, and returns that value
-__attribute__((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_unescape_calculate_difference(const char *backslash, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list) {
   assert(unescape_type != YP_UNESCAPE_NONE);
 

--- a/src/util/yp_list.c
+++ b/src/util/yp_list.c
@@ -7,13 +7,13 @@ yp_list_alloc(void) {
 }
 
 // Initializes a new list.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_list_init(yp_list_t *list) {
   *list = (yp_list_t) { .head = NULL, .tail = NULL };
 }
 
 // Returns true if the given list is empty.
-__attribute__((__visibility__("default"))) extern bool
+EXPORTED extern bool
 yp_list_empty_p(yp_list_t *list) {
   return list->head == NULL;
 }
@@ -30,7 +30,7 @@ yp_list_append(yp_list_t *list, yp_list_node_t *node) {
 }
 
 // Deallocate the internal state of the given list.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_list_free(yp_list_t *list) {
   yp_list_node_t *node = list->head;
   yp_list_node_t *next;

--- a/src/util/yp_string.c
+++ b/src/util/yp_string.c
@@ -66,7 +66,7 @@ yp_string_ensure_owned(yp_string_t *string) {
 }
 
 // Returns the length associated with the string.
-__attribute__ ((__visibility__("default"))) extern size_t
+EXPORTED extern size_t
 yp_string_length(const yp_string_t *string) {
   if (string->type == YP_STRING_SHARED) {
     return (size_t) (string->as.shared.end - string->as.shared.start);
@@ -76,7 +76,7 @@ yp_string_length(const yp_string_t *string) {
 }
 
 // Returns the start pointer associated with the string.
-__attribute__ ((__visibility__("default"))) extern const char *
+EXPORTED extern const char *
 yp_string_source(const yp_string_t *string) {
   if (string->type == YP_STRING_SHARED) {
     return string->as.shared.start;
@@ -86,7 +86,7 @@ yp_string_source(const yp_string_t *string) {
 }
 
 // Free the associated memory of the given string.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_string_free(yp_string_t *string) {
   if (string->type == YP_STRING_OWNED) {
     free(string->as.owned.source);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -11929,7 +11929,7 @@ parse_program(yp_parser_t *parser) {
 /******************************************************************************/
 
 // Initialize a parser with the given start and end pointers.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char *filepath) {
   // Set filepath to the file that was passed
   if (!filepath) filepath = "";
@@ -11990,7 +11990,7 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
 
 // Register a callback that will be called whenever YARP changes the encoding it
 // is using to parse based on the magic comment.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback) {
   parser->encoding_changed_callback = callback;
 }
@@ -12000,7 +12000,7 @@ yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_ch
 // return NULL if it also doesn't understand the encoding or it should return a
 // pointer to a yp_encoding_t struct that contains the functions necessary to
 // parse identifiers.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback) {
   parser->encoding_decode_callback = callback;
 }
@@ -12019,7 +12019,7 @@ yp_comment_list_free(yp_list_t *list) {
 }
 
 // Free any memory associated with the given parser.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parser_free(yp_parser_t *parser) {
   yp_string_free(&parser->filepath_string);
   yp_diagnostic_list_free(&parser->error_list);
@@ -12028,12 +12028,12 @@ yp_parser_free(yp_parser_t *parser) {
 }
 
 // Parse the Ruby source associated with the given parser and return the tree.
-__attribute__((__visibility__("default"))) extern yp_node_t *
+EXPORTED extern yp_node_t *
 yp_parse(yp_parser_t *parser) {
   return parse_program(parser);
 }
 
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_serialize(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
   yp_buffer_append_str(buffer, "YARP", 4);
   yp_buffer_append_u8(buffer, YP_VERSION_MAJOR);
@@ -12046,7 +12046,7 @@ yp_serialize(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
 
 // Parse and serialize the AST represented by the given source to the given
 // buffer.
-__attribute__((__visibility__("default"))) extern void
+EXPORTED extern void
 yp_parse_serialize(const char *source, size_t size, yp_buffer_t *buffer) {
   yp_parser_t parser;
   yp_parser_init(&parser, source, size, NULL);


### PR DESCRIPTION
Small refactor to make mirroring to ruby/ruby easier by keeping default visibility in its own macro, as aligned with the ruby codebase