### PR TITLE
Remove lex-rails GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,18 +49,6 @@ jobs:
     - name: Lex ruby/ruby
       run: bundle exec rake lex:ruby
 
-  lex-rails:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.2
-        bundler-cache: true
-    - name: Lex rails/rails
-      run: bundle exec rake lex:rails
-
   lex-discourse:
     runs-on: ubuntu-latest
     steps:

--- a/targets.yml
+++ b/targets.yml
@@ -10,10 +10,6 @@ ruby:
   excludes:
     - spec/ruby/command_line/fixtures/bad_syntax.rb
 
-rails:
-  repo: https://github.com/rails/rails
-  sha: 8e3449908c59858384ae230d1416c7dcabc8c2dc
-
 discourse:
   repo: https://github.com/discourse/discourse
   sha: 964f37476dbbfb978bf99608a62d0da9ddf531fa


### PR DESCRIPTION
Rails is included as one of the top-100 gems, so we lex it in the lex-top-100 GitHub actions workflow already, and don't need to also lex it individually