### PR TITLE
Introduce autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,7 @@ test-native/run-one
 compile_commands.json
 .cache/
 
+configure
+Makefile
+
 tags

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,29 +1,20 @@
 ifeq ($(shell uname), Darwin)
-SOEXT := dylib
+	SOEXT := dylib
 else
-SOEXT := so
+	SOEXT := so
 endif
 
-OPTFLAGS :=
-CFLAGS :=
-
-# Check for the presence of strncasecmp
-ifeq ($(shell $(CC) -Iinclude -o /dev/null test/availability/strncasecmp.c 2>/dev/null && echo 1), 1)
-CFLAGS := $(CFLAGS) -DHAVE_STRNCASECMP
-endif
-
-# Check for the presence of strnstr
-ifeq ($(shell $(CC) -Iinclude -o /dev/null test/availability/strnstr.c 2>/dev/null && echo 1), 1)
-CFLAGS := $(CFLAGS) -DHAVE_STRNSTR
-endif
+CFLAGS := @CFLAGS@ -std=c99
+DEFS := @DEFS@
+CC := @CC@
 
 all: build/librubyparser.$(SOEXT)
 
 build/librubyparser.$(SOEXT): $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h
-	$(CC) $(OPTFLAGS) $(DEBUG_FLAGS) $(CFLAGS) -std=c99 -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
+	$(CC) $(DEBUG_FLAGS) $(CFLAGS) $(DEFS) -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
 
 build/profile: $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h bin/profile.c
-	$(CC) $(CFLAGS) -O3 -std=c99 -Iinclude -o $@ $(shell find src -name '*.c') bin/profile.c
+	$(CC) $(CFLAGS) $(DEFS) -O3 -Iinclude -o $@ $(shell find src -name '*.c') bin/profile.c
 
 build:
 	mkdir -p build

--- a/Rakefile
+++ b/Rakefile
@@ -38,11 +38,19 @@ require_relative "bin/template"
 desc "Generate all ERB template based files"
 task templates: TEMPLATES
 
-task make: :templates do
+file "configure" do
+  sh "autoconf"
+end
+
+file "Makefile" => "configure" do
+  sh "./configure"
+end
+
+task make: [:templates, "Makefile"] do
   sh "make"
 end
 
-task make_no_debug: :templates do
+task make_no_debug: [:templates, "Makefile"] do
   sh "make all-no-debug"
 end
 
@@ -56,6 +64,7 @@ end
 
 # So `rake clobber` will delete generated files
 CLOBBER.concat(TEMPLATES)
+CLOBBER.concat(["configure", "Makefile"])
 
 CLOBBER << "build/librubyparser.#{RbConfig::CONFIG["SOEXT"]}"
 CLOBBER << "lib/yarp.#{RbConfig::CONFIG["DLEXT"]}"

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,8 @@
+AC_INIT
+# Check that we have a C compiler
+AC_PROG_CC
+AC_DEFINE(_XOPEN_SOURCE, 700)
+AC_CHECK_FUNCS(mmap)
+AC_CHECK_FUNCS(strncasecmp)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -5,10 +5,6 @@
 #define YARP_DEFINES_H
 
 // For strnlen(), strncasecmp()
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 700
-#endif
-
 #if defined(_WIN32)
 #   define YP_EXPORTED_FUNCTION __declspec(dllexport) extern
 #else

--- a/include/yarp/missing.h
+++ b/include/yarp/missing.h
@@ -9,10 +9,6 @@
 
 const char * yp_strnstr(const char *haystack, const char *needle, size_t length);
 
-#ifndef HAVE_STRNSTR
-#define strnstr yp_strnstr
-#endif
-
 int yp_strncasecmp(const char *string1, const char *string2, size_t length);
 
 #ifndef HAVE_STRNCASECMP

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3914,9 +3914,9 @@ parser_lex_encoding_comment(yp_parser_t *parser) {
     // These are the patterns we're going to match to find the encoding comment.
     // This is definitely not complete or even really correct.
     const char *encoding_start = NULL;
-    if ((encoding_start = strnstr(start, "coding:", (size_t) (end - start))) != NULL) {
+    if ((encoding_start = yp_strnstr(start, "coding:", (size_t) (end - start))) != NULL) {
         encoding_start += 7;
-    } else if ((encoding_start = strnstr(start, "coding=", (size_t) (end - start))) != NULL) {
+    } else if ((encoding_start = yp_strnstr(start, "coding=", (size_t) (end - start))) != NULL) {
         encoding_start += 7;
     }
 

--- a/test/availability/strnstr.c
+++ b/test/availability/strnstr.c
@@ -1,6 +1,0 @@
-#include "yarp/defines.h"
-#include <string.h>
-
-int main() {
-    strnstr("", "", 0);
-}


### PR DESCRIPTION
   This PR introduces autotools for detecting whether or not some
    functions exist.  The benefit of using autotools is that we don't need
    to write our own feature detection C files, and that we'll use the same
    `HAVE_*` macros that Ruby uses.  That means we can copy our C files in
    to Ruby and piggyback off Ruby's configure scripts when Ruby is built.