### PR TITLE
Add default location to parameters node

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2458,7 +2458,7 @@ yp_parameters_node_create(yp_parser_t *parser) {
     *node = (yp_parameters_node_t) {
         {
             .type = YP_NODE_PARAMETERS_NODE,
-            .location = { .start = NULL, .end = NULL },
+            .location = { .start = parser->current.start, .end = parser->current.start },
         },
         .rest = NULL,
         .keyword_rest = NULL,


### PR DESCRIPTION
This is currently breaking on 32 bit machines because in the case where we only have errors in the parameters, we never set the location, and then have underflow if the file is sufficiently large