### PR TITLE
Update actions/cache@v3

### DIFF
--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo "$PWD/truffleruby-ws/truffleruby/bin" >> $GITHUB_PATH
 
     - name: Restore ~/.mx/cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.mx/cache
         key: mx-cache-${{ runner.os }}


### PR DESCRIPTION
## Why

The 'actions/cache@v2' is using Node.js 12, which resulted in the following annotations.
Node.js 12 is deprecated.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ .
