### PR TITLE
Fix line and file information in generated files

### DIFF
--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -1,3 +1,4 @@
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
 #include "yarp/node.h"
 
 // Clear the node but preserves the location.
@@ -104,6 +105,7 @@ YP_EXPORTED_FUNCTION void
 yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
     switch (node->type) {
         <%- nodes.each do |node| -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         case <%= node.type %>:
             <%- node.params.each do |param| -%>
             <%- case param -%>
@@ -128,6 +130,7 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
             <%- end -%>
             break;
         <%- end -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         default:
             assert(false && "unreachable");
             break;
@@ -141,6 +144,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
 
     switch (node->type) {
         <%- nodes.each do |node| -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         case <%= node.type %>: {
             memsize->memsize += sizeof(yp_<%= node.human %>_t);
             <%- node.params.each do |param| -%>
@@ -167,6 +171,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
             break;
         }
         <%- end -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
     }
 }
 


### PR DESCRIPTION
When we generate files, error messages (including compilation errors and stack traces) would point to the generated .c file when the error actually originates from the source ERB file.  When fixing these generated files, we need to fix the source ERB file rather than the generated file, so this commit changes the generated file to use the source file for line and file reporting information

For example, if there is a syntax error in the source ERB file like this:

<img width="546" alt="yarp — ~:g:yarp — -fish — 284×76 2023-06-13 11-34-35" src="https://github.com/ruby/yarp/assets/3124/813bcb5c-8f0e-433a-b10f-8ba81bd0c9a3">

When you compile YARP, the error will be reported in the wrong place like this:

<img width="666" alt="wrong" src="https://github.com/ruby/yarp/assets/3124/f4019eb0-cfa6-41f9-803f-bf58c7458d70">

This patch fixes the error message so that it's reported as part of the source ERB file:

<img width="662" alt="fixed" src="https://github.com/ruby/yarp/assets/3124/2522ebc3-34b6-4f46-a77b-c963b4f3c04a">


This PR only fixes `node.c`.  We need to fix the other files, but there also might be a more generic way to do this (maybe like a custom ERB generator that automatically emits the `#line` directives).