### PR TITLE
Profiling and unicode work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ all: build/librubyparser.$(SOEXT)
 build/librubyparser.$(SOEXT): $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h
 	$(CC) $(OPTFLAGS) $(DEBUG_FLAGS) $(CFLAGS) -std=c99 -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
 
+build/profile: $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h bin/profile.c
+	$(CC) $(CFLAGS) -O3 -std=c99 -Iinclude -o $@ $(shell find src -name '*.c') bin/profile.c
+
 build:
 	mkdir -p build
 

--- a/bin/profile.c
+++ b/bin/profile.c
@@ -1,0 +1,98 @@
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#include "yarp.h"
+
+static int
+parse(const char *filepath) {
+    int fd = open(filepath, O_RDONLY);
+    if (fd == -1) {
+        perror("open");
+        return 1;
+    }
+
+    struct stat sb;
+    if (fstat(fd, &sb) == -1) {
+        close(fd);
+        perror("fstat");
+        return 1;
+    }
+
+    size_t size = sb.st_size;
+    const char *source = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+
+    close(fd);
+    if (source == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+
+    yp_parser_t parser;
+    yp_parser_init(&parser, source, size, filepath);
+
+    yp_node_t *node = yp_parse(&parser);
+    yp_node_destroy(&parser, node);
+    yp_parser_free(&parser);
+
+    return 0;
+}
+
+struct node {
+    char *path;
+    struct node *next;
+};
+
+int
+main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <path>\n", argv[0]);
+        return 1;
+    }
+
+    struct node *head = malloc(sizeof(struct node));
+    struct node *tail = head;
+
+    char *path = malloc(strlen(argv[1]) + 1);
+    strcpy(path, argv[1]);
+
+    *head = (struct node) { .path = path, .next = NULL };
+
+    while (head != NULL) {
+        DIR *handle = opendir(head->path);
+        if (!handle) {
+            perror("opendir");
+            return 1;
+        }
+
+        struct dirent *dirent;
+        while ((dirent = readdir(handle)) != NULL) {
+            size_t length = strlen(dirent->d_name);
+
+            char *joined = malloc(strlen(head->path) + length + 2);
+            sprintf(joined, "%s/%s", head->path, dirent->d_name);
+
+            if (dirent->d_type == DT_DIR && dirent->d_name[0] != '.') {
+                struct node *next = malloc(sizeof(struct node));
+                *next = (struct node) { .path = joined, .next = NULL };
+
+                tail->next = next;
+                tail = next;
+            } else if (length > 3 && strcmp(dirent->d_name + length - 3, ".rb") == 0) {
+                parse(joined);
+                free(joined);
+            }
+        }
+
+        closedir(handle);
+        struct node *next = head->next;
+
+        free(head->path);
+        free(head);
+        head = next;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This commit adds two things. The first is a build/profile make target which is a small script that walks through a directory recursively and parses every Ruby file that it finds. I use this in combination with dappprof and dtrace to do some profiling to determine where we're spending the most time.

The second thing this adds is a complete refactor of our UTF-8 decoder. Because UTF-8 is the default encoding and we need to know if characters are alphanumeric or not very commonly, it's important that this path is very fast. Previously we were always decoding the unicode codepoint and then comparing it to a list of known values, but that's incredibly inefficient when the character is < 128 (i.e., almost all Ruby code). Instead we can use a lookup table like we do for all the other encodings.

The UTF-8 decoding is actually significantly faster as well for the few files that actually do need it. It now uses Bjoern Hoehrmann's DFA-based UTF-8 decoder (modified to fit our use case).