### PR TITLE
Github Actions cancel-in-progress

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Main
 
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -1,5 +1,9 @@
 name: Test Loader.java with TruffleRuby
 
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
Use GA's "cancel-in-progress" concurrency check so that subsequent pushes to a PR don't have multiple CI runs going simultaneously.

See https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency