### PR TITLE
Increase default constant id list size

### DIFF
--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -25,7 +25,7 @@ void
 yp_token_list_append(yp_token_list_t *token_list, const yp_token_t *token) {
     if (token_list->size == token_list->capacity) {
         token_list->capacity = token_list->capacity == 0 ? 1 : token_list->capacity * 2;
-        token_list->tokens = realloc(token_list->tokens, sizeof(yp_token_t) * token_list->capacity);
+        token_list->tokens = (yp_token_t *) realloc(token_list->tokens, sizeof(yp_token_t) * token_list->capacity);
     }
     token_list->tokens[token_list->size++] = *token;
 }
@@ -78,7 +78,7 @@ void
 yp_node_list_append(yp_node_list_t *list, yp_node_t *node) {
     if (list->size == list->capacity) {
         list->capacity = list->capacity == 0 ? 4 : list->capacity * 2;
-        list->nodes = realloc(list->nodes, list->capacity * sizeof(yp_node_t *));
+        list->nodes = (yp_node_t **) realloc(list->nodes, sizeof(yp_node_t *) * list->capacity);
     }
     list->nodes[list->size++] = node;
 }

--- a/bin/templates/src/prettyprint.c.erb
+++ b/bin/templates/src/prettyprint.c.erb
@@ -59,13 +59,13 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
             }
             <%- when ConstantParam -%>
             char <%= param.name %>_buffer[12];
-            snprintf(<%= param.name %>_buffer, 12, "%lu", ((yp_<%= node.human %>_t *)node)-><%= param.name %>);
+            snprintf(<%= param.name %>_buffer, 12, "%u", ((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
             <%- when ConstantListParam -%>
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= param.name %>.size; index++) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);
                 char <%= param.name %>_buffer[12];
-                snprintf(<%= param.name %>_buffer, 12, "%lu", ((yp_<%= node.human %>_t *)node)-><%= param.name %>.ids[index]);
+                snprintf(<%= param.name %>_buffer, 12, "%u", ((yp_<%= node.human %>_t *)node)-><%= param.name %>.ids[index]);
                 yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
             }
             <%- when LocationParam -%>

--- a/include/yarp/util/yp_allocator.h
+++ b/include/yarp/util/yp_allocator.h
@@ -1,0 +1,14 @@
+#ifndef YARP_ALLOCATOR_H
+#define YARP_ALLOCATOR_H
+
+#include <stdlib.h>
+
+typedef struct {
+    void *memory;
+    void *current;
+
+    size_t size;
+    size_t capacity;
+} yp_allocator_t;
+
+#endif

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef unsigned long yp_constant_id_t;
+typedef uint32_t yp_constant_id_t;
 
 typedef struct {
     yp_constant_id_t *ids;

--- a/src/util/yp_constant_pool.c
+++ b/src/util/yp_constant_pool.c
@@ -13,8 +13,8 @@ yp_constant_id_list_init(yp_constant_id_list_t *list) {
 bool
 yp_constant_id_list_append(yp_constant_id_list_t *list, yp_constant_id_t id) {
     if (list->size >= list->capacity) {
-        list->capacity = list->capacity == 0 ? 1 : list->capacity * 2;
-        list->ids = realloc(list->ids, sizeof(yp_constant_id_list_t) * list->capacity);
+        list->capacity = list->capacity == 0 ? 8 : list->capacity * 2;
+        list->ids = (yp_constant_id_t *) realloc(list->ids, sizeof(yp_constant_id_t) * list->capacity);
         if (list->ids == NULL) return false;
     }
 

--- a/src/util/yp_string_list.c
+++ b/src/util/yp_string_list.c
@@ -19,7 +19,7 @@ void
 yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string) {
     if (string_list->length + 1 > string_list->capacity) {
         string_list->capacity *= 2;
-        string_list->strings = realloc(string_list->strings, string_list->capacity * sizeof(yp_string_t));
+        string_list->strings = (yp_string_t *) realloc(string_list->strings, string_list->capacity * sizeof(yp_string_t));
     }
 
     string_list->strings[string_list->length++] = *string;


### PR DESCRIPTION
Seeing a lot of reallocations when adding lists of constants because it does one for the 1st constant, then another for the 2nd constant, then another for the 3rd. Setting this to 8 by default doesn't significantly increase memory usage (all of the constant ids are still within a single cache line) but does avoid a bunch of unnecessary syscalls.