### PR TITLE
Use ptrdiff_t instead of long

### DIFF
--- a/include/yarp/util/yp_char.h
+++ b/include/yarp/util/yp_char.h
@@ -14,44 +14,44 @@ bool yp_char_is_hexadecimal_digit(const char c);
 
 // Returns the number of characters at the start of the string that are
 // whitespace. Disallows searching past the given maximum number of characters.
-size_t yp_strspn_whitespace(const char *string, long length);
+size_t yp_strspn_whitespace(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are inline
 // whitespace. Disallows searching past the given maximum number of characters.
-size_t yp_strspn_inline_whitespace(const char *string, long length);
+size_t yp_strspn_inline_whitespace(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are decimal
 // digits. Disallows searching past the given maximum number of characters.
-size_t yp_strspn_decimal_digit(const char *string, long length);
+size_t yp_strspn_decimal_digit(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are
 // hexadecimal digits. Disallows searching past the given maximum number of
 // characters.
-size_t yp_strspn_hexadecimal_digit(const char *string, long length);
+size_t yp_strspn_hexadecimal_digit(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are octal
 // digits or underscores.  Disallows searching past the given maximum number of
 // characters.
-size_t yp_strspn_octal_number(const char *string, long length);
+size_t yp_strspn_octal_number(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are decimal
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
-size_t yp_strspn_decimal_number(const char *string, long length);
+size_t yp_strspn_decimal_number(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are
 // hexadecimal digits or underscores. Disallows searching past the given maximum
 // number of characters.
-size_t yp_strspn_hexadecimal_number(const char *string, long length);
+size_t yp_strspn_hexadecimal_number(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are regexp
 // options. Disallows searching past the given maximum number of characters.
-size_t yp_strspn_regexp_option(const char *string, long length);
+size_t yp_strspn_regexp_option(const char *string, ptrdiff_t length);
 
 // Returns the number of characters at the start of the string that are binary
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
-size_t yp_strspn_binary_number(const char *string, long length);
+size_t yp_strspn_binary_number(const char *string, ptrdiff_t length);
 
 // Returns true if the given character is a whitespace character.
 bool yp_char_is_whitespace(const char c);

--- a/include/yarp/util/yp_strpbrk.h
+++ b/include/yarp/util/yp_strpbrk.h
@@ -18,6 +18,6 @@
 // also don't want it to stop on null bytes. Ruby actually allows null bytes
 // within strings, comments, regular expressions, etc. So we need to be able to
 // skip past them.
-const char * yp_strpbrk(const char *source, const char *charset, long length);
+const char * yp_strpbrk(const char *source, const char *charset, ptrdiff_t length);
 
 #endif

--- a/src/util/yp_char.c
+++ b/src/util/yp_char.c
@@ -54,7 +54,7 @@ static const unsigned char yp_number_table[256] = {
 };
 
 static inline size_t
-yp_strspn_char_kind(const char *string, long length, unsigned char kind) {
+yp_strspn_char_kind(const char *string, ptrdiff_t length, unsigned char kind) {
     if (length <= 0) return 0;
 
     size_t size = 0;
@@ -67,21 +67,21 @@ yp_strspn_char_kind(const char *string, long length, unsigned char kind) {
 // Returns the number of characters at the start of the string that are
 // whitespace. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_whitespace(const char *string, long length) {
+yp_strspn_whitespace(const char *string, ptrdiff_t length) {
     return yp_strspn_char_kind(string, length, YP_CHAR_BIT_WHITESPACE);
 }
 
 // Returns the number of characters at the start of the string that are inline
 // whitespace. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_inline_whitespace(const char *string, long length) {
+yp_strspn_inline_whitespace(const char *string, ptrdiff_t length) {
     return yp_strspn_char_kind(string, length, YP_CHAR_BIT_INLINE_WHITESPACE);
 }
 
 // Returns the number of characters at the start of the string that are regexp
 // options. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_regexp_option(const char *string, long length) {
+yp_strspn_regexp_option(const char *string, ptrdiff_t length) {
     return yp_strspn_char_kind(string, length, YP_CHAR_BIT_REGEXP_OPTION);
 }
 
@@ -103,7 +103,7 @@ yp_char_is_inline_whitespace(const char c) {
 }
 
 static inline size_t
-yp_strspn_number_kind(const char *string, long length, unsigned char kind) {
+yp_strspn_number_kind(const char *string, ptrdiff_t length, unsigned char kind) {
     if (length <= 0) return 0;
 
     size_t size = 0;
@@ -117,7 +117,7 @@ yp_strspn_number_kind(const char *string, long length, unsigned char kind) {
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
 size_t
-yp_strspn_binary_number(const char *string, long length) {
+yp_strspn_binary_number(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_BINARY_NUMBER);
 }
 
@@ -125,14 +125,14 @@ yp_strspn_binary_number(const char *string, long length) {
 // digits or underscores.  Disallows searching past the given maximum number of
 // characters.
 size_t
-yp_strspn_octal_number(const char *string, long length) {
+yp_strspn_octal_number(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_OCTAL_NUMBER);
 }
 
 // Returns the number of characters at the start of the string that are decimal
 // digits. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_decimal_digit(const char *string, long length) {
+yp_strspn_decimal_digit(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_DECIMAL_DIGIT);
 }
 
@@ -140,7 +140,7 @@ yp_strspn_decimal_digit(const char *string, long length) {
 // digits or underscores. Disallows searching past the given maximum number of
 // characters.
 size_t
-yp_strspn_decimal_number(const char *string, long length) {
+yp_strspn_decimal_number(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_DECIMAL_NUMBER);
 }
 
@@ -148,7 +148,7 @@ yp_strspn_decimal_number(const char *string, long length) {
 // hexadecimal digits. Disallows searching past the given maximum number of
 // characters.
 size_t
-yp_strspn_hexadecimal_digit(const char *string, long length) {
+yp_strspn_hexadecimal_digit(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_HEXADECIMAL_DIGIT);
 }
 
@@ -156,7 +156,7 @@ yp_strspn_hexadecimal_digit(const char *string, long length) {
 // hexadecimal digits or underscores. Disallows searching past the given maximum
 // number of characters.
 size_t
-yp_strspn_hexadecimal_number(const char *string, long length) {
+yp_strspn_hexadecimal_number(const char *string, ptrdiff_t length) {
     return yp_strspn_number_kind(string, length, YP_NUMBER_BIT_HEXADECIMAL_NUMBER);
 }
 

--- a/src/util/yp_strpbrk.c
+++ b/src/util/yp_strpbrk.c
@@ -13,7 +13,7 @@
 // within strings, comments, regular expressions, etc. So we need to be able to
 // skip past them.
 const char *
-yp_strpbrk(const char *source, const char *charset, long length) {
+yp_strpbrk(const char *source, const char *charset, ptrdiff_t length) {
     if (length < 0) return NULL;
 
     size_t index = 0;


### PR DESCRIPTION
This is just stylistic but could potentially provide us with some compiler help if we ever accidentally try to subtract different arrays.