### PR TITLE
Refactor to remove parse_file_dup, use debug_mode build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,24 @@ jobs:
     - name: Run Ruby tests
       run: bundle exec rake compile_no_debug
 
+  build-debug-mode:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: head
+        bundler-cache: true
+    - name: Run Ruby tests
+      run: bundle exec rake
+      env:
+        YARP_DEBUG: "1"
+
   lex-ruby:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Run Ruby tests
       run: bundle exec rake
       env:
-        YARP_DEBUG: "1"
+        YARP_DEBUG_MODE_BUILD: "1"
 
   lex-ruby:
     runs-on: ubuntu-latest

--- a/bin/parse
+++ b/bin/parse
@@ -11,5 +11,5 @@ require "yarp"
 if ARGV[0] == "-e"
   pp YARP.parse(ARGV[1])
 else
-  pp YARP.parse_file_dup(ARGV[0])
+  pp YARP.parse_file(ARGV[0])
 end

--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -2,8 +2,8 @@
 
 require "mkmf"
 
-if ENV["YARP_DEBUG"]
-  $CFLAGS << " -DYARP_DEBUG"
+if ENV["YARP_DEBUG_MODE_BUILD"]
+  $CFLAGS << " -DYARP_DEBUG_MODE_BUILD"
 end
 
 if ENV["BUNDLE"]

--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -2,6 +2,10 @@
 
 require "mkmf"
 
+if ENV["YARP_DEBUG"]
+  $CFLAGS << " -DYARP_DEBUG"
+end
+
 if ENV["BUNDLE"]
   # In this version we want to bundle all of the C source files together into
   # the gem so that it can all be compiled together.

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -297,13 +297,13 @@ static VALUE
 parse(VALUE self, VALUE string) {
     source_t source;
     source_string_load(&source, string);
-#ifdef YARP_DEBUG
+#ifdef YARP_DEBUG_MODE_BUILD
     char* dup = malloc(source.size);
     memcpy(dup, source.source, source.size);
     source.source = dup;
 #endif
     VALUE value = parse_source(&source, NULL);
-#ifdef YARP_DEBUG
+#ifdef YARP_DEBUG_MODE_BUILD
     free(dup);
 #endif
     return value;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -11,11 +11,11 @@ yp_version(void) {
     return YP_VERSION_MACRO;
 }
 
-#ifndef YP_DEBUG
-#define YP_DEBUG 0
+#ifndef YP_DEBUG_LOGGING
+#define YP_DEBUG_LOGGING 0
 #endif
 
-#if YP_DEBUG
+#if YP_DEBUG_LOGGING
 
 /******************************************************************************/
 /* Debugging                                                                  */
@@ -267,7 +267,7 @@ lex_state_set(yp_parser_t *parser, yp_lex_state_t state) {
     parser->lex_state = state;
 }
 
-#if YP_DEBUG
+#if YP_DEBUG_LOGGING
 static inline void
 debug_lex_state_set(yp_parser_t *parser, yp_lex_state_t state, char const * caller_name, int line_number) {
     fprintf(stderr, "Caller: %s:%d\nPrevious: ", caller_name, line_number);

--- a/tasks/lex.rake
+++ b/tasks/lex.rake
@@ -295,7 +295,7 @@ task "parse:topgems": ["download:topgems", :compile] do
   class ParseTop100GemsTest < Test::Unit::TestCase
     Dir["#{TOP_100_GEMS_DIR}/**/*.rb"].each do |filepath|
       test filepath do
-        result = YARP.parse_file_dup(filepath)
+        result = YARP.parse_file(filepath)
 
         if TOP_100_GEMS_INVALID_SYNTAX_PREFIXES.any? { |prefix| filepath.start_with?(prefix) }
           assert_false result.success?

--- a/test/comments_test.rb
+++ b/test/comments_test.rb
@@ -40,7 +40,7 @@ class CommentsTest < Test::Unit::TestCase
   private
 
   def assert_comment(source, type)
-    result = YARP.parse_dup(source)
+    result = YARP.parse(source)
     assert result.errors.empty?, result.errors.map(&:message).join("\n")
     result => YARP::ParseResult[comments: [YARP::Comment[type: type]]]
   end

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -34,20 +34,20 @@ class EncodingTest < Test::Unit::TestCase
     CP1252
   ].each do |encoding|
     define_method "test_encoding_#{encoding}" do
-      result = YARP.parse_dup("# encoding: #{encoding}\nident")
+      result = YARP.parse("# encoding: #{encoding}\nident")
       actual = result.value.statements.body.first.message.value.encoding
       assert_equal Encoding.find(encoding), actual
     end
   end
 
   def test_coding
-    result = YARP.parse_dup("# coding: utf-8\nident")
+    result = YARP.parse("# coding: utf-8\nident")
     actual = result.value.statements.body.first.message.value.encoding
     assert_equal Encoding.find("utf-8"), actual
   end
 
   def test_emacs_style
-    result = YARP.parse_dup("# -*- coding: utf-8 -*-\nident")
+    result = YARP.parse("# -*- coding: utf-8 -*-\nident")
     actual = result.value.statements.body.first.message.value.encoding
     assert_equal Encoding.find("utf-8"), actual
   end
@@ -59,7 +59,7 @@ class EncodingTest < Test::Unit::TestCase
       utf-8-mac
       utf-8-*
     ].each do |encoding|
-      result = YARP.parse_dup("# coding: #{encoding}\nident")
+      result = YARP.parse("# coding: #{encoding}\nident")
       actual = result.value.statements.body.first.message.value.encoding
       assert_equal Encoding.find("utf-8"), actual
     end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -957,7 +957,7 @@ class ErrorsTest < Test::Unit::TestCase
   def assert_errors(expected, source, errors)
     assert_nil Ripper.sexp_raw(source)
 
-    result = YARP.parse_dup(source)
+    result = YARP.parse(source)
     result => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: [*, node]]]]
 
     assert_equal_nodes(expected, node, compare_location: false)
@@ -966,12 +966,12 @@ class ErrorsTest < Test::Unit::TestCase
 
   def assert_error_messages(source, errors)
     assert_nil Ripper.sexp_raw(source)
-    result = YARP.parse_dup(source)
+    result = YARP.parse(source)
     assert_equal(errors, result.errors.map(&:message))
   end
 
   def expression(source)
-    YARP.parse_dup(source) => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: [*, node]]]]
+    YARP.parse(source) => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: [*, node]]]]
     node
   end
 end

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -474,7 +474,7 @@ module YARP
     private
 
     def assert_location(kind, source, expected = 0...source.length)
-      YARP.parse_dup(source) => ParseResult[comments: [], errors: [], value: node]
+      YARP.parse(source) => ParseResult[comments: [], errors: [], value: node]
 
       node => ProgramNode[statements: [*, node]]
       node = yield node if block_given?

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -46,7 +46,7 @@ class ParseTest < Test::Unit::TestCase
       refute_nil Ripper.sexp_raw(source)
 
       # Next, parse the source and print the value.
-      result = YARP.parse_file_dup(filepath)
+      result = YARP.parse_file(filepath)
       value = result.value
       printed = normalize_printed(PP.pp(value, +"", 79))
 


### PR DESCRIPTION
Instead of exposing parse_file_dup as a debugging utility, this commit adds a debug mode build that will perform the same checks without the additional complexity of parse_file_dup