### PR TITLE
Encoding fast path

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -436,6 +436,20 @@ compile(VALUE self, VALUE string) {
     return result;
 }
 
+static VALUE
+profile_file(VALUE self, VALUE filepath) {
+    source_t source;
+    if (source_file_load(&source, filepath) != 0) return Qnil;
+
+    yp_parser_t parser;
+    yp_parser_init(&parser, source.source, source.size, StringValueCStr(filepath));
+
+    yp_node_t *node = yp_parse(&parser);
+    yp_node_destroy(&parser, node);
+
+    return Qnil;
+}
+
 RUBY_FUNC_EXPORTED void
 Init_yarp(void) {
     if (strcmp(yp_version(), EXPECTED_YARP_VERSION) != 0) {
@@ -475,6 +489,8 @@ Init_yarp(void) {
     rb_define_singleton_method(rb_cYARP, "memsize", memsize, 1);
 
     rb_define_singleton_method(rb_cYARP, "compile", compile, 1);
+
+    rb_define_singleton_method(rb_cYARP, "profile_file", profile_file, 1);
 
     Init_yarp_pack();
 }

--- a/include/yarp/enc/yp_encoding.h
+++ b/include/yarp/enc/yp_encoding.h
@@ -11,285 +11,151 @@
 #define YP_ENCODING_ALPHANUMERIC_BIT 1 << 1
 #define YP_ENCODING_UPPERCASE_BIT 1 << 2
 
+// This lookup table is referenced in both the UTF-8 encoding file and the
+// parser directly in order to speed up the default encoding processing.
+extern unsigned char yp_encoding_unicode_table[256];
+
 // The function is shared between all of the encodings that use single bytes to
 // represent characters. They don't have need of a dynamic function to determine
 // their width.
 size_t yp_encoding_single_char_width(__attribute__((unused)) const char *c);
 
-/******************************************************************************/
-/* ASCII                                                                      */
-/******************************************************************************/
-
+// ASCII
 size_t yp_encoding_ascii_char_width(const char *c);
-
 size_t yp_encoding_ascii_alpha_char(const char *c);
-
 size_t yp_encoding_ascii_alnum_char(const char *c);
-
 bool yp_encoding_ascii_isupper_char(const char *c);
 
-/******************************************************************************/
-/* Big5                                                                       */
-/******************************************************************************/
-
+// Big5
 size_t yp_encoding_big5_char_width(const char *c);
-
 size_t yp_encoding_big5_alpha_char(const char *c);
-
 size_t yp_encoding_big5_alnum_char(const char *c);
-
 bool yp_encoding_big5_isupper_char(const char *c);
 
-/******************************************************************************/
-/* EUC-JP                                                                     */
-/******************************************************************************/
-
+// EUC-JP
 size_t yp_encoding_euc_jp_char_width(const char *c);
-
 size_t yp_encoding_euc_jp_alpha_char(const char *c);
-
 size_t yp_encoding_euc_jp_alnum_char(const char *c);
-
 bool yp_encoding_euc_jp_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-1                                                                 */
-/******************************************************************************/
-
+// ISO-8859-1
 size_t yp_encoding_iso_8859_1_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_1_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_1_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_1_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-2                                                                 */
-/******************************************************************************/
-
+// ISO-8859-2
 size_t yp_encoding_iso_8859_2_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_2_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_2_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_2_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-3                                                                 */
-/******************************************************************************/
-
+// ISO-8859-3
 size_t yp_encoding_iso_8859_3_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_3_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_3_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_3_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-4                                                                 */
-/******************************************************************************/
-
+// ISO-8859-4
 size_t yp_encoding_iso_8859_4_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_4_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_4_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_4_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-5                                                                 */
-/******************************************************************************/
-
+// ISO-8859-5
 size_t yp_encoding_iso_8859_5_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_5_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_5_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_5_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-6                                                                 */
-/******************************************************************************/
-
+// ISO-8859-6
 size_t yp_encoding_iso_8859_6_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_6_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_6_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_6_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-7                                                                 */
-/******************************************************************************/
-
+// ISO-8859-7
 size_t yp_encoding_iso_8859_7_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_7_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_7_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_7_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-8                                                                 */
-/******************************************************************************/
-
+// ISO-8859-8
 size_t yp_encoding_iso_8859_8_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_8_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_8_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_8_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-9                                                                 */
-/******************************************************************************/
-
+// ISO-8859-9
 size_t yp_encoding_iso_8859_9_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_9_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_9_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_9_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-10                                                                */
-/******************************************************************************/
-
+// ISO-8859-10
 size_t yp_encoding_iso_8859_10_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_10_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_10_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_10_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-11                                                                */
-/******************************************************************************/
-
+// ISO-8859-11
 size_t yp_encoding_iso_8859_11_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_11_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_11_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_11_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-13                                                                */
-/******************************************************************************/
-
+// ISO-8859-13
 size_t yp_encoding_iso_8859_13_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_13_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_13_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_13_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-14                                                                */
-/******************************************************************************/
-
+// ISO-8859-14
 size_t yp_encoding_iso_8859_14_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_14_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_14_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_14_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-15                                                                */
-/******************************************************************************/
-
+// ISO-8859-15
 size_t yp_encoding_iso_8859_15_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_15_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_15_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_15_isupper_char(const char *c);
 
-/******************************************************************************/
-/* ISO-8859-16                                                                */
-/******************************************************************************/
-
+// ISO-8859-16
 size_t yp_encoding_iso_8859_16_char_width(const char *c);
-
 size_t yp_encoding_iso_8859_16_alpha_char(const char *c);
-
 size_t yp_encoding_iso_8859_16_alnum_char(const char *c);
-
 bool yp_encoding_iso_8859_16_isupper_char(const char *c);
 
-/******************************************************************************/
-/* Shift-JIS                                                                  */
-/******************************************************************************/
-
+// Shift-JIS
 size_t yp_encoding_shift_jis_char_width(const char *c);
-
 size_t yp_encoding_shift_jis_alpha_char(const char *c);
-
 size_t yp_encoding_shift_jis_alnum_char(const char *c);
-
 bool yp_encoding_shift_jis_isupper_char(const char *c);
 
-/******************************************************************************/
-/* UTF-8                                                                      */
-/******************************************************************************/
-
+// UTF-8
 size_t yp_encoding_utf_8_char_width(const char *c);
-
 size_t yp_encoding_utf_8_alpha_char(const char *c);
-
 size_t yp_encoding_utf_8_alnum_char(const char *c);
-
 bool yp_encoding_utf_8_isupper_char(const char *c);
 
-/******************************************************************************/
-/* Windows-31J                                                                */
-/******************************************************************************/
-
+// Windows-31J
 size_t yp_encoding_windows_31j_char_width(const char *c);
-
 size_t yp_encoding_windows_31j_alpha_char(const char *c);
-
 size_t yp_encoding_windows_31j_alnum_char(const char *c);
-
 bool yp_encoding_windows_31j_isupper_char(const char *c);
 
-/******************************************************************************/
-/* Windows-1251                                                               */
-/******************************************************************************/
-
+// Windows-1251
 size_t yp_encoding_windows_1251_char_width(const char *c);
-
 size_t yp_encoding_windows_1251_alpha_char(const char *c);
-
 size_t yp_encoding_windows_1251_alnum_char(const char *c);
-
 bool yp_encoding_windows_1251_isupper_char(const char *c);
 
-/******************************************************************************/
-/* Windows-1252                                                               */
-/******************************************************************************/
-
+// Windows-1252
 size_t yp_encoding_windows_1252_char_width(const char *c);
-
 size_t yp_encoding_windows_1252_alpha_char(const char *c);
-
 size_t yp_encoding_windows_1252_alnum_char(const char *c);
-
 bool yp_encoding_windows_1252_isupper_char(const char *c);
 
 #endif

--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -353,6 +353,11 @@ struct yp_parser {
     // it's parsing so that it can change with a magic comment.
     yp_encoding_t encoding;
 
+    // Whether or not the encoding has been changed by a magic comment. We use
+    // this to provide a fast path for the lexer instead of going through the
+    // function pointer.
+    bool encoding_changed;
+
     // When the encoding that is being used to parse the source is changed by
     // YARP, we provide the ability here to call out to a user-defined function.
     yp_encoding_changed_callback_t encoding_changed_callback;

--- a/src/enc/unicode.c
+++ b/src/enc/unicode.c
@@ -10,8 +10,8 @@ typedef uint32_t unicode_codepoint_t;
 // this table is different from other encodings where we used a lookup table
 // because the indices of those tables are the byte representations, not the
 // codepoints themselves.
-static unsigned char yp_encoding_unicode_table[256] = {
-  //0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+unsigned char yp_encoding_unicode_table[256] = {
+//  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 1x
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 2x


### PR DESCRIPTION
Instead of going through the function pointer every time, instead check if the encoding has been changed. This patch entirely eliminates the encoding-related functions from the profile.