### PR TITLE
Constant pool

### DIFF
--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -7,6 +7,7 @@
 
 #include "yarp/ast.h"
 #include "yarp/enc/yp_encoding.h"
+#include "yarp/util/yp_constant_pool.h"
 #include "yarp/util/yp_list.h"
 #include "yarp/util/yp_state_stack.h"
 

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -1,0 +1,39 @@
+// The constant pool is a data structure that stores a set of strings. Each
+// string is assigned a unique id, which can be used to compare strings for
+// equality. This comparison ends up being much faster than strcmp, since it
+// only requires a single integer comparison.
+
+#ifndef YP_CONSTANT_POOL_H
+#define YP_CONSTANT_POOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef unsigned long yp_constant_id_t;
+
+typedef struct {
+    yp_constant_id_t id;
+    const char *start;
+    size_t length;
+    size_t hash;
+} yp_constant_t;
+
+typedef struct {
+    yp_constant_t *constants;
+    size_t size;
+    size_t capacity;
+} yp_constant_pool_t;
+
+// Initialize a new constant pool with a given capacity.
+bool yp_constant_pool_init(yp_constant_pool_t *constant_pool, size_t capacity);
+
+// Insert a constant into a constant pool. Returns the id of the constant, or 0
+// if any potential calls to resize fail.
+yp_constant_id_t yp_constant_pool_insert(yp_constant_pool_t *constant_pool, const char *start, size_t length);
+
+// Free the memory associated with a constant pool.
+void yp_constant_pool_free(yp_constant_pool_t *constant_pool);
+
+#endif

--- a/src/util/yp_constant_pool.c
+++ b/src/util/yp_constant_pool.c
@@ -1,0 +1,102 @@
+#include "yarp/util/yp_constant_pool.h"
+
+// A relatively simple hash function (djb2) that is used to hash strings. We are
+// optimizing here for simplicity and speed.
+static inline size_t
+yp_constant_pool_hash(const char *start, size_t length) {
+    // This is a prime number used as the initial value for the hash function.
+    size_t value = 5381;
+
+    for (size_t index = 0; index < length; index++) {
+        value = ((value << 5) + value) + ((unsigned char) start[index]);
+    }
+
+    return value;
+}
+
+// Resize a constant pool to a given capacity.
+static inline bool
+yp_constant_pool_resize(yp_constant_pool_t *constant_pool) {
+    size_t next_capacity = constant_pool->capacity * 2;
+    yp_constant_t *next_constants = calloc(next_capacity, sizeof(yp_constant_t));
+    if (next_constants == NULL) return false;
+
+    // For each constant in the current constant pool, rehash the content, find
+    // the index in the next constant pool, and insert it.
+    for (size_t index = 0; index < constant_pool->capacity; index++) {
+        yp_constant_t *constant = &constant_pool->constants[index];
+
+        // If an id is set on this constant, then we know we have content here.
+        // In this case we need to insert it into the next constant pool.
+        if (constant->id != 0) {
+            size_t next_index = constant->hash % next_capacity;
+
+            // This implements linear scanning to find the next available slot
+            // in case this index is already taken. We don't need to bother
+            // comparing the values since we know that the hash is unique.
+            while (next_constants[next_index].id != 0) {
+                next_index = (next_index + 1) % next_capacity;
+            }
+
+            // Here we copy over the entire constant, which includes the id so
+            // that they are consistent between resizes.
+            next_constants[next_index] = *constant;
+        }
+    }
+
+    free(constant_pool->constants);
+    constant_pool->constants = next_constants;
+    constant_pool->capacity = next_capacity;
+    return true;
+}
+
+// Initialize a new constant pool with a given capacity.
+bool
+yp_constant_pool_init(yp_constant_pool_t *constant_pool, size_t capacity) {
+    constant_pool->constants = calloc(capacity, sizeof(yp_constant_t));
+    if (constant_pool->constants == NULL) return false;
+
+    constant_pool->size = 0;
+    constant_pool->capacity = capacity;
+    return true;
+}
+
+// Insert a constant into a constant pool. Returns the id of the constant, or 0
+// if any potential calls to resize fail.
+yp_constant_id_t
+yp_constant_pool_insert(yp_constant_pool_t *constant_pool, const char *start, size_t length) {
+    if (constant_pool->size >= constant_pool->capacity * 0.75) {
+        if (!yp_constant_pool_resize(constant_pool)) return 0;
+    }
+
+    size_t hash = yp_constant_pool_hash(start, length);
+    size_t index = hash % constant_pool->capacity;
+    yp_constant_t *constant;
+
+    while (constant = &constant_pool->constants[index], constant->id != 0) {
+        // If there is a collision, then we need to check if the content is the
+        // same as the content we are trying to insert. If it is, then we can
+        // return the id of the existing constant.
+        if ((constant->length == length) && strncmp(constant->start, start, length) == 0) {
+            return constant_pool->constants[index].id;
+        }
+
+        index = (index + 1) % constant_pool->capacity;
+    }
+
+    yp_constant_id_t id = ++constant_pool->size;
+    constant_pool->constants[index] = (yp_constant_t) {
+        .id = id,
+        .start = start,
+        .length = length,
+        .hash = hash
+    };
+
+    return id;
+}
+
+// Free the memory associated with a constant pool.
+void
+yp_constant_pool_free(yp_constant_pool_t *constant_pool) {
+    free(constant_pool->constants);
+}


### PR DESCRIPTION
This is the initial work toward having a constant pool in YARP. This first commit adds a constant pool struct. This struct is effectively a hash map pointing from strings to ID. The IDs can be used to uniquely identify strings. They are incremental starting at 1.

## Implementation

This is implemented with a hash table using the dbj2 hashing function. This was chosen because the strings are likely to be short (we're going to use this for local variables and method names). This was also chosen because we don't need any kind of cryptographic security here (you would choose a difference hashing function if there were a possibility of DDOS, but if you're parsing user input as Ruby code you've already lost that battle).

The interface for this is relatively small (just 3 functions). They are:

```c
// Initialize a new constant pool with a given capacity.
bool yp_constant_pool_init(yp_constant_pool_t *constant_pool, size_t capacity);

// Insert a constant into a constant pool. Returns the id of the constant, or 0
// if any potential calls to resize fail.
yp_constant_id_t yp_constant_pool_insert(yp_constant_pool_t *constant_pool, const char *start, size_t length);

// Free the memory associated with a constant pool.
void yp_constant_pool_free(yp_constant_pool_t *constant_pool);
```

The `yp_constant_id_t` type is an alias of an unsigned long, like most of CRuby uses. Internal to `yp_constant_pool_insert` it will resize the hash table as necessary, but the IDs will always be consistent.

## Usage

Once we have the constant pool in place, one is going to be initialized on the parser struct. From then on, any locals or method calls that get parsed should be inserted into the table. This has a couple of benefits:

* When comparing if an identifier is a local or not, we can store `yp_constant_id_t`s in the local table instead of tokens. Resolving locals should then be much more efficient.
* We can remove the method name field on calls and replace it with a constant ID. This should have a helpful impact on memory usage as it will go from being an entire string struct to a single integer.
* When serializing, the serialized buffer can be much smaller when many identifiers are shared. When outputting, we'll add an offset into the buffered string to the header that indicates the start of the constant pool. Then after we finish serializing the tree, we'll serialize the constant pool. We'll do this by allocating enough space in the buffer to house all of the strings (they're all constant, so they will be an offset and a length) then walking through the table and serializing the constants at the correct index in the constant pool such that they are linearly increasing. Then when deserializing you should be able to take a constant index and calculate where in the buffer it is stored.