### PR TITLE
Style: define functions on one line in .h files

### DIFF
--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -12,16 +12,12 @@
 
 #define EXPECTED_YARP_VERSION "0.4.0"
 
-VALUE
-yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding);
+VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding);
 
-VALUE
-yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
+VALUE yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
 
-VALUE
-yp_compile(yp_node_t *node);
+VALUE yp_compile(yp_node_t *node);
 
-void
-Init_yarp_pack(void);
+void Init_yarp_pack(void);
 
 #endif // YARP_EXT_NODE_H

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -28,44 +28,35 @@
 #define YP_VERSION_MINOR 4
 #define YP_VERSION_PATCH 0
 
-void
-yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
+void yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
-void
-yp_print_node(yp_parser_t *parser, yp_node_t *node);
+void yp_print_node(yp_parser_t *parser, yp_node_t *node);
 
 // Returns the YARP version and notably the serialization format
-YP_EXPORTED_FUNCTION extern const char *
-yp_version(void);
+YP_EXPORTED_FUNCTION extern const char * yp_version(void);
 
 // Initialize a parser with the given start and end pointers.
-YP_EXPORTED_FUNCTION extern void
-yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char *filepath);
+YP_EXPORTED_FUNCTION extern void yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char *filepath);
 
 // Register a callback that will be called whenever YARP changes the encoding it
 // is using to parse based on the magic comment.
-YP_EXPORTED_FUNCTION extern void
-yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
+YP_EXPORTED_FUNCTION extern void yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
 
 // Register a callback that will be called when YARP encounters a magic comment
 // with an encoding referenced that it doesn't understand. The callback should
 // return NULL if it also doesn't understand the encoding or it should return a
 // pointer to a yp_encoding_t struct that contains the functions necessary to
 // parse identifiers.
-YP_EXPORTED_FUNCTION extern void
-yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback);
+YP_EXPORTED_FUNCTION extern void yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback);
 
 // Free any memory associated with the given parser.
-YP_EXPORTED_FUNCTION extern void
-yp_parser_free(yp_parser_t *parser);
+YP_EXPORTED_FUNCTION extern void yp_parser_free(yp_parser_t *parser);
 
 // Parse the Ruby source associated with the given parser and return the tree.
-YP_EXPORTED_FUNCTION extern yp_node_t *
-yp_parse(yp_parser_t *parser);
+YP_EXPORTED_FUNCTION extern yp_node_t * yp_parse(yp_parser_t *parser);
 
 // Deallocate a node and all of its children.
-YP_EXPORTED_FUNCTION extern void
-yp_node_destroy(yp_parser_t *parser, struct yp_node *node);
+YP_EXPORTED_FUNCTION extern void yp_node_destroy(yp_parser_t *parser, struct yp_node *node);
 
 // This struct stores the information gathered by the yp_node_memsize function.
 // It contains both the memory footprint and additionally metadata about the
@@ -76,24 +67,19 @@ typedef struct {
 } yp_memsize_t;
 
 // Calculates the memory footprint of a given node.
-YP_EXPORTED_FUNCTION extern void
-yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize);
+YP_EXPORTED_FUNCTION extern void yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize);
 
 // Pretty-prints the AST represented by the given node to the given buffer.
-YP_EXPORTED_FUNCTION extern void
-yp_prettyprint(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
+YP_EXPORTED_FUNCTION extern void yp_prettyprint(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
 // Serialize the AST represented by the given node to the given buffer.
-YP_EXPORTED_FUNCTION extern void
-yp_serialize(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
+YP_EXPORTED_FUNCTION extern void yp_serialize(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
 // Parse and serialize the AST represented by the given source to the given
 // buffer.
-YP_EXPORTED_FUNCTION extern void
-yp_parse_serialize(const char *source, size_t size, yp_buffer_t *buffer);
+YP_EXPORTED_FUNCTION extern void yp_parse_serialize(const char *source, size_t size, yp_buffer_t *buffer);
 
 // Returns a string representation of the given token type.
-YP_EXPORTED_FUNCTION extern const char *
-yp_token_type_to_str(yp_token_type_t token_type);
+YP_EXPORTED_FUNCTION extern const char * yp_token_type_to_str(yp_token_type_t token_type);
 
 #endif

--- a/include/yarp/diagnostic.h
+++ b/include/yarp/diagnostic.h
@@ -16,11 +16,9 @@ typedef struct {
 } yp_diagnostic_t;
 
 // Append a diagnostic to the given list of diagnostics.
-void
-yp_diagnostic_list_append(yp_list_t *list, const char *start, const char *end, const char *message);
+void yp_diagnostic_list_append(yp_list_t *list, const char *start, const char *end, const char *message);
 
 // Deallocate the internal state of the given diagnostic list.
-void
-yp_diagnostic_list_free(yp_list_t *list);
+void yp_diagnostic_list_free(yp_list_t *list);
 
 #endif

--- a/include/yarp/enc/yp_encoding.h
+++ b/include/yarp/enc/yp_encoding.h
@@ -14,375 +14,282 @@
 // The function is shared between all of the encodings that use single bytes to
 // represent characters. They don't have need of a dynamic function to determine
 // their width.
-size_t
-yp_encoding_single_char_width(__attribute__((unused)) const char *c);
+size_t yp_encoding_single_char_width(__attribute__((unused)) const char *c);
 
 /******************************************************************************/
 /* ASCII                                                                      */
 /******************************************************************************/
 
-size_t
-yp_encoding_ascii_char_width(const char *c);
+size_t yp_encoding_ascii_char_width(const char *c);
 
-size_t
-yp_encoding_ascii_alpha_char(const char *c);
+size_t yp_encoding_ascii_alpha_char(const char *c);
 
-size_t
-yp_encoding_ascii_alnum_char(const char *c);
+size_t yp_encoding_ascii_alnum_char(const char *c);
 
-bool
-yp_encoding_ascii_isupper_char(const char *c);
+bool yp_encoding_ascii_isupper_char(const char *c);
 
 /******************************************************************************/
 /* Big5                                                                       */
 /******************************************************************************/
 
-size_t
-yp_encoding_big5_char_width(const char *c);
+size_t yp_encoding_big5_char_width(const char *c);
 
-size_t
-yp_encoding_big5_alpha_char(const char *c);
+size_t yp_encoding_big5_alpha_char(const char *c);
 
-size_t
-yp_encoding_big5_alnum_char(const char *c);
+size_t yp_encoding_big5_alnum_char(const char *c);
 
-bool
-yp_encoding_big5_isupper_char(const char *c);
+bool yp_encoding_big5_isupper_char(const char *c);
 
 /******************************************************************************/
 /* EUC-JP                                                                     */
 /******************************************************************************/
 
-size_t
-yp_encoding_euc_jp_char_width(const char *c);
+size_t yp_encoding_euc_jp_char_width(const char *c);
 
-size_t
-yp_encoding_euc_jp_alpha_char(const char *c);
+size_t yp_encoding_euc_jp_alpha_char(const char *c);
 
-size_t
-yp_encoding_euc_jp_alnum_char(const char *c);
+size_t yp_encoding_euc_jp_alnum_char(const char *c);
 
-bool
-yp_encoding_euc_jp_isupper_char(const char *c);
+bool yp_encoding_euc_jp_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-1                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_1_char_width(const char *c);
+size_t yp_encoding_iso_8859_1_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_1_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_1_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_1_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_1_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_1_isupper_char(const char *c);
+bool yp_encoding_iso_8859_1_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-2                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_2_char_width(const char *c);
+size_t yp_encoding_iso_8859_2_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_2_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_2_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_2_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_2_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_2_isupper_char(const char *c);
+bool yp_encoding_iso_8859_2_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-3                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_3_char_width(const char *c);
+size_t yp_encoding_iso_8859_3_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_3_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_3_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_3_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_3_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_3_isupper_char(const char *c);
+bool yp_encoding_iso_8859_3_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-4                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_4_char_width(const char *c);
+size_t yp_encoding_iso_8859_4_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_4_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_4_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_4_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_4_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_4_isupper_char(const char *c);
+bool yp_encoding_iso_8859_4_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-5                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_5_char_width(const char *c);
+size_t yp_encoding_iso_8859_5_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_5_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_5_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_5_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_5_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_5_isupper_char(const char *c);
+bool yp_encoding_iso_8859_5_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-6                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_6_char_width(const char *c);
+size_t yp_encoding_iso_8859_6_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_6_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_6_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_6_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_6_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_6_isupper_char(const char *c);
+bool yp_encoding_iso_8859_6_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-7                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_7_char_width(const char *c);
+size_t yp_encoding_iso_8859_7_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_7_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_7_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_7_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_7_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_7_isupper_char(const char *c);
+bool yp_encoding_iso_8859_7_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-8                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_8_char_width(const char *c);
+size_t yp_encoding_iso_8859_8_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_8_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_8_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_8_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_8_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_8_isupper_char(const char *c);
+bool yp_encoding_iso_8859_8_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-9                                                                 */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_9_char_width(const char *c);
+size_t yp_encoding_iso_8859_9_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_9_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_9_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_9_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_9_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_9_isupper_char(const char *c);
+bool yp_encoding_iso_8859_9_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-10                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_10_char_width(const char *c);
+size_t yp_encoding_iso_8859_10_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_10_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_10_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_10_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_10_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_10_isupper_char(const char *c);
+bool yp_encoding_iso_8859_10_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-11                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_11_char_width(const char *c);
+size_t yp_encoding_iso_8859_11_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_11_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_11_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_11_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_11_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_11_isupper_char(const char *c);
+bool yp_encoding_iso_8859_11_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-13                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_13_char_width(const char *c);
+size_t yp_encoding_iso_8859_13_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_13_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_13_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_13_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_13_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_13_isupper_char(const char *c);
+bool yp_encoding_iso_8859_13_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-14                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_14_char_width(const char *c);
+size_t yp_encoding_iso_8859_14_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_14_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_14_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_14_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_14_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_14_isupper_char(const char *c);
+bool yp_encoding_iso_8859_14_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-15                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_15_char_width(const char *c);
+size_t yp_encoding_iso_8859_15_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_15_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_15_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_15_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_15_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_15_isupper_char(const char *c);
+bool yp_encoding_iso_8859_15_isupper_char(const char *c);
 
 /******************************************************************************/
 /* ISO-8859-16                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_iso_8859_16_char_width(const char *c);
+size_t yp_encoding_iso_8859_16_char_width(const char *c);
 
-size_t
-yp_encoding_iso_8859_16_alpha_char(const char *c);
+size_t yp_encoding_iso_8859_16_alpha_char(const char *c);
 
-size_t
-yp_encoding_iso_8859_16_alnum_char(const char *c);
+size_t yp_encoding_iso_8859_16_alnum_char(const char *c);
 
-bool
-yp_encoding_iso_8859_16_isupper_char(const char *c);
+bool yp_encoding_iso_8859_16_isupper_char(const char *c);
 
 /******************************************************************************/
 /* Shift-JIS                                                                  */
 /******************************************************************************/
 
-size_t
-yp_encoding_shift_jis_char_width(const char *c);
+size_t yp_encoding_shift_jis_char_width(const char *c);
 
-size_t
-yp_encoding_shift_jis_alpha_char(const char *c);
+size_t yp_encoding_shift_jis_alpha_char(const char *c);
 
-size_t
-yp_encoding_shift_jis_alnum_char(const char *c);
+size_t yp_encoding_shift_jis_alnum_char(const char *c);
 
-bool
-yp_encoding_shift_jis_isupper_char(const char *c);
+bool yp_encoding_shift_jis_isupper_char(const char *c);
 
 /******************************************************************************/
 /* UTF-8                                                                      */
 /******************************************************************************/
 
-size_t
-yp_encoding_utf_8_char_width(const char *c);
+size_t yp_encoding_utf_8_char_width(const char *c);
 
-size_t
-yp_encoding_utf_8_alpha_char(const char *c);
+size_t yp_encoding_utf_8_alpha_char(const char *c);
 
-size_t
-yp_encoding_utf_8_alnum_char(const char *c);
+size_t yp_encoding_utf_8_alnum_char(const char *c);
 
-bool
-yp_encoding_utf_8_isupper_char(const char *c);
+bool yp_encoding_utf_8_isupper_char(const char *c);
 
 /******************************************************************************/
 /* Windows-31J                                                                */
 /******************************************************************************/
 
-size_t
-yp_encoding_windows_31j_char_width(const char *c);
+size_t yp_encoding_windows_31j_char_width(const char *c);
 
-size_t
-yp_encoding_windows_31j_alpha_char(const char *c);
+size_t yp_encoding_windows_31j_alpha_char(const char *c);
 
-size_t
-yp_encoding_windows_31j_alnum_char(const char *c);
+size_t yp_encoding_windows_31j_alnum_char(const char *c);
 
-bool
-yp_encoding_windows_31j_isupper_char(const char *c);
+bool yp_encoding_windows_31j_isupper_char(const char *c);
 
 /******************************************************************************/
 /* Windows-1251                                                               */
 /******************************************************************************/
 
-size_t
-yp_encoding_windows_1251_char_width(const char *c);
+size_t yp_encoding_windows_1251_char_width(const char *c);
 
-size_t
-yp_encoding_windows_1251_alpha_char(const char *c);
+size_t yp_encoding_windows_1251_alpha_char(const char *c);
 
-size_t
-yp_encoding_windows_1251_alnum_char(const char *c);
+size_t yp_encoding_windows_1251_alnum_char(const char *c);
 
-bool
-yp_encoding_windows_1251_isupper_char(const char *c);
+bool yp_encoding_windows_1251_isupper_char(const char *c);
 
 /******************************************************************************/
 /* Windows-1252                                                               */
 /******************************************************************************/
 
-size_t
-yp_encoding_windows_1252_char_width(const char *c);
+size_t yp_encoding_windows_1252_char_width(const char *c);
 
-size_t
-yp_encoding_windows_1252_alpha_char(const char *c);
+size_t yp_encoding_windows_1252_alpha_char(const char *c);
 
-size_t
-yp_encoding_windows_1252_alnum_char(const char *c);
+size_t yp_encoding_windows_1252_alnum_char(const char *c);
 
-bool
-yp_encoding_windows_1252_isupper_char(const char *c);
+bool yp_encoding_windows_1252_isupper_char(const char *c);
 
 #endif

--- a/include/yarp/missing.h
+++ b/include/yarp/missing.h
@@ -7,15 +7,13 @@
 #include <stddef.h>
 #include <string.h>
 
-const char *
-yp_strnstr(const char *haystack, const char *needle, size_t length);
+const char * yp_strnstr(const char *haystack, const char *needle, size_t length);
 
 #ifndef HAVE_STRNSTR
 #define strnstr yp_strnstr
 #endif
 
-int
-yp_strncasecmp(const char *string1, const char *string2, size_t length);
+int yp_strncasecmp(const char *string1, const char *string2, size_t length);
 
 #ifndef HAVE_STRNCASECMP
 #define strncasecmp yp_strncasecmp

--- a/include/yarp/node.h
+++ b/include/yarp/node.h
@@ -7,28 +7,22 @@
 #include "yarp/parser.h"
 
 // Initialize a yp_token_list_t with its default values.
-void
-yp_token_list_init(yp_token_list_t *token_list);
+void yp_token_list_init(yp_token_list_t *token_list);
 
 // Append a token to the given list.
-void
-yp_token_list_append(yp_token_list_t *token_list, const yp_token_t *token);
+void yp_token_list_append(yp_token_list_t *token_list, const yp_token_t *token);
 
 // Checks if the current token list includes the given token.
-bool
-yp_token_list_includes(yp_token_list_t *token_list, const yp_token_t *token);
+bool yp_token_list_includes(yp_token_list_t *token_list, const yp_token_t *token);
 
 // Initiailize a list of nodes.
-void
-yp_node_list_init(yp_node_list_t *node_list);
+void yp_node_list_init(yp_node_list_t *node_list);
 
 // Append a new node onto the end of the node list.
-void
-yp_node_list_append(yp_node_list_t *list, yp_node_t *node);
+void yp_node_list_append(yp_node_list_t *list, yp_node_t *node);
 
 // Clear the node but preserves the location.
-void
-yp_node_clear(yp_node_t *node);
+void yp_node_clear(yp_node_t *node);
 
 #define YP_EMPTY_NODE_LIST { .nodes = NULL, .size = 0, .capacity = 0 }
 

--- a/include/yarp/pack.h
+++ b/include/yarp/pack.h
@@ -137,7 +137,6 @@ yp_pack_parse(
 
 // YARP abstracts sizes away from the native system - this converts an abstract
 // size to a native size.
-YP_EXPORTED_FUNCTION extern size_t
-yp_size_to_native(yp_pack_size size);
+YP_EXPORTED_FUNCTION extern size_t yp_size_to_native(yp_pack_size size);
 
 #endif

--- a/include/yarp/regexp.h
+++ b/include/yarp/regexp.h
@@ -13,8 +13,6 @@
 
 // Parse a regular expression and extract the names of all of the named capture
 // groups.
-YP_EXPORTED_FUNCTION extern bool
-yp_regexp_named_capture_group_names(const char *source, size_t size,
-                                    yp_string_list_t *named_captures);
+YP_EXPORTED_FUNCTION extern bool yp_regexp_named_capture_group_names(const char *source, size_t size, yp_string_list_t *named_captures);
 
 #endif

--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -30,10 +30,8 @@ typedef enum {
 
 // Unescape the contents of the given token into the given string using the
 // given unescape mode.
-YP_EXPORTED_FUNCTION extern void
-yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list);
+YP_EXPORTED_FUNCTION extern void yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list);
 
-YP_EXPORTED_FUNCTION extern size_t
-yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list);
+YP_EXPORTED_FUNCTION extern size_t yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list);
 
 #endif

--- a/include/yarp/util/yp_buffer.h
+++ b/include/yarp/util/yp_buffer.h
@@ -18,27 +18,21 @@ typedef struct {
 } yp_buffer_t;
 
 // Allocate a new yp_buffer_t.
-YP_EXPORTED_FUNCTION extern yp_buffer_t *
-yp_buffer_alloc(void);
+YP_EXPORTED_FUNCTION extern yp_buffer_t * yp_buffer_alloc(void);
 
 // Initialize a yp_buffer_t with its default values.
-YP_EXPORTED_FUNCTION extern void
-yp_buffer_init(yp_buffer_t *buffer);
+YP_EXPORTED_FUNCTION extern void yp_buffer_init(yp_buffer_t *buffer);
 
 // Append a string to the buffer.
-void
-yp_buffer_append_str(yp_buffer_t *buffer, const char *value, size_t length);
+void yp_buffer_append_str(yp_buffer_t *buffer, const char *value, size_t length);
 
 // Append a single byte to the buffer.
-void
-yp_buffer_append_u8(yp_buffer_t *buffer, uint8_t value);
+void yp_buffer_append_u8(yp_buffer_t *buffer, uint8_t value);
 
 // Append a 32-bit unsigned integer to the buffer.
-void
-yp_buffer_append_u32(yp_buffer_t *buffer, uint32_t value);
+void yp_buffer_append_u32(yp_buffer_t *buffer, uint32_t value);
 
 // Free the memory associated with the buffer.
-YP_EXPORTED_FUNCTION extern void
-yp_buffer_free(yp_buffer_t *buffer);
+YP_EXPORTED_FUNCTION extern void yp_buffer_free(yp_buffer_t *buffer);
 
 #endif

--- a/include/yarp/util/yp_char.h
+++ b/include/yarp/util/yp_char.h
@@ -6,87 +6,69 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-bool
-yp_char_is_binary_digit(const char c);
+bool yp_char_is_binary_digit(const char c);
 
-bool
-yp_char_is_octal_digit(const char c);
+bool yp_char_is_octal_digit(const char c);
 
-bool
-yp_char_is_hexadecimal_digit(const char c);
+bool yp_char_is_hexadecimal_digit(const char c);
 
 // Returns the number of characters at the start of the string that are
 // whitespace. Disallows searching past the given maximum number of characters.
-size_t
-yp_strspn_whitespace(const char *string, long length);
+size_t yp_strspn_whitespace(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are inline
 // whitespace. Disallows searching past the given maximum number of characters.
-size_t
-yp_strspn_inline_whitespace(const char *string, long length);
+size_t yp_strspn_inline_whitespace(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are decimal
 // digits. Disallows searching past the given maximum number of characters.
-size_t
-yp_strspn_decimal_digit(const char *string, long length);
+size_t yp_strspn_decimal_digit(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are
 // hexadecimal digits. Disallows searching past the given maximum number of
 // characters.
-size_t
-yp_strspn_hexadecimal_digit(const char *string, long length);
+size_t yp_strspn_hexadecimal_digit(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are octal
 // digits or underscores.  Disallows searching past the given maximum number of
 // characters.
-size_t
-yp_strspn_octal_number(const char *string, long length);
+size_t yp_strspn_octal_number(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are decimal
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
-size_t
-yp_strspn_decimal_number(const char *string, long length);
+size_t yp_strspn_decimal_number(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are
 // hexadecimal digits or underscores. Disallows searching past the given maximum
 // number of characters.
-size_t
-yp_strspn_hexadecimal_number(const char *string, long length);
+size_t yp_strspn_hexadecimal_number(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are regexp
 // options. Disallows searching past the given maximum number of characters.
-size_t
-yp_strspn_regexp_option(const char *string, long length);
+size_t yp_strspn_regexp_option(const char *string, long length);
 
 // Returns the number of characters at the start of the string that are binary
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
-size_t
-yp_strspn_binary_number(const char *string, long length);
+size_t yp_strspn_binary_number(const char *string, long length);
 
 // Returns true if the given character is a whitespace character.
-bool
-yp_char_is_whitespace(const char c);
+bool yp_char_is_whitespace(const char c);
 
 // Returns true if the given character is an inline whitespace character.
-bool
-yp_char_is_inline_whitespace(const char c);
+bool yp_char_is_inline_whitespace(const char c);
 
 // Returns true if the given character is a binary digit.
-bool
-yp_char_is_binary_digit(const char c);
+bool yp_char_is_binary_digit(const char c);
 
 // Returns true if the given character is an octal digit.
-bool
-yp_char_is_octal_digit(const char c);
+bool yp_char_is_octal_digit(const char c);
 
 // Returns true if the given character is a decimal digit.
-bool
-yp_char_is_decimal_digit(const char c);
+bool yp_char_is_decimal_digit(const char c);
 
 // Returns true if the given character is a hexadecimal digit.
-bool
-yp_char_is_hexadecimal_digit(const char c);
+bool yp_char_is_hexadecimal_digit(const char c);
 
 #endif

--- a/include/yarp/util/yp_conversion.h
+++ b/include/yarp/util/yp_conversion.h
@@ -9,10 +9,8 @@
 #include <assert.h>
 #include <stdint.h>
 
-uint32_t
-yp_long_to_u32(long value);
+uint32_t yp_long_to_u32(long value);
 
-uint32_t
-yp_ulong_to_u32(unsigned long value);
+uint32_t yp_ulong_to_u32(unsigned long value);
 
 #endif

--- a/include/yarp/util/yp_list.h
+++ b/include/yarp/util/yp_list.h
@@ -50,23 +50,18 @@ typedef struct {
 } yp_list_t;
 
 // Allocate a new list.
-yp_list_t *
-yp_list_alloc(void);
+yp_list_t * yp_list_alloc(void);
 
 // Initializes a new list.
-YP_EXPORTED_FUNCTION extern void
-yp_list_init(yp_list_t *list);
+YP_EXPORTED_FUNCTION extern void yp_list_init(yp_list_t *list);
 
 // Returns true if the given list is empty.
-YP_EXPORTED_FUNCTION extern bool
-yp_list_empty_p(yp_list_t *list);
+YP_EXPORTED_FUNCTION extern bool yp_list_empty_p(yp_list_t *list);
 
 // Append a node to the given list.
-void
-yp_list_append(yp_list_t *list, yp_list_node_t *node);
+void yp_list_append(yp_list_t *list, yp_list_node_t *node);
 
 // Deallocate the internal state of the given list.
-YP_EXPORTED_FUNCTION extern void
-yp_list_free(yp_list_t *list);
+YP_EXPORTED_FUNCTION extern void yp_list_free(yp_list_t *list);
 
 #endif

--- a/include/yarp/util/yp_state_stack.h
+++ b/include/yarp/util/yp_state_stack.h
@@ -10,19 +10,15 @@
 typedef uint32_t yp_state_stack_t;
 
 // Initializes the state stack to an empty stack.
-void
-yp_state_stack_init(yp_state_stack_t *stack);
+void yp_state_stack_init(yp_state_stack_t *stack);
 
 // Pushes a value onto the stack.
-void
-yp_state_stack_push(yp_state_stack_t *stack, bool value);
+void yp_state_stack_push(yp_state_stack_t *stack, bool value);
 
 // Pops a value off the stack.
-void
-yp_state_stack_pop(yp_state_stack_t *stack);
+void yp_state_stack_pop(yp_state_stack_t *stack);
 
 // Returns the value at the top of the stack.
-bool
-yp_state_stack_p(yp_state_stack_t *stack);
+bool yp_state_stack_p(yp_state_stack_t *stack);
 
 #endif

--- a/include/yarp/util/yp_string.h
+++ b/include/yarp/util/yp_string.h
@@ -30,40 +30,31 @@ typedef struct {
 } yp_string_t;
 
 // Allocate a new yp_string_t.
-yp_string_t *
-yp_string_alloc(void);
+yp_string_t * yp_string_alloc(void);
 
 // Initialize a shared string that is based on initial input.
-void
-yp_string_shared_init(yp_string_t *string, const char *start, const char *end);
+void yp_string_shared_init(yp_string_t *string, const char *start, const char *end);
 
 // Initialize an owned string that is responsible for freeing allocated memory.
-void
-yp_string_owned_init(yp_string_t *string, char *source, size_t length);
+void yp_string_owned_init(yp_string_t *string, char *source, size_t length);
 
 // Initialize a constant string that doesn't own its memory source.
-void
-yp_string_constant_init(yp_string_t *string, const char *source, size_t length);
+void yp_string_constant_init(yp_string_t *string, const char *source, size_t length);
 
 // Returns the memory size associated with the string.
-size_t
-yp_string_memsize(const yp_string_t *string);
+size_t yp_string_memsize(const yp_string_t *string);
 
 // Ensure the string is owned. If it is not, then reinitialize it as owned and
 // copy over the previous source.
-void
-yp_string_ensure_owned(yp_string_t *string);
+void yp_string_ensure_owned(yp_string_t *string);
 
 // Returns the length associated with the string.
-YP_EXPORTED_FUNCTION extern size_t
-yp_string_length(const yp_string_t *string);
+YP_EXPORTED_FUNCTION extern size_t yp_string_length(const yp_string_t *string);
 
 // Returns the start pointer associated with the string.
-YP_EXPORTED_FUNCTION extern const char *
-yp_string_source(const yp_string_t *string);
+YP_EXPORTED_FUNCTION extern const char * yp_string_source(const yp_string_t *string);
 
 // Free the associated memory of the given string.
-YP_EXPORTED_FUNCTION extern void
-yp_string_free(yp_string_t *string);
+YP_EXPORTED_FUNCTION extern void yp_string_free(yp_string_t *string);
 
 #endif // YARP_STRING_H

--- a/include/yarp/util/yp_string_list.h
+++ b/include/yarp/util/yp_string_list.h
@@ -15,19 +15,15 @@ typedef struct {
 } yp_string_list_t;
 
 // Allocate a new yp_string_list_t.
-yp_string_list_t *
-yp_string_list_alloc(void);
+yp_string_list_t * yp_string_list_alloc(void);
 
 // Initialize a yp_string_list_t with its default values.
-YP_EXPORTED_FUNCTION extern void
-yp_string_list_init(yp_string_list_t *string_list);
+YP_EXPORTED_FUNCTION extern void yp_string_list_init(yp_string_list_t *string_list);
 
 // Append a yp_string_t to the given string list.
-void
-yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string);
+void yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string);
 
 // Free the memory associated with the string list.
-YP_EXPORTED_FUNCTION extern void
-yp_string_list_free(yp_string_list_t *string_list);
+YP_EXPORTED_FUNCTION extern void yp_string_list_free(yp_string_list_t *string_list);
 
 #endif

--- a/include/yarp/util/yp_strpbrk.h
+++ b/include/yarp/util/yp_strpbrk.h
@@ -18,7 +18,6 @@
 // also don't want it to stop on null bytes. Ruby actually allows null bytes
 // within strings, comments, regular expressions, etc. So we need to be able to
 // skip past them.
-const char *
-yp_strpbrk(const char *source, const char *charset, long length);
+const char * yp_strpbrk(const char *source, const char *charset, long length);
 
 #endif


### PR DESCRIPTION
Change the style for function definitions in .h files to match ruby/ruby so that it's consistent when we mirror