### PR TITLE
Split up operator assignment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -594,6 +594,50 @@ nodes:
 
           foo&.bar
           ^^^^^^^^
+  - name: CallOperatorAndWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: CallNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator on a call.
+
+          foo.bar &&= value
+          ^^^^^^^^^^^^^^^^^
+  - name: CallOperatorOrWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: CallNode
+      - name: value
+        type: node
+      - name: operator_loc
+        type: location
+    comment: |
+      Represents the use of the `||=` operator on a call.
+
+          foo.bar ||= value
+          ^^^^^^^^^^^^^^^^^
+  - name: CallOperatorWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: CallNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator_id
+        type: constant
+    comment: |
+      Represents the use of an assignment operator on a call.
+
+          foo.bar += baz
+          ^^^^^^^^^^^^^^
   - name: CapturePatternNode
     child_nodes:
       - name: value
@@ -648,6 +692,47 @@ nodes:
 
           class Foo end
           ^^^^^^^^^^^^^
+  - name: ClassVariableOperatorAndWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator for assignment to a class variable.
+
+          @@target &&= value
+          ^^^^^^^^^^^^^^^^
+  - name: ClassVariableOperatorOrWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `||=` operator for assignment to a class variable.
+
+          @@target ||= value
+          ^^^^^^^^^^^^^^^^^^
+  - name: ClassVariableOperatorWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator
+        type: constant
+    comment: |
+      Represents assigning to a class variable using an operator that isn't `=`.
+
+          @@target += value
+          ^^^^^^^^^^^^^^^^^
   - name: ClassVariableReadNode
     comment: |
       Represents referencing a class variable.
@@ -667,6 +752,47 @@ nodes:
 
           @@foo = 1
           ^^^^^^^^^
+  - name: ConstantOperatorAndWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator for assignment to a constant.
+
+          Target &&= value
+          ^^^^^^^^^^^^^^^^
+  - name: ConstantOperatorOrWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `||=` operator for assignment to a constant.
+
+          Target ||= value
+          ^^^^^^^^^^^^^^^^
+  - name: ConstantOperatorWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator
+        type: constant
+    comment: |
+      Represents assigning to a constant using an operator that isn't `=`.
+
+          Target += value
+          ^^^^^^^^^^^^^^^
   - name: ConstantPathNode
     child_nodes:
       - name: parent
@@ -680,6 +806,50 @@ nodes:
 
           Foo::Bar
           ^^^^^^^^
+  - name: ConstantPathOperatorAndWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: ConstantPathNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator for assignment to a constant path.
+
+          Parent::Child &&= value
+          ^^^^^^^^^^^^^^^^^^^^^^^
+  - name: ConstantPathOperatorOrWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: ConstantPathNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `||=` operator for assignment to a constant path.
+
+          Parent::Child ||= value
+          ^^^^^^^^^^^^^^^^^^^^^^^
+  - name: ConstantPathOperatorWriteNode
+    child_nodes:
+      - name: target
+        type: node
+        kind: ConstantPathNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator
+        type: constant
+    comment: |
+      Represents assigning to a constant path using an operator that isn't `=`.
+
+          Parent::Child += value
+          ^^^^^^^^^^^^^^^^^^^^^^
   - name: ConstantPathWriteNode
     child_nodes:
       - name: target
@@ -864,6 +1034,47 @@ nodes:
 
           super
           ^^^^^
+  - name: GlobalVariableOperatorAndWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator for assignment to a global variable.
+
+          $target &&= value
+          ^^^^^^^^^^^^^^^^^
+  - name: GlobalVariableOperatorOrWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `||=` operator for assignment to a global variable.
+
+          $target ||= value
+          ^^^^^^^^^^^^^^^^^
+  - name: GlobalVariableOperatorWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator
+        type: constant
+    comment: |
+      Represents assigning to a global variable using an operator that isn't `=`.
+
+          $target += value
+          ^^^^^^^^^^^^^^^^
   - name: GlobalVariableReadNode
     comment: |
       Represents referencing a global variable.
@@ -962,6 +1173,47 @@ nodes:
 
           case a; in b then c end
                   ^^^^^^^^^^^
+  - name: InstanceVariableOperatorAndWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `&&=` operator for assignment to an instance variable.
+
+          @target &&= value
+          ^^^^^^^^^^^^^^^^^
+  - name: InstanceVariableOperatorOrWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents the use of the `||=` operator for assignment to an instance variable.
+
+          @target ||= value
+          ^^^^^^^^^^^^^^^^^
+  - name: InstanceVariableOperatorWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: operator
+        type: constant
+    comment: |
+      Represents assigning to an instance variable using an operator that isn't `=`.
+
+          @target += value
+          ^^^^^^^^^^^^^^^^
   - name: InstanceVariableReadNode
     comment: |
       Represents referencing an instance variable.
@@ -1094,6 +1346,53 @@ nodes:
 
           ->(value) { value * 2 }
           ^^^^^^^^^^^^^^^^^^^^^^^
+  - name: LocalVariableOperatorAndWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: constant_id
+        type: constant
+    comment: |
+      Represents the use of the `&&=` operator for assignment to a local variable.
+
+          target &&= value
+          ^^^^^^^^^^^^^^^^
+  - name: LocalVariableOperatorOrWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: constant_id
+        type: constant
+    comment: |
+      Represents the use of the `||=` operator for assignment to a local variable.
+
+          target ||= value
+          ^^^^^^^^^^^^^^^^
+  - name: LocalVariableOperatorWriteNode
+    child_nodes:
+      - name: name_loc
+        type: location
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+      - name: constant_id
+        type: constant
+      - name: operator_id
+        type: constant
+    comment: |
+      Represents assigning to a local variable using an operator that isn't `=`.
+
+          target += value
+          ^^^^^^^^^^^^^^^
   - name: LocalVariableReadNode
     child_nodes:
       - name: constant_id
@@ -1224,45 +1523,6 @@ nodes:
 
           $1
           ^^
-  - name: OperatorAndAssignmentNode
-    child_nodes:
-      - name: target
-        type: node
-      - name: value
-        type: node
-      - name: operator_loc
-        type: location
-    comment: |
-      Represents the use of the `&&=` operator for assignment.
-
-          target &&= value
-          ^^^^^^^^^^^^^^^^
-  - name: OperatorAssignmentNode
-    child_nodes:
-      - name: target
-        type: node
-      - name: operator
-        type: token
-      - name: value
-        type: node
-    comment: |
-      Represents assigning to a value using an operator that isn't `=`.
-
-          foo += bar
-          ^^^^^^^^^^
-  - name: OperatorOrAssignmentNode
-    child_nodes:
-      - name: target
-        type: node
-      - name: value
-        type: node
-      - name: operator_loc
-        type: location
-    comment: |
-      Represents the use of the `||=` operator for assignment.
-
-          target ||= value
-          ^^^^^^^^^^^^^^^^
   - name: OptionalParameterNode
     child_nodes:
       - name: constant_id

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -31,8 +31,6 @@ Each node's child is then appended to the serialized string. The child node type
 * `node?` - A child node that is optionally present. If the node is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just as like parent node.
 * `node[]` - A child node that is an array of nodes. This is structured as a variable-length integer length, followed by the child nodes themselves.
 * `string` - A child node that is a string. For example, this is used as the name of the method in a call node, since it cannot directly reference the source string (as in `@-` or `foo=`). This is structured as a variable-length integer byte length, followed by the string itself (_without_ a trailing null byte).
-* `token` - A child node that is a token. This is structured as a single byte type, followed by two variable-length integers that represent offsets into the source string.
-* `token?` - A child node that is a token that is optionally present. If the token is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just like the `token` child node.
 * `constant` - A variable-length integer that represents an index in the constant pool.
 * `constant[]` - A child node that is an array of constants. This is structured as a variable-length integer length, followed by the child constants themselves.
 * `location` - A child node that is a location. This is structured as a variable-length integer start followed by a variable-length integer length.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1115,6 +1115,72 @@ yp_call_node_vcall_p(yp_call_node_t *node) {
     );
 }
 
+// Allocate and initialize a new CallOperatorAndWriteNode node.
+static yp_call_operator_and_write_node_t *
+yp_call_operator_and_write_node_create(yp_parser_t *parser, yp_call_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_call_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_call_operator_and_write_node_t);
+
+    *node = (yp_call_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_CALL_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate a new CallOperatorWriteNode node.
+static yp_call_operator_write_node_t *
+yp_call_operator_write_node_create(yp_parser_t *parser, yp_call_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_call_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_call_operator_write_node_t);
+
+    *node = (yp_call_operator_write_node_t) {
+        {
+            .type = YP_NODE_CALL_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator_id = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new CallOperatorOrWriteNode node.
+static yp_call_operator_or_write_node_t *
+yp_call_operator_or_write_node_create(yp_parser_t *parser, yp_call_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_call_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_call_operator_or_write_node_t);
+
+    *node = (yp_call_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_CALL_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
 // Allocate and initialize a new CapturePatternNode node.
 static yp_capture_pattern_node_t *
 yp_capture_pattern_node_create(yp_parser_t *parser, yp_node_t *value, yp_node_t *target, const yp_token_t *operator) {
@@ -1204,6 +1270,74 @@ yp_class_node_create(yp_parser_t *parser, yp_constant_id_list_t *locals, const y
     return node;
 }
 
+// Allocate and initialize a new ClassVariableOperatorAndWriteNode node.
+static yp_class_variable_operator_and_write_node_t *
+yp_class_variable_operator_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_CLASS_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_class_variable_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_class_variable_operator_and_write_node_t);
+
+    *node = (yp_class_variable_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_CLASS_VARIABLE_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ClassVariableOperatorWriteNode node.
+static yp_class_variable_operator_write_node_t *
+yp_class_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_class_variable_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_class_variable_operator_write_node_t);
+
+    *node = (yp_class_variable_operator_write_node_t) {
+        {
+            .type = YP_NODE_CLASS_VARIABLE_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ClassVariableOperatorOrWriteNode node.
+static yp_class_variable_operator_or_write_node_t *
+yp_class_variable_operator_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_CLASS_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_class_variable_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_class_variable_operator_or_write_node_t);
+
+    *node = (yp_class_variable_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_CLASS_VARIABLE_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
 // Allocate and initialize a new ClassVariableReadNode node.
 static yp_class_variable_read_node_t *
 yp_class_variable_read_node_create(yp_parser_t *parser, const yp_token_t *token) {
@@ -1228,6 +1362,72 @@ yp_class_variable_read_node_to_class_variable_write_node(yp_parser_t *parser, yp
         },
         .name_loc = YP_LOCATION_NODE_VALUE((yp_node_t *)read_node),
         .operator_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantPathOperatorAndWriteNode node.
+static yp_constant_path_operator_and_write_node_t *
+yp_constant_path_operator_and_write_node_create(yp_parser_t *parser, yp_constant_path_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_constant_path_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_path_operator_and_write_node_t);
+
+    *node = (yp_constant_path_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_PATH_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantPathOperatorWriteNode node.
+static yp_constant_path_operator_write_node_t *
+yp_constant_path_operator_write_node_create(yp_parser_t *parser, yp_constant_path_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_constant_path_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_path_operator_write_node_t);
+
+    *node = (yp_constant_path_operator_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_PATH_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantPathOperatorOrWriteNode node.
+static yp_constant_path_operator_or_write_node_t *
+yp_constant_path_operator_or_write_node_create(yp_parser_t *parser, yp_constant_path_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_constant_path_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_path_operator_or_write_node_t);
+
+    *node = (yp_constant_path_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_PATH_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value
     };
 
@@ -1270,6 +1470,74 @@ yp_constant_path_write_node_create(yp_parser_t *parser, yp_node_t *target, const
         },
         .target = target,
         .operator_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantOperatorAndWriteNode node.
+static yp_constant_operator_and_write_node_t *
+yp_constant_operator_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_CONSTANT_READ_NODE);
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_constant_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_operator_and_write_node_t);
+
+    *node = (yp_constant_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantOperatorWriteNode node.
+static yp_constant_operator_write_node_t *
+yp_constant_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_constant_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_operator_write_node_t);
+
+    *node = (yp_constant_operator_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new ConstantOperatorOrWriteNode node.
+static yp_constant_operator_or_write_node_t *
+yp_constant_operator_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_CONSTANT_READ_NODE);
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_constant_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_constant_operator_or_write_node_t);
+
+    *node = (yp_constant_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_CONSTANT_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value
     };
 
@@ -1568,6 +1836,74 @@ yp_hash_pattern_node_node_list_create(yp_parser_t *parser, yp_node_list_t *assoc
         yp_node_t *assoc = assocs->nodes[index];
         yp_node_list_append(&node->assocs, assoc);
     }
+
+    return node;
+}
+
+// Allocate and initialize a new GlobalVariableOperatorAndWriteNode node.
+static yp_global_variable_operator_and_write_node_t *
+yp_global_variable_operator_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_GLOBAL_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_global_variable_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_global_variable_operator_and_write_node_t);
+
+    *node = (yp_global_variable_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_GLOBAL_VARIABLE_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new GlobalVariableOperatorWriteNode node.
+static yp_global_variable_operator_write_node_t *
+yp_global_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_global_variable_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_global_variable_operator_write_node_t);
+
+    *node = (yp_global_variable_operator_write_node_t) {
+        {
+            .type = YP_NODE_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new GlobalVariableOperatorOrWriteNode node.
+static yp_global_variable_operator_or_write_node_t *
+yp_global_variable_operator_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_GLOBAL_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_global_variable_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_global_variable_operator_or_write_node_t);
+
+    *node = (yp_global_variable_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_GLOBAL_VARIABLE_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
 
     return node;
 }
@@ -1873,6 +2209,74 @@ yp_in_node_create(yp_parser_t *parser, yp_node_t *pattern, yp_statements_node_t 
     return node;
 }
 
+// Allocate and initialize a new InstanceVariableOperatorAndWriteNode node.
+static yp_instance_variable_operator_and_write_node_t *
+yp_instance_variable_operator_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_INSTANCE_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_instance_variable_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_instance_variable_operator_and_write_node_t);
+
+    *node = (yp_instance_variable_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_INSTANCE_VARIABLE_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new InstanceVariableOperatorWriteNode node.
+static yp_instance_variable_operator_write_node_t *
+yp_instance_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_instance_variable_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_instance_variable_operator_write_node_t);
+
+    *node = (yp_instance_variable_operator_write_node_t) {
+        {
+            .type = YP_NODE_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new InstanceVariableOperatorOrWriteNode node.
+static yp_instance_variable_operator_or_write_node_t *
+yp_instance_variable_operator_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    assert(target->type == YP_NODE_INSTANCE_VARIABLE_READ_NODE);
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_instance_variable_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_instance_variable_operator_or_write_node_t);
+
+    *node = (yp_instance_variable_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_INSTANCE_VARIABLE_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
+}
+
 // Allocate and initialize a new InstanceVariableReadNode node.
 static yp_instance_variable_read_node_t *
 yp_instance_variable_read_node_create(yp_parser_t *parser, const yp_token_t *token) {
@@ -2151,6 +2555,77 @@ yp_lambda_node_create(
     return node;
 }
 
+// Allocate and initialize a new LocalVariableOperatorAndWriteNode node.
+static yp_local_variable_operator_and_write_node_t *
+yp_local_variable_operator_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id) {
+    assert(target->type == YP_NODE_LOCAL_VARIABLE_READ_NODE || target->type == YP_NODE_CALL_NODE);
+    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
+    yp_local_variable_operator_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_operator_and_write_node_t);
+
+    *node = (yp_local_variable_operator_and_write_node_t) {
+        {
+            .type = YP_NODE_LOCAL_VARIABLE_OPERATOR_AND_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .constant_id = constant_id
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new LocalVariableOperatorWriteNode node.
+static yp_local_variable_operator_write_node_t *
+yp_local_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id) {
+    yp_local_variable_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_operator_write_node_t);
+
+    *node = (yp_local_variable_operator_write_node_t) {
+        {
+            .type = YP_NODE_LOCAL_VARIABLE_OPERATOR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .constant_id = constant_id,
+        .operator_id = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new LocalVariableOperatorOrWriteNode node.
+static yp_local_variable_operator_or_write_node_t *
+yp_local_variable_operator_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id) {
+    assert(target->type == YP_NODE_LOCAL_VARIABLE_READ_NODE || target->type == YP_NODE_CALL_NODE);
+    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
+    yp_local_variable_operator_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_operator_or_write_node_t);
+
+    *node = (yp_local_variable_operator_or_write_node_t) {
+        {
+            .type = YP_NODE_LOCAL_VARIABLE_OPERATOR_OR_WRITE_NODE,
+            .location = {
+                .start = target->location.start,
+                .end = value->location.end
+            }
+        },
+        .name_loc = target->location,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value,
+        .constant_id = constant_id
+    };
+
+    return node;
+}
+
 // Allocate a new LocalVariableReadNode node.
 static yp_local_variable_read_node_t *
 yp_local_variable_read_node_create(yp_parser_t *parser, const yp_token_t *name, uint32_t depth) {
@@ -2379,71 +2854,6 @@ yp_numbered_reference_read_node_create(yp_parser_t *parser, const yp_token_t *na
             .type = YP_NODE_NUMBERED_REFERENCE_READ_NODE,
             .location = YP_LOCATION_TOKEN_VALUE(name),
         }
-    };
-
-    return node;
-}
-
-// Allocate and initialize a new OperatorAndAssignmentNode node.
-static yp_operator_and_assignment_node_t *
-yp_operator_and_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
-    assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
-    yp_operator_and_assignment_node_t *node = YP_ALLOC_NODE(parser, yp_operator_and_assignment_node_t);
-
-    *node = (yp_operator_and_assignment_node_t) {
-        {
-            .type = YP_NODE_OPERATOR_AND_ASSIGNMENT_NODE,
-            .location = {
-                .start = target->location.start,
-                .end = value->location.end
-            }
-        },
-        .target = target,
-        .value = value,
-        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
-    };
-
-    return node;
-}
-
-// Allocate a new OperatorAssignmentNode node.
-static yp_operator_assignment_node_t *
-yp_operator_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
-    yp_operator_assignment_node_t *node = YP_ALLOC_NODE(parser, yp_operator_assignment_node_t);
-
-    *node = (yp_operator_assignment_node_t) {
-        {
-            .type = YP_NODE_OPERATOR_ASSIGNMENT_NODE,
-            .location = {
-                .start = target->location.start,
-                .end = value->location.end
-            }
-        },
-        .target = target,
-        .operator = *operator,
-        .value = value
-    };
-
-    return node;
-}
-
-// Allocate and initialize a new OperatorOrAssignmentNode node.
-static yp_operator_or_assignment_node_t *
-yp_operator_or_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
-    assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
-    yp_operator_or_assignment_node_t *node = YP_ALLOC_NODE(parser, yp_operator_or_assignment_node_t);
-
-    *node = (yp_operator_or_assignment_node_t) {
-        {
-            .type = YP_NODE_OPERATOR_OR_ASSIGNMENT_NODE,
-            .location = {
-                .start = target->location.start,
-                .end = value->location.end
-            }
-        },
-        .target = target,
-        .value = value,
-        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
     };
 
     return node;
@@ -11659,30 +12069,98 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
         }
         case YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL: {
             switch (node->type) {
-                case YP_NODE_CALL_NODE: {
-                    // If we have no arguments to the call node and we need this to be a
-                    // target then this is either a method call or a local variable write.
-                    // This _must_ happen before the value is parsed because it could be
-                    // referenced in the value.
-                    yp_call_node_t *call_node = (yp_call_node_t *) node;
-                    if (yp_call_node_vcall_p(call_node)) {
-                        yp_parser_local_add_location(parser, call_node->message_loc.start, call_node->message_loc.end);
-                    }
-                }
+                case YP_NODE_BACK_REFERENCE_READ_NODE:
+                case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
+                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
-                case YP_CASE_WRITABLE: {
-                    yp_token_t operator = parser->current;
+                case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    yp_token_t target_operator = not_provided(parser);
-                    node = parse_target(parser, node, &target_operator, NULL);
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    yp_node_t *result = (yp_node_t *) yp_global_variable_operator_and_write_node_create(parser, node, &token, value);
 
-                    if (node->type == YP_NODE_MULTI_WRITE_NODE) {
-                        yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Cannot use `&&=' on a multi-write.");
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CALL_NODE: {
+                    yp_call_node_t *call_node = (yp_call_node_t *) node;
+
+                    // If we have a vcall (a method with no arguments and no
+                    // receiver that could have been a local variable) then we
+                    // will transform it into a local variable write.
+                    if (yp_call_node_vcall_p(call_node)) {
+                        yp_location_t message_loc = call_node->message_loc;
+                        yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
+
+                        if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
+                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                        }
+
+                        parser_lex(parser);
+
+                        yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                        yp_constant_id_t constant_id = yp_parser_constant_id_location(parser, message_loc.start, message_loc.end);
+                        yp_node_t *result = (yp_node_t *) yp_local_variable_operator_and_write_node_create(parser, node, &token, value, constant_id);
+
+                        yp_node_destroy(parser, node);
+                        return result;
                     }
 
+                    parser_lex(parser);
+
+                    yp_token_t operator = not_provided(parser);
+                    node = parse_target(parser, node, &operator, NULL);
+
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
-                    return (yp_node_t *) yp_operator_and_assignment_node_create(parser, node, &token, value);
+                    return (yp_node_t *) yp_call_operator_and_write_node_create(parser, call_node, &token, value);
+                }
+                case YP_NODE_CLASS_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    yp_node_t *result = (yp_node_t *) yp_class_variable_operator_and_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CONSTANT_PATH_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    return (yp_node_t *) yp_constant_path_operator_and_write_node_create(parser, (yp_constant_path_node_t *) node, &token, value);
+                }
+                case YP_NODE_CONSTANT_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    yp_node_t *result = (yp_node_t *) yp_constant_operator_and_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_INSTANCE_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    yp_node_t *result = (yp_node_t *) yp_instance_variable_operator_and_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_LOCAL_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                    yp_constant_id_t constant_id = ((yp_local_variable_read_node_t *) node)->constant_id;
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_operator_and_write_node_create(parser, node, &token, value, constant_id);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_MULTI_WRITE_NODE: {
+                    parser_lex(parser);
+                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Cannot use `&&=' on a multi-write.");
+                    return node;
                 }
                 default:
                     parser_lex(parser);
@@ -11690,36 +12168,104 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an &&= sign, but we don't know what it's for.
                     // We need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected `&&='.");
+                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected `&&='.");
                     return node;
             }
         }
         case YP_TOKEN_PIPE_PIPE_EQUAL: {
             switch (node->type) {
-                case YP_NODE_CALL_NODE: {
-                    // If we have no arguments to the call node and we need this to be a
-                    // target then this is either a method call or a local variable write.
-                    // This _must_ happen before the value is parsed because it could be
-                    // referenced in the value.
-                    yp_call_node_t *call_node = (yp_call_node_t *) node;
-                    if (yp_call_node_vcall_p(call_node)) {
-                        yp_parser_local_add_location(parser, call_node->message_loc.start, call_node->message_loc.end);
-                    }
-                }
+                case YP_NODE_BACK_REFERENCE_READ_NODE:
+                case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
+                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
-                case YP_CASE_WRITABLE: {
-                    yp_token_t operator = parser->current;
+                case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
 
-                    yp_token_t target_operator = not_provided(parser);
-                    node = parse_target(parser, node, &target_operator, NULL);
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    yp_node_t *result = (yp_node_t *) yp_global_variable_operator_or_write_node_create(parser, node, &token, value);
 
-                    if (node->type == YP_NODE_MULTI_WRITE_NODE) {
-                        yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Cannot use `||=' on a multi-write.");
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CALL_NODE: {
+                    yp_call_node_t *call_node = (yp_call_node_t *) node;
+
+                    // If we have a vcall (a method with no arguments and no
+                    // receiver that could have been a local variable) then we
+                    // will transform it into a local variable write.
+                    if (yp_call_node_vcall_p(call_node)) {
+                        yp_location_t message_loc = call_node->message_loc;
+                        yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
+
+                        if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
+                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                        }
+
+                        parser_lex(parser);
+
+                        yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                        yp_constant_id_t constant_id = yp_parser_constant_id_location(parser, message_loc.start, message_loc.end);
+                        yp_node_t *result = (yp_node_t *) yp_local_variable_operator_or_write_node_create(parser, node, &token, value, constant_id);
+
+                        yp_node_destroy(parser, node);
+                        return result;
                     }
 
+                    parser_lex(parser);
+
+                    yp_token_t operator = not_provided(parser);
+                    node = parse_target(parser, node, &operator, NULL);
+
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
-                    return (yp_node_t *) yp_operator_or_assignment_node_create(parser, node, &token, value);
+                    return (yp_node_t *) yp_call_operator_or_write_node_create(parser, call_node, &token, value);
+                }
+                case YP_NODE_CLASS_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    yp_node_t *result = (yp_node_t *) yp_class_variable_operator_or_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CONSTANT_PATH_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    return (yp_node_t *) yp_constant_path_operator_or_write_node_create(parser, (yp_constant_path_node_t *) node, &token, value);
+                }
+                case YP_NODE_CONSTANT_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    yp_node_t *result = (yp_node_t *) yp_constant_operator_or_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_INSTANCE_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    yp_node_t *result = (yp_node_t *) yp_instance_variable_operator_or_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_LOCAL_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
+                    yp_constant_id_t constant_id = ((yp_local_variable_read_node_t *) node)->constant_id;
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_operator_or_write_node_create(parser, node, &token, value, constant_id);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_MULTI_WRITE_NODE: {
+                    parser_lex(parser);
+                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Cannot use `||=' on a multi-write.");
+                    return node;
                 }
                 default:
                     parser_lex(parser);
@@ -11727,7 +12273,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an ||= sign, but we don't know what it's for.
                     // We need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected `||='.");
+                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected `||='.");
                     return node;
             }
         }
@@ -11743,24 +12289,97 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
         case YP_TOKEN_STAR_EQUAL:
         case YP_TOKEN_STAR_STAR_EQUAL: {
             switch (node->type) {
-                case YP_NODE_CALL_NODE: {
-                    // If we have no arguments to the call node and we need this to be a
-                    // target then this is either a method call or a local variable write.
-                    // This _must_ happen before the value is parsed because it could be
-                    // referenced in the value.
-                    yp_call_node_t *call_node = (yp_call_node_t *) node;
-                    if (yp_call_node_vcall_p(call_node)) {
-                        yp_parser_local_add_location(parser, call_node->message_loc.start, call_node->message_loc.end);
-                    }
-                }
+                case YP_NODE_BACK_REFERENCE_READ_NODE:
+                case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
+                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
-                case YP_CASE_WRITABLE: {
+                case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator");
+                    yp_node_t *result = (yp_node_t *) yp_global_variable_operator_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CALL_NODE: {
+                    yp_call_node_t *call_node = (yp_call_node_t *) node;
+
+                    // If we have a vcall (a method with no arguments and no
+                    // receiver that could have been a local variable) then we
+                    // will transform it into a local variable write.
+                    if (yp_call_node_vcall_p(call_node)) {
+                        yp_location_t message_loc = call_node->message_loc;
+                        yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
+
+                        if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
+                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                        }
+
+                        parser_lex(parser);
+
+                        yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
+                        yp_constant_id_t constant_id = yp_parser_constant_id_location(parser, message_loc.start, message_loc.end);
+                        yp_node_t *result = (yp_node_t *) yp_local_variable_operator_write_node_create(parser, node, &token, value, constant_id);
+
+                        yp_node_destroy(parser, node);
+                        return result;
+                    }
+                
                     yp_token_t operator = not_provided(parser);
                     node = parse_target(parser, node, &operator, NULL);
 
                     parser_lex(parser);
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
-                    return (yp_node_t *) yp_operator_assignment_node_create(parser, node, &token, value);
+                    return (yp_node_t *) yp_call_operator_write_node_create(parser, call_node, &token, value);
+                }
+                case YP_NODE_CLASS_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
+                    yp_node_t *result = (yp_node_t *) yp_class_variable_operator_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_CONSTANT_PATH_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
+                    return (yp_node_t *) yp_constant_path_operator_write_node_create(parser, (yp_constant_path_node_t *) node, &token, value);
+                }
+                case YP_NODE_CONSTANT_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
+                    yp_node_t *result = (yp_node_t *) yp_constant_operator_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_INSTANCE_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
+                    yp_node_t *result = (yp_node_t *) yp_instance_variable_operator_write_node_create(parser, node, &token, value);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_LOCAL_VARIABLE_READ_NODE: {
+                    parser_lex(parser);
+
+                    yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
+                    yp_constant_id_t constant_id = ((yp_local_variable_read_node_t *) node)->constant_id;
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_operator_write_node_create(parser, node, &token, value, constant_id);
+
+                    yp_node_destroy(parser, node);
+                    return result;
+                }
+                case YP_NODE_MULTI_WRITE_NODE: {
+                    parser_lex(parser);
+                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected operator.");
+                    return node;
                 }
                 default:
                     parser_lex(parser);

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -53,10 +53,6 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
             }
             <%- when StringParam -%>
             argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
-            <%- when TokenParam -%>
-            argv[<%= index %>] = yp_token_new(parser, &cast-><%= param.name %>, encoding);
-            <%- when OptionalTokenParam -%>
-            argv[<%= index %>] = cast-><%= param.name %>.type == YP_TOKEN_NOT_PROVIDED ? Qnil : yp_token_new(parser, &cast-><%= param.name %>, encoding);
             <%- when LocationListParam -%>
             argv[<%= index %>] = rb_ary_new();
             for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -72,7 +72,6 @@ typedef struct yp_<%= node.human %> {
     <%= case param
     in NodeParam | OptionalNodeParam then "struct #{param.c_type} *#{param.name}"
     in NodeListParam then "struct yp_node_list #{param.name}"
-    in TokenParam | OptionalTokenParam then "yp_token_t #{param.name}"
     in LocationListParam then "yp_location_list_t #{param.name}"
     in ConstantParam then "yp_constant_id_t #{param.name}"
     in ConstantListParam then "yp_constant_id_list_t #{param.name}"

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -78,15 +78,6 @@ public class Loader {
         return string;
     }
 
-    private Nodes.Token loadOptionalToken() {
-        if (buffer.get(buffer.position()) != 0) {
-            return loadToken();
-        } else {
-            buffer.position(buffer.position() + 1); // continue after the 0 byte
-            return null;
-        }
-    }
-
     private Nodes.Node loadOptionalNode() {
         if (buffer.get(buffer.position()) != 0) {
             return loadNode();
@@ -125,12 +116,6 @@ public class Loader {
             nodes[i] = loadNode();
         }
         return nodes;
-    }
-
-    private Nodes.Token loadToken() {
-        int type = buffer.get() & 0xFF;
-        final Nodes.TokenType tokenType = Nodes.TOKEN_TYPES[type];
-        return new Nodes.Token(tokenType, loadVarInt(), loadVarInt());
     }
 
     private Nodes.Location loadLocation() {
@@ -179,11 +164,9 @@ public class Loader {
               when OptionalNodeParam then "#{param.java_cast}loadOptionalNode()"
               when StringParam then "loadString()"
               when NodeListParam then "loadNodes()"
-              when TokenParam then "loadToken()"
               when LocationListParam then "loadLocations()"
               when ConstantParam then "loadConstant()"
               when ConstantListParam then "loadConstants()"
-              when OptionalTokenParam then "loadOptionalToken()"
               when LocationParam then "loadLocation()"
               when OptionalLocationParam then "loadOptionalLocation()"
               when UInt32Param then "loadVarInt()"

--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -10,15 +10,6 @@ import java.util.Arrays;
 // @formatter:off
 public abstract class Nodes {
 
-    public enum TokenType {
-        OPTIONAL_TOKEN,
-        <%- tokens.each do |token| -%>
-        <%= token.name %>,
-        <%- end -%>
-    }
-
-    static final TokenType[] TOKEN_TYPES = TokenType.values();
-
 <%- flags.each do |group| -%>
     public static final class <%= group.name %> implements Comparable<<%= group.name %>> {
 
@@ -66,25 +57,6 @@ public abstract class Nodes {
     }
 
 <%- end -%>
-    public static final class Token {
-        public final TokenType type;
-        public final int startOffset;
-        public final int length;
-
-        public Token(TokenType type, int startOffset, int length) {
-            this.type = type;
-            this.startOffset = startOffset;
-            this.length = length;
-        }
-
-        public int length() {
-            return length;
-        }
-
-        public int endOffset() {
-            return startOffset + length;
-        }
-    }
 
     public static final class Location {
         public final int startOffset;

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -70,12 +70,5 @@ module YARP
       <%= node.name %>.new(<%= (node.params.map(&:name) + ["0", "0"]).join(", ") %>)
     end
     <%- end -%>
-    <%- tokens.each do |token| -%>
-
-    # Create a new <%= token.name %> token
-    def <%= token.name %>(value, location = Location.null)
-      Token.new(:<%= token.name %>, value, location.start_offset, location.length)
-    end
-    <%- end -%>
   end
 end

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -54,30 +54,10 @@ module YARP
         io.read(4).unpack1("L")
       end
 
-      def load_token
-        type =
-          case io.getbyte
-          <%- tokens.each_with_index do |token, index| -%>
-          when <%= index + 1 %> then :<%= token.name.inspect %>
-          <%- end -%>
-          end
-
-        start_offset, length = load_varint, load_varint
-        range = source.byteslice(start_offset, length)
-        Token.new(type, range, start_offset, length)
-      end
-
       def load_optional_node
         if io.getbyte != 0
           io.pos -= 1
           load_node
-        end
-      end
-
-      def load_optional_token
-        if io.getbyte != 0
-          io.pos -= 1
-          load_token
         end
       end
 
@@ -126,11 +106,9 @@ module YARP
             when OptionalNodeParam then "load_optional_node"
             when StringParam then "load_string"
             when NodeListParam then "Array.new(load_varint) { load_node }"
-            when TokenParam then "load_token"
             when LocationListParam then "Array.new(load_varint) { load_location }"
             when ConstantParam then "load_constant"
             when ConstantListParam then "Array.new(load_varint) { load_constant }"
-            when OptionalTokenParam then "load_optional_token"
             when LocationParam then "load_location"
             when OptionalLocationParam then "load_optional_location"
             when UInt32Param then "load_varint"

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -81,7 +81,7 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
         case <%= node.type %>:
             <%- node.params.each do |param| -%>
             <%- case param -%>
-            <%- when TokenParam, OptionalTokenParam, LocationParam, OptionalLocationParam, UInt32Param, ConstantParam -%>
+            <%- when LocationParam, OptionalLocationParam, UInt32Param, ConstantParam -%>
             <%- when NodeParam -%>
             yp_node_destroy(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             <%- when OptionalNodeParam -%>
@@ -121,7 +121,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
             memsize->memsize += sizeof(yp_<%= node.human %>_t);
             <%- node.params.each do |param| -%>
             <%- case param -%>
-            <%- when TokenParam, OptionalTokenParam, ConstantParam, UInt32Param, LocationParam, OptionalLocationParam -%>
+            <%- when ConstantParam, UInt32Param, LocationParam, OptionalLocationParam -%>
             <%- when NodeParam -%>
             yp_node_memsize_node((yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, memsize);
             <%- when OptionalNodeParam -%>

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -37,14 +37,6 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);
                 prettyprint_node(buffer, parser, (yp_node_t *) ((yp_<%= node.human %>_t *) node)-><%= param.name %>.nodes[index]);
             }
-            <%- when TokenParam -%>
-            prettyprint_token(buffer, &((yp_<%= node.human %>_t *)node)-><%= param.name %>);
-            <%- when OptionalTokenParam -%>
-            if (((yp_<%= node.human %>_t *)node)-><%= param.name %>.type == YP_TOKEN_NOT_PROVIDED) {
-                yp_buffer_append_str(buffer, "nil", 3);
-            } else {
-                prettyprint_token(buffer, &((yp_<%= node.human %>_t *)node)-><%= param.name %>);
-            }
             <%- when LocationListParam -%>
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= param.name %>.size; index++) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -5,13 +5,6 @@
 #include "yarp/util/yp_buffer.h"
 
 static void
-prettyprint_token(yp_buffer_t *buffer, yp_token_t *token) {
-    yp_buffer_append_str(buffer, "\"", 1);
-    yp_buffer_append_str(buffer, token->start, (size_t) (token->end - token->start));
-    yp_buffer_append_str(buffer, "\"", 1);
-}
-
-static void
 prettyprint_location(yp_buffer_t *buffer, yp_parser_t *parser, yp_location_t *location) {
     char printed[] = "[0000-0000]";
     sprintf(printed, "[%04ld-%04ld]", location->start - parser->start, location->end - parser->start);

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -17,17 +17,6 @@ yp_ulong_to_u32(unsigned long value) {
 }
 
 static void
-serialize_token(yp_parser_t *parser, yp_token_t *token, yp_buffer_t *buffer) {
-    assert(token->start);
-    assert(token->end);
-    assert(token->start <= token->end);
-
-    yp_buffer_append_u8(buffer, token->type);
-    yp_buffer_append_u32(buffer, yp_long_to_u32(token->start - parser->start));
-    yp_buffer_append_u32(buffer, yp_long_to_u32(token->end - token->start));
-}
-
-static void
 serialize_location(yp_parser_t *parser, yp_location_t *location, yp_buffer_t *buffer) {
     assert(location->start);
     assert(location->end);

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -63,14 +63,6 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
             for (uint32_t index = 0; index < <%= param.name %>_size; index++) {
                 yp_serialize_node(parser, (yp_node_t *) ((yp_<%= node.human %>_t *)node)-><%= param.name %>.nodes[index], buffer);
             }
-            <%- when TokenParam -%>
-            serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
-            <%- when OptionalTokenParam -%>
-            if (((yp_<%= node.human %>_t *)node)-><%= param.name %>.type == YP_TOKEN_NOT_PROVIDED) {
-                yp_buffer_append_u8(buffer, 0);
-            } else {
-                serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
-            }
             <%- when LocationListParam -%>
             uint32_t <%= param.name %>_size = yp_ulong_to_u32(((yp_<%= node.human %>_t *)node)-><%= param.name %>.size);
             yp_buffer_append_u32(buffer, <%= param.name %>_size);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -57,19 +57,6 @@ class NodeListParam < Param
   def java_type = "Node[]"
 end
 
-# This represents a parameter to a node that is a token. We pass them as
-# references and store them by copying.
-class TokenParam < Param
-  def rbs_class = "Token"
-  def java_type = "Token"
-end
-
-# This represents a parameter to a node that is a token that is optional.
-class OptionalTokenParam < Param
-  def rbs_class = "Token?"
-  def java_type = "Token"
-end
-
 # This represents a parameter to a node that is a list of locations.
 class LocationListParam < Param
   def rbs_class = "Array[Location]"
@@ -119,8 +106,6 @@ PARAM_TYPES = {
   "node?" => OptionalNodeParam,
   "node[]" => NodeListParam,
   "string" => StringParam,
-  "token" => TokenParam,
-  "token?" => OptionalTokenParam,
   "location[]" => LocationListParam,
   "constant" => ConstantParam,
   "constant[]" => ConstantListParam,

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -162,11 +162,38 @@ module YARP
       assert_location(CallNode, "foo bar('baz')")
     end
 
+    def test_CallOperatorAndWriteNode
+      assert_location(CallOperatorAndWriteNode, "foo.foo &&= bar")
+      assert_location(CallOperatorAndWriteNode, "foo[foo] &&= bar")
+    end
+
+    def test_CallOperatorWriteNode
+      assert_location(CallOperatorWriteNode, "foo.foo += bar")
+      assert_location(CallOperatorWriteNode, "foo[foo] += bar")
+    end
+
+    def test_CallOperatorOrWriteNode
+      assert_location(CallOperatorOrWriteNode, "foo.foo ||= bar")
+      assert_location(CallOperatorOrWriteNode, "foo[foo] ||= bar")
+    end
+
     def test_CaseNode
       assert_location(CaseNode, "case foo; when bar; end")
       assert_location(CaseNode, "case foo; when bar; else; end")
       assert_location(CaseNode, "case foo; when bar; when baz; end")
       assert_location(CaseNode, "case foo; when bar; when baz; else; end")
+    end
+
+    def test_ClassVariableOperatorAndWriteNode
+      assert_location(ClassVariableOperatorAndWriteNode, "@@foo &&= bar")
+    end
+
+    def test_ClassVariableOperatorWriteNode
+      assert_location(ClassVariableOperatorWriteNode, "@@foo += bar")
+    end
+
+    def test_ClassVariableOperatorOrWriteNode
+      assert_location(ClassVariableOperatorOrWriteNode, "@@foo ||= bar")
     end
 
     def test_ClassVariableReadNode
@@ -181,6 +208,30 @@ module YARP
       assert_location(ConstantPathNode, "Foo::Bar")
       assert_location(ConstantPathNode, "::Foo")
       assert_location(ConstantPathNode, "::Foo::Bar")
+    end
+
+    def test_ConstantPathOperatorAndWriteNode
+      assert_location(ConstantPathOperatorAndWriteNode, "Parent::Child &&= bar")
+    end
+
+    def test_ConstantPathOperatorWriteNode
+      assert_location(ConstantPathOperatorWriteNode, "Parent::Child += bar")
+    end
+
+    def test_ConstantPathOperatorOrWriteNode
+      assert_location(ConstantPathOperatorOrWriteNode, "Parent::Child ||= bar")
+    end
+
+    def test_ConstantOperatorAndWriteNode
+      assert_location(ConstantOperatorAndWriteNode, "Foo &&= bar")
+    end
+
+    def test_ConstantOperatorWriteNode
+      assert_location(ConstantOperatorWriteNode, "Foo += bar")
+    end
+
+    def test_ConstantOperatorOrWriteNode
+      assert_location(ConstantOperatorOrWriteNode, "Foo ||= bar")
     end
 
     def test_ConstantReadNode
@@ -221,6 +272,18 @@ module YARP
       assert_location(ForwardingSuperNode, "super {}")
     end
 
+    def test_GlobalVariableOperatorAndWriteNode
+      assert_location(GlobalVariableOperatorAndWriteNode, "$foo &&= bar")
+    end
+
+    def test_GlobalVariableOperatorWriteNode
+      assert_location(GlobalVariableOperatorWriteNode, "$foo += bar")
+    end
+
+    def test_GlobalVariableOperatorOrWriteNode
+      assert_location(GlobalVariableOperatorOrWriteNode, "$foo ||= bar")
+    end
+
     def test_HashNode
       assert_location(HashNode, "{ foo: 2 }")
       assert_location(HashNode, "{ \nfoo: 2, \nbar: 3 \n}")
@@ -233,6 +296,18 @@ module YARP
     def test_ImaginaryNode
       assert_location(ImaginaryNode, "1i")
       assert_location(ImaginaryNode, "1ri")
+    end
+
+    def test_InstanceVariableOperatorAndWriteNode
+      assert_location(InstanceVariableOperatorAndWriteNode, "@foo &&= bar")
+    end
+
+    def test_InstanceVariableOperatorWriteNode
+      assert_location(InstanceVariableOperatorWriteNode, "@foo += bar")
+    end
+
+    def test_InstanceVariableOperatorOrWriteNode
+      assert_location(InstanceVariableOperatorOrWriteNode, "@foo ||= bar")
     end
 
     def test_InstanceVariableReadNode
@@ -271,6 +346,21 @@ module YARP
       assert_location(InterpolatedXStringNode, '`foo #{bar} baz`')
     end
 
+    def test_LocalVariableOperatorAndWriteNode
+      assert_location(LocalVariableOperatorAndWriteNode, "foo &&= bar")
+      assert_location(LocalVariableOperatorAndWriteNode, "foo = 1; foo &&= bar", 9...20)
+    end
+
+    def test_LocalVariableOperatorWriteNode
+      assert_location(LocalVariableOperatorWriteNode, "foo += bar")
+      assert_location(LocalVariableOperatorWriteNode, "foo = 1; foo += bar", 9...19)
+    end
+
+    def test_LocalVariableOperatorOrWriteNode
+      assert_location(LocalVariableOperatorOrWriteNode, "foo ||= bar")
+      assert_location(LocalVariableOperatorOrWriteNode, "foo = 1; foo ||= bar", 9...20)
+    end
+
     def test_KeywordHashNode
       assert_location(KeywordHashNode, "foo(a, b: 1)", 7...11) { |node| node.arguments.arguments[1] }
     end
@@ -288,36 +378,6 @@ module YARP
 
     def test_NoKeywordsParameterNode
       assert_location(NoKeywordsParameterNode, "def foo(**nil); end", 8...13) { |node| node.parameters.keyword_rest }
-    end
-
-    def test_OperatorAndAssignmentNode
-      assert_location(OperatorAndAssignmentNode, "foo = 1; foo &&= bar", 9...20)
-
-      assert_location(OperatorAndAssignmentNode, "foo &&= bar")
-      assert_location(OperatorAndAssignmentNode, "foo.foo &&= bar")
-      assert_location(OperatorAndAssignmentNode, "foo[foo] &&= bar")
-
-      assert_location(OperatorAndAssignmentNode, "@foo &&= bar")
-      assert_location(OperatorAndAssignmentNode, "@@foo &&= bar")
-      assert_location(OperatorAndAssignmentNode, "$foo &&= bar")
-
-      assert_location(OperatorAndAssignmentNode, "Foo &&= bar")
-      assert_location(OperatorAndAssignmentNode, "Foo::Foo &&= bar")
-    end
-
-    def test_OperatorOrAssignmentNode
-      assert_location(OperatorOrAssignmentNode, "foo = 1; foo ||= bar", 9...20)
-
-      assert_location(OperatorOrAssignmentNode, "foo ||= bar")
-      assert_location(OperatorOrAssignmentNode, "foo.foo ||= bar")
-      assert_location(OperatorOrAssignmentNode, "foo[foo] ||= bar")
-
-      assert_location(OperatorOrAssignmentNode, "@foo ||= bar")
-      assert_location(OperatorOrAssignmentNode, "@@foo ||= bar")
-      assert_location(OperatorOrAssignmentNode, "$foo ||= bar")
-
-      assert_location(OperatorOrAssignmentNode, "Foo ||= bar")
-      assert_location(OperatorOrAssignmentNode, "Foo::Foo ||= bar")
     end
 
     def test_OrNode

--- a/test/snapshots/blocks.txt
+++ b/test/snapshots/blocks.txt
@@ -88,10 +88,12 @@ ProgramNode(0...402)(
            (61...62)
          ),
          StatementsNode(63...72)(
-           [OperatorAssignmentNode(63...72)(
-              LocalVariableWriteNode(63...67)(:memo, 0, nil, (63...67), nil),
-              PLUS_EQUAL(68...70)("+="),
-              LocalVariableReadNode(71...72)(:x, 0)
+           [LocalVariableOperatorWriteNode(63...72)(
+              (63...67),
+              (68...70),
+              LocalVariableReadNode(71...72)(:x, 0),
+              :memo,
+              :+
             )]
          ),
          (51...52),

--- a/test/snapshots/boolean_operators.txt
+++ b/test/snapshots/boolean_operators.txt
@@ -1,20 +1,24 @@
 ProgramNode(0...24)(
   [:a],
   StatementsNode(0...24)(
-    [OperatorAndAssignmentNode(0...7)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
+    [LocalVariableOperatorAndWriteNode(0...7)(
+       (0...1),
+       (2...5),
        CallNode(6...7)(nil, nil, (6...7), nil, nil, nil, nil, 0, "b"),
-       (2...5)
+       :a
      ),
-     OperatorAssignmentNode(9...15)(
-       LocalVariableWriteNode(9...10)(:a, 0, nil, (9...10), nil),
-       PLUS_EQUAL(11...13)("+="),
-       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 0, "b")
+     LocalVariableOperatorWriteNode(9...15)(
+       (9...10),
+       (11...13),
+       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 0, "b"),
+       :a,
+       :+
      ),
-     OperatorOrAssignmentNode(17...24)(
-       LocalVariableWriteNode(17...18)(:a, 0, nil, (17...18), nil),
+     LocalVariableOperatorOrWriteNode(17...24)(
+       (17...18),
+       (19...22),
        CallNode(23...24)(nil, nil, (23...24), nil, nil, nil, nil, 0, "b"),
-       (19...22)
+       :a
      )]
   )
 )

--- a/test/snapshots/defined.txt
+++ b/test/snapshots/defined.txt
@@ -8,10 +8,12 @@ ProgramNode(0...78)(
      ),
      DefinedNode(27...43)(
        (35...36),
-       OperatorAssignmentNode(36...42)(
-         LocalVariableWriteNode(36...37)(:x, 0, nil, (36...37), nil),
-         PERCENT_EQUAL(38...40)("%="),
-         IntegerNode(41...42)()
+       LocalVariableOperatorWriteNode(36...42)(
+         (36...37),
+         (38...40),
+         IntegerNode(41...42)(),
+         :x,
+         :%
        ),
        (42...43),
        (27...35)

--- a/test/snapshots/seattlerb/bug_op_asgn_rescue.txt
+++ b/test/snapshots/seattlerb/bug_op_asgn_rescue.txt
@@ -1,14 +1,15 @@
 ProgramNode(0...18)(
   [:a],
   StatementsNode(0...18)(
-    [OperatorOrAssignmentNode(0...18)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
+    [LocalVariableOperatorOrWriteNode(0...18)(
+       (0...1),
+       (2...5),
        RescueModifierNode(6...18)(
          CallNode(6...7)(nil, nil, (6...7), nil, nil, nil, nil, 0, "b"),
          (8...14),
          NilNode(15...18)()
        ),
-       (2...5)
+       :a
      )]
   )
 )

--- a/test/snapshots/seattlerb/const_2_op_asgn_or2.txt
+++ b/test/snapshots/seattlerb/const_2_op_asgn_or2.txt
@@ -1,18 +1,14 @@
 ProgramNode(0...12)(
   [],
   StatementsNode(0...12)(
-    [OperatorOrAssignmentNode(0...12)(
-       ConstantPathWriteNode(0...6)(
-         ConstantPathNode(0...6)(
-           ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
-           ConstantReadNode(5...6)(),
-           (3...5)
-         ),
-         nil,
-         nil
+    [ConstantPathOperatorOrWriteNode(0...12)(
+       ConstantPathNode(0...6)(
+         ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
+         ConstantReadNode(5...6)(),
+         (3...5)
        ),
-       IntegerNode(11...12)(),
-       (7...10)
+       (7...10),
+       IntegerNode(11...12)()
      )]
   )
 )

--- a/test/snapshots/seattlerb/const_3_op_asgn_or.txt
+++ b/test/snapshots/seattlerb/const_3_op_asgn_or.txt
@@ -1,14 +1,10 @@
 ProgramNode(0...9)(
   [],
   StatementsNode(0...9)(
-    [OperatorOrAssignmentNode(0...9)(
-       ConstantPathWriteNode(0...3)(
-         ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
-         nil,
-         nil
-       ),
-       IntegerNode(8...9)(),
-       (4...7)
+    [ConstantPathOperatorOrWriteNode(0...9)(
+       ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
+       (4...7),
+       IntegerNode(8...9)()
      )]
   )
 )

--- a/test/snapshots/seattlerb/const_op_asgn_and1.txt
+++ b/test/snapshots/seattlerb/const_op_asgn_and1.txt
@@ -1,14 +1,11 @@
 ProgramNode(0...8)(
   [],
   StatementsNode(0...8)(
-    [OperatorAssignmentNode(0...8)(
-       ConstantPathWriteNode(0...3)(
-         ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
-         nil,
-         nil
-       ),
-       AMPERSAND_EQUAL(4...6)("&="),
-       IntegerNode(7...8)()
+    [ConstantPathOperatorWriteNode(0...8)(
+       ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
+       (4...6),
+       IntegerNode(7...8)(),
+       :&
      )]
   )
 )

--- a/test/snapshots/seattlerb/const_op_asgn_and2.txt
+++ b/test/snapshots/seattlerb/const_op_asgn_and2.txt
@@ -1,14 +1,10 @@
 ProgramNode(0...9)(
   [],
   StatementsNode(0...9)(
-    [OperatorAndAssignmentNode(0...9)(
-       ConstantPathWriteNode(0...3)(
-         ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
-         nil,
-         nil
-       ),
-       IntegerNode(8...9)(),
-       (4...7)
+    [ConstantPathOperatorAndWriteNode(0...9)(
+       ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
+       (4...7),
+       IntegerNode(8...9)()
      )]
   )
 )

--- a/test/snapshots/seattlerb/const_op_asgn_or.txt
+++ b/test/snapshots/seattlerb/const_op_asgn_or.txt
@@ -1,18 +1,14 @@
 ProgramNode(0...10)(
   [],
   StatementsNode(0...10)(
-    [OperatorOrAssignmentNode(0...10)(
-       ConstantPathWriteNode(0...4)(
-         ConstantPathNode(0...4)(
-           ConstantReadNode(0...1)(),
-           ConstantReadNode(3...4)(),
-           (1...3)
-         ),
-         nil,
-         nil
+    [ConstantPathOperatorOrWriteNode(0...10)(
+       ConstantPathNode(0...4)(
+         ConstantReadNode(0...1)(),
+         ConstantReadNode(3...4)(),
+         (1...3)
        ),
-       IntegerNode(9...10)(),
-       (5...8)
+       (5...8),
+       IntegerNode(9...10)()
      )]
   )
 )

--- a/test/snapshots/seattlerb/index_0_opasgn.txt
+++ b/test/snapshots/seattlerb/index_0_opasgn.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...8)(
   [],
   StatementsNode(0...8)(
-    [OperatorAssignmentNode(0...8)(
+    [CallOperatorWriteNode(0...8)(
        CallNode(0...3)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          nil,
@@ -13,8 +13,9 @@ ProgramNode(0...8)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(4...6)("+="),
-       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 0, "b")
+       (4...6),
+       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 0, "b"),
+       :+
      )]
   )
 )

--- a/test/snapshots/seattlerb/messy_op_asgn_lineno.txt
+++ b/test/snapshots/seattlerb/messy_op_asgn_lineno.txt
@@ -9,17 +9,13 @@ ProgramNode(0...15)(
        ArgumentsNode(2...15)(
          [ParenthesesNode(2...15)(
             StatementsNode(3...14)(
-              [OperatorAssignmentNode(3...14)(
-                 ConstantPathWriteNode(3...7)(
-                   ConstantPathNode(3...7)(
-                     ConstantReadNode(3...4)(),
-                     ConstantReadNode(6...7)(),
-                     (4...6)
-                   ),
-                   nil,
-                   nil
+              [ConstantPathOperatorWriteNode(3...14)(
+                 ConstantPathNode(3...7)(
+                   ConstantReadNode(3...4)(),
+                   ConstantReadNode(6...7)(),
+                   (4...6)
                  ),
-                 STAR_EQUAL(8...10)("*="),
+                 (8...10),
                  CallNode(11...14)(
                    nil,
                    nil,
@@ -42,7 +38,8 @@ ProgramNode(0...15)(
                    nil,
                    0,
                    "d"
-                 )
+                 ),
+                 :*
                )]
             ),
             (2...3),

--- a/test/snapshots/seattlerb/op_asgn_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_command_call.txt
@@ -1,8 +1,9 @@
 ProgramNode(0...11)(
   [:a],
   StatementsNode(0...11)(
-    [OperatorOrAssignmentNode(0...11)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
+    [LocalVariableOperatorOrWriteNode(0...11)(
+       (0...1),
+       (2...5),
        CallNode(6...11)(
          CallNode(6...7)(nil, nil, (6...7), nil, nil, nil, nil, 0, "b"),
          (7...8),
@@ -14,7 +15,7 @@ ProgramNode(0...11)(
          0,
          "c"
        ),
-       (2...5)
+       :a
      )]
   )
 )

--- a/test/snapshots/seattlerb/op_asgn_dot_ident_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_dot_ident_command_call.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...11)(
   [],
   StatementsNode(0...11)(
-    [OperatorOrAssignmentNode(0...11)(
+    [CallOperatorOrWriteNode(0...11)(
        CallNode(0...3)(
          ConstantReadNode(0...1)(),
          (1...2),

--- a/test/snapshots/seattlerb/op_asgn_index_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_index_command_call.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...16)(
   [],
   StatementsNode(0...16)(
-    [OperatorOrAssignmentNode(0...16)(
+    [CallOperatorOrWriteNode(0...16)(
        CallNode(0...5)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          nil,

--- a/test/snapshots/seattlerb/op_asgn_primary_colon_const_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_primary_colon_const_command_call.txt
@@ -1,17 +1,13 @@
 ProgramNode(0...11)(
   [],
   StatementsNode(0...11)(
-    [OperatorAssignmentNode(0...11)(
-       ConstantPathWriteNode(0...4)(
-         ConstantPathNode(0...4)(
-           ConstantReadNode(0...1)(),
-           ConstantReadNode(3...4)(),
-           (1...3)
-         ),
-         nil,
-         nil
+    [ConstantPathOperatorWriteNode(0...11)(
+       ConstantPathNode(0...4)(
+         ConstantReadNode(0...1)(),
+         ConstantReadNode(3...4)(),
+         (1...3)
        ),
-       STAR_EQUAL(5...7)("*="),
+       (5...7),
        CallNode(8...11)(
          nil,
          nil,
@@ -24,7 +20,8 @@ ProgramNode(0...11)(
          nil,
          0,
          "c"
-       )
+       ),
+       :*
      )]
   )
 )

--- a/test/snapshots/seattlerb/op_asgn_primary_colon_identifier1.txt
+++ b/test/snapshots/seattlerb/op_asgn_primary_colon_identifier1.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...9)(
   [],
   StatementsNode(0...9)(
-    [OperatorAssignmentNode(0...9)(
+    [CallOperatorWriteNode(0...9)(
        CallNode(0...4)(
          ConstantReadNode(0...1)(),
          (1...3),
@@ -13,8 +13,9 @@ ProgramNode(0...9)(
          0,
          "b="
        ),
-       PLUS_EQUAL(5...7)("+="),
-       IntegerNode(8...9)()
+       (5...7),
+       IntegerNode(8...9)(),
+       :+
      )]
   )
 )

--- a/test/snapshots/seattlerb/op_asgn_primary_colon_identifier_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_primary_colon_identifier_command_call.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...11)(
   [],
   StatementsNode(0...11)(
-    [OperatorAssignmentNode(0...11)(
+    [CallOperatorWriteNode(0...11)(
        CallNode(0...4)(
          ConstantReadNode(0...1)(),
          (1...3),
@@ -13,7 +13,7 @@ ProgramNode(0...11)(
          0,
          "b="
        ),
-       STAR_EQUAL(5...7)("*="),
+       (5...7),
        CallNode(8...11)(
          nil,
          nil,
@@ -26,7 +26,8 @@ ProgramNode(0...11)(
          nil,
          0,
          "c"
-       )
+       ),
+       :*
      )]
   )
 )

--- a/test/snapshots/seattlerb/op_asgn_val_dot_ident_command_call.txt
+++ b/test/snapshots/seattlerb/op_asgn_val_dot_ident_command_call.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...11)(
   [],
   StatementsNode(0...11)(
-    [OperatorOrAssignmentNode(0...11)(
+    [CallOperatorOrWriteNode(0...11)(
        CallNode(0...3)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          (1...2),

--- a/test/snapshots/seattlerb/parse_line_defn_complex.txt
+++ b/test/snapshots/seattlerb/parse_line_defn_complex.txt
@@ -25,10 +25,12 @@ ProgramNode(0...40)(
             0,
             "p"
           ),
-          OperatorAssignmentNode(18...24)(
-            LocalVariableWriteNode(18...19)(:y, 0, nil, (18...19), nil),
-            STAR_EQUAL(20...22)("*="),
-            IntegerNode(23...24)()
+          LocalVariableOperatorWriteNode(18...24)(
+            (18...19),
+            (20...22),
+            IntegerNode(23...24)(),
+            :y,
+            :*
           ),
           ReturnNode(27...35)(
             (27...33),

--- a/test/snapshots/seattlerb/parse_line_op_asgn.txt
+++ b/test/snapshots/seattlerb/parse_line_op_asgn.txt
@@ -1,10 +1,12 @@
 ProgramNode(6...34)(
   [:foo],
   StatementsNode(6...34)(
-    [OperatorAssignmentNode(6...24)(
-       LocalVariableWriteNode(6...9)(:foo, 0, nil, (6...9), nil),
-       PLUS_EQUAL(10...12)("+="),
-       CallNode(21...24)(nil, nil, (21...24), nil, nil, nil, nil, 0, "bar")
+    [LocalVariableOperatorWriteNode(6...24)(
+       (6...9),
+       (10...12),
+       CallNode(21...24)(nil, nil, (21...24), nil, nil, nil, nil, 0, "bar"),
+       :foo,
+       :+
      ),
      CallNode(31...34)(nil, nil, (31...34), nil, nil, nil, nil, 0, "baz")]
   )

--- a/test/snapshots/seattlerb/safe_op_asgn.txt
+++ b/test/snapshots/seattlerb/safe_op_asgn.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...11)(
   [],
   StatementsNode(0...11)(
-    [OperatorAssignmentNode(0...11)(
+    [CallOperatorWriteNode(0...11)(
        CallNode(0...4)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          (1...3),
@@ -13,7 +13,7 @@ ProgramNode(0...11)(
          1,
          "b="
        ),
-       PLUS_EQUAL(5...7)("+="),
+       (5...7),
        CallNode(8...11)(
          nil,
          nil,
@@ -24,7 +24,8 @@ ProgramNode(0...11)(
          nil,
          0,
          "x"
-       )
+       ),
+       :+
      )]
   )
 )

--- a/test/snapshots/seattlerb/safe_op_asgn2.txt
+++ b/test/snapshots/seattlerb/safe_op_asgn2.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...10)(
   [],
   StatementsNode(0...10)(
-    [OperatorOrAssignmentNode(0...10)(
+    [CallOperatorOrWriteNode(0...10)(
        CallNode(0...4)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          (1...3),

--- a/test/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/snapshots/unparser/corpus/literal/assignment.txt
@@ -582,7 +582,7 @@ ProgramNode(0...719)(
        0,
        "[]="
      ),
-     OperatorOrAssignmentNode(536...550)(
+     CallOperatorOrWriteNode(536...550)(
        CallNode(536...542)(
          LocalVariableReadNode(536...537)(:a, 0),
          nil,
@@ -609,10 +609,10 @@ ProgramNode(0...719)(
        ),
        (543...546)
      ),
-     OperatorOrAssignmentNode(551...561)(
-       InstanceVariableWriteNode(551...553)((551...553), nil, nil),
-       StringNode(558...561)((558...560), (560...560), (560...561), ""),
-       (554...557)
+     InstanceVariableOperatorOrWriteNode(551...561)(
+       (551...553),
+       (554...557),
+       StringNode(558...561)((558...560), (560...560), (560...561), "")
      ),
      LocalVariableWriteNode(562...591)(
        :x,
@@ -665,7 +665,7 @@ ProgramNode(0...719)(
        0,
        "[]="
      ),
-     OperatorOrAssignmentNode(651...672)(
+     CallOperatorOrWriteNode(651...672)(
        CallNode(651...664)(
          LocalVariableReadNode(651...652)(:a, 0),
          nil,
@@ -702,16 +702,16 @@ ProgramNode(0...719)(
        ),
        (665...668)
      ),
-     OperatorOrAssignmentNode(687...719)(
-       InstanceVariableWriteNode(687...689)((687...689), nil, nil),
+     InstanceVariableOperatorOrWriteNode(687...719)(
+       (687...689),
+       (690...693),
        InterpolatedStringNode(694...719)(
          (694...704),
          [StringNode(705...707)(nil, (705...707), nil, "  "),
           StringInterpolatedNode(707...710)((707...709), nil, (709...710)),
           StringNode(710...711)(nil, (710...711), nil, "\n")],
          (711...719)
-       ),
-       (690...693)
+       )
      )]
   )
 )

--- a/test/snapshots/unparser/corpus/literal/opasgn.txt
+++ b/test/snapshots/unparser/corpus/literal/opasgn.txt
@@ -1,48 +1,61 @@
 ProgramNode(0...233)(
   [:a, :h],
   StatementsNode(0...233)(
-    [OperatorAssignmentNode(0...6)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
-       PLUS_EQUAL(2...4)("+="),
-       IntegerNode(5...6)()
+    [LocalVariableOperatorWriteNode(0...6)(
+       (0...1),
+       (2...4),
+       IntegerNode(5...6)(),
+       :a,
+       :+
      ),
-     OperatorAssignmentNode(7...13)(
-       LocalVariableWriteNode(7...8)(:a, 0, nil, (7...8), nil),
-       MINUS_EQUAL(9...11)("-="),
-       IntegerNode(12...13)()
+     LocalVariableOperatorWriteNode(7...13)(
+       (7...8),
+       (9...11),
+       IntegerNode(12...13)(),
+       :a,
+       :-
      ),
-     OperatorAssignmentNode(14...21)(
-       LocalVariableWriteNode(14...15)(:a, 0, nil, (14...15), nil),
-       STAR_STAR_EQUAL(16...19)("**="),
-       IntegerNode(20...21)()
+     LocalVariableOperatorWriteNode(14...21)(
+       (14...15),
+       (16...19),
+       IntegerNode(20...21)(),
+       :a,
+       :**
      ),
-     OperatorAssignmentNode(22...28)(
-       LocalVariableWriteNode(22...23)(:a, 0, nil, (22...23), nil),
-       STAR_EQUAL(24...26)("*="),
-       IntegerNode(27...28)()
+     LocalVariableOperatorWriteNode(22...28)(
+       (22...23),
+       (24...26),
+       IntegerNode(27...28)(),
+       :a,
+       :*
      ),
-     OperatorAssignmentNode(29...35)(
-       LocalVariableWriteNode(29...30)(:a, 0, nil, (29...30), nil),
-       SLASH_EQUAL(31...33)("/="),
-       IntegerNode(34...35)()
+     LocalVariableOperatorWriteNode(29...35)(
+       (29...30),
+       (31...33),
+       IntegerNode(34...35)(),
+       :a,
+       :/
      ),
-     OperatorAndAssignmentNode(36...43)(
-       LocalVariableWriteNode(36...37)(:a, 0, nil, (36...37), nil),
+     LocalVariableOperatorAndWriteNode(36...43)(
+       (36...37),
+       (38...41),
        CallNode(42...43)(nil, nil, (42...43), nil, nil, nil, nil, 0, "b"),
-       (38...41)
+       :a
      ),
-     OperatorOrAssignmentNode(44...51)(
-       LocalVariableWriteNode(44...45)(:a, 0, nil, (44...45), nil),
+     LocalVariableOperatorOrWriteNode(44...51)(
+       (44...45),
+       (46...49),
        IntegerNode(50...51)(),
-       (46...49)
+       :a
      ),
      CallNode(52...65)(
        ParenthesesNode(52...61)(
          StatementsNode(53...60)(
-           [OperatorOrAssignmentNode(53...60)(
-              LocalVariableWriteNode(53...54)(:a, 0, nil, (53...54), nil),
+           [LocalVariableOperatorOrWriteNode(53...60)(
+              (53...54),
+              (55...58),
               IntegerNode(59...60)(),
-              (55...58)
+              :a
             )]
          ),
          (52...53),
@@ -60,10 +73,11 @@ ProgramNode(0...233)(
      CallNode(66...83)(
        ParenthesesNode(66...76)(
          StatementsNode(67...75)(
-           [OperatorOrAssignmentNode(67...75)(
-              LocalVariableWriteNode(67...68)(:h, 0, nil, (67...68), nil),
+           [LocalVariableOperatorOrWriteNode(67...75)(
+              (67...68),
+              (69...72),
               HashNode(73...75)((73...74), [], (74...75)),
-              (69...72)
+              :h
             )]
          ),
          (66...67),
@@ -81,7 +95,7 @@ ProgramNode(0...233)(
        0,
        "[]="
      ),
-     OperatorAssignmentNode(84...92)(
+     CallOperatorWriteNode(84...92)(
        CallNode(84...87)(
          LocalVariableReadNode(84...85)(:a, 0),
          (85...86),
@@ -93,10 +107,11 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       PLUS_EQUAL(88...90)("+="),
-       IntegerNode(91...92)()
+       (88...90),
+       IntegerNode(91...92)(),
+       :+
      ),
-     OperatorAssignmentNode(93...101)(
+     CallOperatorWriteNode(93...101)(
        CallNode(93...96)(
          LocalVariableReadNode(93...94)(:a, 0),
          (94...95),
@@ -108,10 +123,11 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       MINUS_EQUAL(97...99)("-="),
-       IntegerNode(100...101)()
+       (97...99),
+       IntegerNode(100...101)(),
+       :-
      ),
-     OperatorAssignmentNode(102...111)(
+     CallOperatorWriteNode(102...111)(
        CallNode(102...105)(
          LocalVariableReadNode(102...103)(:a, 0),
          (103...104),
@@ -123,10 +139,11 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       STAR_STAR_EQUAL(106...109)("**="),
-       IntegerNode(110...111)()
+       (106...109),
+       IntegerNode(110...111)(),
+       :**
      ),
-     OperatorAssignmentNode(112...120)(
+     CallOperatorWriteNode(112...120)(
        CallNode(112...115)(
          LocalVariableReadNode(112...113)(:a, 0),
          (113...114),
@@ -138,10 +155,11 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       STAR_EQUAL(116...118)("*="),
-       IntegerNode(119...120)()
+       (116...118),
+       IntegerNode(119...120)(),
+       :*
      ),
-     OperatorAssignmentNode(121...129)(
+     CallOperatorWriteNode(121...129)(
        CallNode(121...124)(
          LocalVariableReadNode(121...122)(:a, 0),
          (122...123),
@@ -153,10 +171,11 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       SLASH_EQUAL(125...127)("/="),
-       IntegerNode(128...129)()
+       (125...127),
+       IntegerNode(128...129)(),
+       :/
      ),
-     OperatorAndAssignmentNode(130...139)(
+     CallOperatorAndWriteNode(130...139)(
        CallNode(130...133)(
          LocalVariableReadNode(130...131)(:a, 0),
          (131...132),
@@ -168,10 +187,10 @@ ProgramNode(0...233)(
          0,
          "b="
        ),
-       CallNode(138...139)(nil, nil, (138...139), nil, nil, nil, nil, 0, "b"),
-       (134...137)
+       (134...137),
+       CallNode(138...139)(nil, nil, (138...139), nil, nil, nil, nil, 0, "b")
      ),
-     OperatorOrAssignmentNode(140...149)(
+     CallOperatorOrWriteNode(140...149)(
        CallNode(140...143)(
          LocalVariableReadNode(140...141)(:a, 0),
          (141...142),
@@ -186,7 +205,7 @@ ProgramNode(0...233)(
        IntegerNode(148...149)(),
        (144...147)
      ),
-     OperatorAssignmentNode(150...159)(
+     CallOperatorWriteNode(150...159)(
        CallNode(150...154)(
          LocalVariableReadNode(150...151)(:a, 0),
          nil,
@@ -210,10 +229,11 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(155...157)("+="),
-       IntegerNode(158...159)()
+       (155...157),
+       IntegerNode(158...159)(),
+       :+
      ),
-     OperatorAssignmentNode(160...169)(
+     CallOperatorWriteNode(160...169)(
        CallNode(160...164)(
          LocalVariableReadNode(160...161)(:a, 0),
          nil,
@@ -237,10 +257,11 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       MINUS_EQUAL(165...167)("-="),
-       IntegerNode(168...169)()
+       (165...167),
+       IntegerNode(168...169)(),
+       :-
      ),
-     OperatorAssignmentNode(170...180)(
+     CallOperatorWriteNode(170...180)(
        CallNode(170...174)(
          LocalVariableReadNode(170...171)(:a, 0),
          nil,
@@ -264,10 +285,11 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       STAR_STAR_EQUAL(175...178)("**="),
-       IntegerNode(179...180)()
+       (175...178),
+       IntegerNode(179...180)(),
+       :**
      ),
-     OperatorAssignmentNode(181...190)(
+     CallOperatorWriteNode(181...190)(
        CallNode(181...185)(
          LocalVariableReadNode(181...182)(:a, 0),
          nil,
@@ -291,10 +313,11 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       STAR_EQUAL(186...188)("*="),
-       IntegerNode(189...190)()
+       (186...188),
+       IntegerNode(189...190)(),
+       :*
      ),
-     OperatorAssignmentNode(191...200)(
+     CallOperatorWriteNode(191...200)(
        CallNode(191...195)(
          LocalVariableReadNode(191...192)(:a, 0),
          nil,
@@ -318,10 +341,11 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       SLASH_EQUAL(196...198)("/="),
-       IntegerNode(199...200)()
+       (196...198),
+       IntegerNode(199...200)(),
+       :/
      ),
-     OperatorAndAssignmentNode(201...211)(
+     CallOperatorAndWriteNode(201...211)(
        CallNode(201...205)(
          LocalVariableReadNode(201...202)(:a, 0),
          nil,
@@ -345,10 +369,10 @@ ProgramNode(0...233)(
          0,
          "[]="
        ),
-       CallNode(210...211)(nil, nil, (210...211), nil, nil, nil, nil, 0, "b"),
-       (206...209)
+       (206...209),
+       CallNode(210...211)(nil, nil, (210...211), nil, nil, nil, nil, 0, "b")
      ),
-     OperatorOrAssignmentNode(212...222)(
+     CallOperatorOrWriteNode(212...222)(
        CallNode(212...216)(
          LocalVariableReadNode(212...213)(:a, 0),
          nil,
@@ -375,7 +399,7 @@ ProgramNode(0...233)(
        IntegerNode(221...222)(),
        (217...220)
      ),
-     OperatorAssignmentNode(223...233)(
+     CallOperatorWriteNode(223...233)(
        CallNode(223...228)(
          CallNode(223...226)(
            nil,
@@ -397,8 +421,9 @@ ProgramNode(0...233)(
          0,
          "A="
        ),
-       PLUS_EQUAL(229...231)("+="),
-       IntegerNode(232...233)()
+       (229...231),
+       IntegerNode(232...233)(),
+       :+
      )]
   )
 )

--- a/test/snapshots/unparser/corpus/literal/send.txt
+++ b/test/snapshots/unparser/corpus/literal/send.txt
@@ -6,8 +6,9 @@ ProgramNode(0...991)(
        (0...6),
        ConstantReadNode(7...8)(),
        StatementsNode(11...31)(
-         [OperatorOrAssignmentNode(11...31)(
-            LocalVariableWriteNode(11...14)(:foo, 0, nil, (11...14), nil),
+         [LocalVariableOperatorOrWriteNode(11...31)(
+            (11...14),
+            (15...18),
             ParenthesesNode(19...31)(
               StatementsNode(21...30)(
                 [MultiWriteNode(21...30)(
@@ -44,7 +45,7 @@ ProgramNode(0...991)(
               (19...20),
               (30...31)
             ),
-            (15...18)
+            :foo
           )]
        ),
        (32...35)

--- a/test/snapshots/whitequark/and_asgn.txt
+++ b/test/snapshots/whitequark/and_asgn.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...28)(
   [],
   StatementsNode(0...28)(
-    [OperatorAndAssignmentNode(0...11)(
+    [CallOperatorAndWriteNode(0...11)(
        CallNode(0...5)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          (3...4),
@@ -13,10 +13,10 @@ ProgramNode(0...28)(
          0,
          "a="
        ),
-       IntegerNode(10...11)(),
-       (6...9)
+       (6...9),
+       IntegerNode(10...11)()
      ),
-     OperatorAndAssignmentNode(13...28)(
+     CallOperatorAndWriteNode(13...28)(
        CallNode(13...22)(
          CallNode(13...16)(nil, nil, (13...16), nil, nil, nil, nil, 0, "foo"),
          nil,
@@ -30,8 +30,8 @@ ProgramNode(0...28)(
          0,
          "[]="
        ),
-       IntegerNode(27...28)(),
-       (23...26)
+       (23...26),
+       IntegerNode(27...28)()
      )]
   )
 )

--- a/test/snapshots/whitequark/const_op_asgn.txt
+++ b/test/snapshots/whitequark/const_op_asgn.txt
@@ -1,50 +1,41 @@
 ProgramNode(0...77)(
   [],
   StatementsNode(0...77)(
-    [OperatorAssignmentNode(0...8)(
-       ConstantPathWriteNode(0...3)(
-         ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
-         nil,
-         nil
-       ),
-       PLUS_EQUAL(4...6)("+="),
-       IntegerNode(7...8)()
+    [ConstantPathOperatorWriteNode(0...8)(
+       ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
+       (4...6),
+       IntegerNode(7...8)(),
+       :+
      ),
-     OperatorAssignmentNode(10...16)(
-       ConstantPathWriteNode(10...11)(ConstantReadNode(10...11)(), nil, nil),
-       PLUS_EQUAL(12...14)("+="),
-       IntegerNode(15...16)()
+     ConstantOperatorWriteNode(10...16)(
+       (10...11),
+       (12...14),
+       IntegerNode(15...16)(),
+       :+
      ),
-     OperatorAssignmentNode(18...27)(
-       ConstantPathWriteNode(18...22)(
-         ConstantPathNode(18...22)(
-           ConstantReadNode(18...19)(),
-           ConstantReadNode(21...22)(),
-           (19...21)
-         ),
-         nil,
-         nil
+     ConstantPathOperatorWriteNode(18...27)(
+       ConstantPathNode(18...22)(
+         ConstantReadNode(18...19)(),
+         ConstantReadNode(21...22)(),
+         (19...21)
        ),
-       PLUS_EQUAL(23...25)("+="),
-       IntegerNode(26...27)()
+       (23...25),
+       IntegerNode(26...27)(),
+       :+
      ),
      DefNode(29...50)(
        (33...34),
        nil,
        nil,
        StatementsNode(36...45)(
-         [OperatorOrAssignmentNode(36...45)(
-            ConstantPathWriteNode(36...39)(
-              ConstantPathNode(36...39)(
-                nil,
-                ConstantReadNode(38...39)(),
-                (36...38)
-              ),
+         [ConstantPathOperatorOrWriteNode(36...45)(
+            ConstantPathNode(36...39)(
               nil,
-              nil
+              ConstantReadNode(38...39)(),
+              (36...38)
             ),
-            IntegerNode(44...45)(),
-            (40...43)
+            (40...43),
+            IntegerNode(44...45)()
           )]
        ),
        [],
@@ -60,18 +51,14 @@ ProgramNode(0...77)(
        nil,
        nil,
        StatementsNode(59...72)(
-         [OperatorOrAssignmentNode(59...72)(
-            ConstantPathWriteNode(59...66)(
-              ConstantPathNode(59...66)(
-                SelfNode(59...63)(),
-                ConstantReadNode(65...66)(),
-                (63...65)
-              ),
-              nil,
-              nil
+         [ConstantPathOperatorOrWriteNode(59...72)(
+            ConstantPathNode(59...66)(
+              SelfNode(59...63)(),
+              ConstantReadNode(65...66)(),
+              (63...65)
             ),
-            IntegerNode(71...72)(),
-            (67...70)
+            (67...70),
+            IntegerNode(71...72)()
           )]
        ),
        [],

--- a/test/snapshots/whitequark/op_asgn.txt
+++ b/test/snapshots/whitequark/op_asgn.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...35)(
   [],
   StatementsNode(0...35)(
-    [OperatorAssignmentNode(0...10)(
+    [CallOperatorWriteNode(0...10)(
        CallNode(0...5)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          (3...4),
@@ -13,10 +13,11 @@ ProgramNode(0...35)(
          0,
          "A="
        ),
-       PLUS_EQUAL(6...8)("+="),
-       IntegerNode(9...10)()
+       (6...8),
+       IntegerNode(9...10)(),
+       :+
      ),
-     OperatorAssignmentNode(12...22)(
+     CallOperatorWriteNode(12...22)(
        CallNode(12...17)(
          CallNode(12...15)(nil, nil, (12...15), nil, nil, nil, nil, 0, "foo"),
          (15...16),
@@ -28,10 +29,11 @@ ProgramNode(0...35)(
          0,
          "a="
        ),
-       PLUS_EQUAL(18...20)("+="),
-       IntegerNode(21...22)()
+       (18...20),
+       IntegerNode(21...22)(),
+       :+
      ),
-     OperatorAssignmentNode(24...35)(
+     CallOperatorWriteNode(24...35)(
        CallNode(24...30)(
          CallNode(24...27)(nil, nil, (24...27), nil, nil, nil, nil, 0, "foo"),
          (27...29),
@@ -43,8 +45,9 @@ ProgramNode(0...35)(
          0,
          "a="
        ),
-       PLUS_EQUAL(31...33)("+="),
-       IntegerNode(34...35)()
+       (31...33),
+       IntegerNode(34...35)(),
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/op_asgn_cmd.txt
+++ b/test/snapshots/whitequark/op_asgn_cmd.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...64)(
   [],
   StatementsNode(0...64)(
-    [OperatorAssignmentNode(0...14)(
+    [CallOperatorWriteNode(0...14)(
        CallNode(0...5)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          (3...4),
@@ -13,7 +13,7 @@ ProgramNode(0...64)(
          0,
          "A="
        ),
-       PLUS_EQUAL(6...8)("+="),
+       (6...8),
        CallNode(9...14)(
          nil,
          nil,
@@ -36,9 +36,10 @@ ProgramNode(0...64)(
          nil,
          0,
          "m"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(16...30)(
+     CallOperatorWriteNode(16...30)(
        CallNode(16...21)(
          CallNode(16...19)(nil, nil, (16...19), nil, nil, nil, nil, 0, "foo"),
          (19...20),
@@ -50,7 +51,7 @@ ProgramNode(0...64)(
          0,
          "a="
        ),
-       PLUS_EQUAL(22...24)("+="),
+       (22...24),
        CallNode(25...30)(
          nil,
          nil,
@@ -73,29 +74,16 @@ ProgramNode(0...64)(
          nil,
          0,
          "m"
-       )
-     ),
-     OperatorAssignmentNode(32...47)(
-       ConstantPathWriteNode(32...38)(
-         ConstantPathNode(32...38)(
-           CallNode(32...35)(
-             nil,
-             nil,
-             (32...35),
-             nil,
-             nil,
-             nil,
-             nil,
-             0,
-             "foo"
-           ),
-           ConstantReadNode(37...38)(),
-           (35...37)
-         ),
-         nil,
-         nil
        ),
-       PLUS_EQUAL(39...41)("+="),
+       :+
+     ),
+     ConstantPathOperatorWriteNode(32...47)(
+       ConstantPathNode(32...38)(
+         CallNode(32...35)(nil, nil, (32...35), nil, nil, nil, nil, 0, "foo"),
+         ConstantReadNode(37...38)(),
+         (35...37)
+       ),
+       (39...41),
        CallNode(42...47)(
          nil,
          nil,
@@ -118,9 +106,10 @@ ProgramNode(0...64)(
          nil,
          0,
          "m"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(49...64)(
+     CallOperatorWriteNode(49...64)(
        CallNode(49...55)(
          CallNode(49...52)(nil, nil, (49...52), nil, nil, nil, nil, 0, "foo"),
          (52...54),
@@ -132,7 +121,7 @@ ProgramNode(0...64)(
          0,
          "a="
        ),
-       PLUS_EQUAL(56...58)("+="),
+       (56...58),
        CallNode(59...64)(
          nil,
          nil,
@@ -155,7 +144,8 @@ ProgramNode(0...64)(
          nil,
          0,
          "m"
-       )
+       ),
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/op_asgn_index.txt
+++ b/test/snapshots/whitequark/op_asgn_index.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...14)(
   [],
   StatementsNode(0...14)(
-    [OperatorAssignmentNode(0...14)(
+    [CallOperatorWriteNode(0...14)(
        CallNode(0...9)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          nil,
@@ -13,8 +13,9 @@ ProgramNode(0...14)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(10...12)("+="),
-       IntegerNode(13...14)()
+       (10...12),
+       IntegerNode(13...14)(),
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/op_asgn_index_cmd.txt
+++ b/test/snapshots/whitequark/op_asgn_index_cmd.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...18)(
   [],
   StatementsNode(0...18)(
-    [OperatorAssignmentNode(0...18)(
+    [CallOperatorWriteNode(0...18)(
        CallNode(0...9)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          nil,
@@ -13,7 +13,7 @@ ProgramNode(0...18)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(10...12)("+="),
+       (10...12),
        CallNode(13...18)(
          nil,
          nil,
@@ -36,7 +36,8 @@ ProgramNode(0...18)(
          nil,
          0,
          "m"
-       )
+       ),
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/or_asgn.txt
+++ b/test/snapshots/whitequark/or_asgn.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...28)(
   [],
   StatementsNode(0...28)(
-    [OperatorOrAssignmentNode(0...11)(
+    [CallOperatorOrWriteNode(0...11)(
        CallNode(0...5)(
          CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 0, "foo"),
          (3...4),
@@ -16,7 +16,7 @@ ProgramNode(0...28)(
        IntegerNode(10...11)(),
        (6...9)
      ),
-     OperatorOrAssignmentNode(13...28)(
+     CallOperatorOrWriteNode(13...28)(
        CallNode(13...22)(
          CallNode(13...16)(nil, nil, (13...16), nil, nil, nil, nil, 0, "foo"),
          nil,

--- a/test/snapshots/whitequark/rescue_mod_op_assign.txt
+++ b/test/snapshots/whitequark/rescue_mod_op_assign.txt
@@ -1,14 +1,16 @@
 ProgramNode(0...22)(
   [:foo],
   StatementsNode(0...22)(
-    [OperatorAssignmentNode(0...22)(
-       LocalVariableWriteNode(0...3)(:foo, 0, nil, (0...3), nil),
-       PLUS_EQUAL(4...6)("+="),
+    [LocalVariableOperatorWriteNode(0...22)(
+       (0...3),
+       (4...6),
        RescueModifierNode(7...22)(
          CallNode(7...11)(nil, nil, (7...11), nil, nil, nil, nil, 0, "meth"),
          (12...18),
          CallNode(19...22)(nil, nil, (19...22), nil, nil, nil, nil, 0, "bar")
-       )
+       ),
+       :foo,
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/ruby_bug_12402.txt
+++ b/test/snapshots/whitequark/ruby_bug_12402.txt
@@ -1,9 +1,9 @@
 ProgramNode(0...437)(
   [:foo],
   StatementsNode(0...437)(
-    [OperatorAssignmentNode(0...27)(
-       LocalVariableWriteNode(0...3)(:foo, 0, nil, (0...3), nil),
-       PLUS_EQUAL(4...6)("+="),
+    [LocalVariableOperatorWriteNode(0...27)(
+       (0...3),
+       (4...6),
        CallNode(7...27)(
          nil,
          nil,
@@ -30,11 +30,13 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       )
+       ),
+       :foo,
+       :+
      ),
-     OperatorAssignmentNode(29...57)(
-       LocalVariableWriteNode(29...32)(:foo, 0, nil, (29...32), nil),
-       PLUS_EQUAL(33...35)("+="),
+     LocalVariableOperatorWriteNode(29...57)(
+       (29...32),
+       (33...35),
        RescueModifierNode(36...57)(
          CallNode(36...46)(
            nil,
@@ -61,7 +63,9 @@ ProgramNode(0...437)(
          ),
          (47...53),
          NilNode(54...57)()
-       )
+       ),
+       :foo,
+       :+
      ),
      LocalVariableWriteNode(59...85)(
        :foo,
@@ -129,7 +133,7 @@ ProgramNode(0...437)(
        (87...90),
        (91...92)
      ),
-     OperatorAssignmentNode(116...145)(
+     CallOperatorWriteNode(116...145)(
        CallNode(116...121)(
          LocalVariableReadNode(116...119)(:foo, 0),
          (119...120),
@@ -141,7 +145,7 @@ ProgramNode(0...437)(
          0,
          "C="
        ),
-       PLUS_EQUAL(122...124)("+="),
+       (122...124),
        CallNode(125...145)(
          nil,
          nil,
@@ -168,9 +172,10 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(147...177)(
+     CallOperatorWriteNode(147...177)(
        CallNode(147...152)(
          LocalVariableReadNode(147...150)(:foo, 0),
          (150...151),
@@ -182,7 +187,7 @@ ProgramNode(0...437)(
          0,
          "C="
        ),
-       PLUS_EQUAL(153...155)("+="),
+       (153...155),
        RescueModifierNode(156...177)(
          CallNode(156...166)(
            nil,
@@ -209,9 +214,10 @@ ProgramNode(0...437)(
          ),
          (167...173),
          NilNode(174...177)()
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(179...208)(
+     CallOperatorWriteNode(179...208)(
        CallNode(179...184)(
          LocalVariableReadNode(179...182)(:foo, 0),
          (182...183),
@@ -223,7 +229,7 @@ ProgramNode(0...437)(
          0,
          "m="
        ),
-       PLUS_EQUAL(185...187)("+="),
+       (185...187),
        CallNode(188...208)(
          nil,
          nil,
@@ -250,9 +256,10 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(210...240)(
+     CallOperatorWriteNode(210...240)(
        CallNode(210...215)(
          LocalVariableReadNode(210...213)(:foo, 0),
          (213...214),
@@ -264,7 +271,7 @@ ProgramNode(0...437)(
          0,
          "m="
        ),
-       PLUS_EQUAL(216...218)("+="),
+       (216...218),
        RescueModifierNode(219...240)(
          CallNode(219...229)(
            nil,
@@ -291,18 +298,16 @@ ProgramNode(0...437)(
          ),
          (230...236),
          NilNode(237...240)()
-       )
-     ),
-     OperatorOrAssignmentNode(242...273)(
-       ConstantPathWriteNode(242...248)(
-         ConstantPathNode(242...248)(
-           LocalVariableReadNode(242...245)(:foo, 0),
-           ConstantReadNode(247...248)(),
-           (245...247)
-         ),
-         nil,
-         nil
        ),
+       :+
+     ),
+     ConstantPathOperatorOrWriteNode(242...273)(
+       ConstantPathNode(242...248)(
+         LocalVariableReadNode(242...245)(:foo, 0),
+         ConstantReadNode(247...248)(),
+         (245...247)
+       ),
+       (249...252),
        CallNode(253...273)(
          nil,
          nil,
@@ -329,19 +334,15 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       ),
-       (249...252)
+       )
      ),
-     OperatorOrAssignmentNode(275...307)(
-       ConstantPathWriteNode(275...281)(
-         ConstantPathNode(275...281)(
-           LocalVariableReadNode(275...278)(:foo, 0),
-           ConstantReadNode(280...281)(),
-           (278...280)
-         ),
-         nil,
-         nil
+     ConstantPathOperatorOrWriteNode(275...307)(
+       ConstantPathNode(275...281)(
+         LocalVariableReadNode(275...278)(:foo, 0),
+         ConstantReadNode(280...281)(),
+         (278...280)
        ),
+       (282...285),
        RescueModifierNode(286...307)(
          CallNode(286...296)(
            nil,
@@ -368,10 +369,9 @@ ProgramNode(0...437)(
          ),
          (297...303),
          NilNode(304...307)()
-       ),
-       (282...285)
+       )
      ),
-     OperatorAssignmentNode(309...339)(
+     CallOperatorWriteNode(309...339)(
        CallNode(309...315)(
          LocalVariableReadNode(309...312)(:foo, 0),
          (312...314),
@@ -383,7 +383,7 @@ ProgramNode(0...437)(
          0,
          "m="
        ),
-       PLUS_EQUAL(316...318)("+="),
+       (316...318),
        CallNode(319...339)(
          nil,
          nil,
@@ -410,9 +410,10 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(341...372)(
+     CallOperatorWriteNode(341...372)(
        CallNode(341...347)(
          LocalVariableReadNode(341...344)(:foo, 0),
          (344...346),
@@ -424,7 +425,7 @@ ProgramNode(0...437)(
          0,
          "m="
        ),
-       PLUS_EQUAL(348...350)("+="),
+       (348...350),
        RescueModifierNode(351...372)(
          CallNode(351...361)(
            nil,
@@ -451,9 +452,10 @@ ProgramNode(0...437)(
          ),
          (362...368),
          NilNode(369...372)()
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(374...404)(
+     CallOperatorWriteNode(374...404)(
        CallNode(374...380)(
          LocalVariableReadNode(374...377)(:foo, 0),
          nil,
@@ -465,7 +467,7 @@ ProgramNode(0...437)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(381...383)("+="),
+       (381...383),
        CallNode(384...404)(
          nil,
          nil,
@@ -492,9 +494,10 @@ ProgramNode(0...437)(
          nil,
          0,
          "raise"
-       )
+       ),
+       :+
      ),
-     OperatorAssignmentNode(406...437)(
+     CallOperatorWriteNode(406...437)(
        CallNode(406...412)(
          LocalVariableReadNode(406...409)(:foo, 0),
          nil,
@@ -506,7 +509,7 @@ ProgramNode(0...437)(
          0,
          "[]="
        ),
-       PLUS_EQUAL(413...415)("+="),
+       (413...415),
        RescueModifierNode(416...437)(
          CallNode(416...426)(
            nil,
@@ -533,7 +536,8 @@ ProgramNode(0...437)(
          ),
          (427...433),
          NilNode(434...437)()
-       )
+       ),
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/ruby_bug_12669.txt
+++ b/test/snapshots/whitequark/ruby_bug_12669.txt
@@ -1,12 +1,12 @@
 ProgramNode(0...74)(
   [:a, :b],
   StatementsNode(0...74)(
-    [OperatorAssignmentNode(0...18)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
-       PLUS_EQUAL(2...4)("+="),
-       OperatorAssignmentNode(5...18)(
-         LocalVariableWriteNode(5...6)(:b, 0, nil, (5...6), nil),
-         PLUS_EQUAL(7...9)("+="),
+    [LocalVariableOperatorWriteNode(0...18)(
+       (0...1),
+       (2...4),
+       LocalVariableOperatorWriteNode(5...18)(
+         (5...6),
+         (7...9),
          CallNode(10...18)(
            nil,
            nil,
@@ -19,12 +19,16 @@ ProgramNode(0...74)(
            nil,
            0,
            "raise"
-         )
-       )
+         ),
+         :b,
+         :+
+       ),
+       :a,
+       :+
      ),
-     OperatorAssignmentNode(20...37)(
-       LocalVariableWriteNode(20...21)(:a, 0, nil, (20...21), nil),
-       PLUS_EQUAL(22...24)("+="),
+     LocalVariableOperatorWriteNode(20...37)(
+       (20...21),
+       (22...24),
        LocalVariableWriteNode(25...37)(
          :b,
          0,
@@ -43,14 +47,16 @@ ProgramNode(0...74)(
          ),
          (25...26),
          (27...28)
-       )
+       ),
+       :a,
+       :+
      ),
      LocalVariableWriteNode(39...56)(
        :a,
        0,
-       OperatorAssignmentNode(43...56)(
-         LocalVariableWriteNode(43...44)(:b, 0, nil, (43...44), nil),
-         PLUS_EQUAL(45...47)("+="),
+       LocalVariableOperatorWriteNode(43...56)(
+         (43...44),
+         (45...47),
          CallNode(48...56)(
            nil,
            nil,
@@ -63,7 +69,9 @@ ProgramNode(0...74)(
            nil,
            0,
            "raise"
-         )
+         ),
+         :b,
+         :+
        ),
        (39...40),
        (41...42)

--- a/test/snapshots/whitequark/send_op_asgn_conditional.txt
+++ b/test/snapshots/whitequark/send_op_asgn_conditional.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...10)(
   [],
   StatementsNode(0...10)(
-    [OperatorAndAssignmentNode(0...10)(
+    [CallOperatorAndWriteNode(0...10)(
        CallNode(0...4)(
          CallNode(0...1)(nil, nil, (0...1), nil, nil, nil, nil, 0, "a"),
          (1...3),
@@ -13,8 +13,8 @@ ProgramNode(0...10)(
          1,
          "b="
        ),
-       IntegerNode(9...10)(),
-       (5...8)
+       (5...8),
+       IntegerNode(9...10)()
      )]
   )
 )

--- a/test/snapshots/whitequark/var_and_asgn.txt
+++ b/test/snapshots/whitequark/var_and_asgn.txt
@@ -1,10 +1,11 @@
 ProgramNode(0...7)(
   [:a],
   StatementsNode(0...7)(
-    [OperatorAndAssignmentNode(0...7)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
+    [LocalVariableOperatorAndWriteNode(0...7)(
+       (0...1),
+       (2...5),
        IntegerNode(6...7)(),
-       (2...5)
+       :a
      )]
   )
 )

--- a/test/snapshots/whitequark/var_op_asgn.txt
+++ b/test/snapshots/whitequark/var_op_asgn.txt
@@ -1,30 +1,35 @@
 ProgramNode(0...53)(
   [:a],
   StatementsNode(0...53)(
-    [OperatorAssignmentNode(0...11)(
-       ClassVariableWriteNode(0...5)((0...5), nil, nil),
-       PIPE_EQUAL(6...8)("|="),
-       IntegerNode(9...11)()
+    [ClassVariableOperatorWriteNode(0...11)(
+       (0...5),
+       (6...8),
+       IntegerNode(9...11)(),
+       :|
      ),
-     OperatorAssignmentNode(13...20)(
-       InstanceVariableWriteNode(13...15)((13...15), nil, nil),
-       PIPE_EQUAL(16...18)("|="),
-       IntegerNode(19...20)()
+     InstanceVariableOperatorWriteNode(13...20)(
+       (13...15),
+       (16...18),
+       IntegerNode(19...20)(),
+       :|
      ),
-     OperatorAssignmentNode(22...28)(
-       LocalVariableWriteNode(22...23)(:a, 0, nil, (22...23), nil),
-       PLUS_EQUAL(24...26)("+="),
-       IntegerNode(27...28)()
+     LocalVariableOperatorWriteNode(22...28)(
+       (22...23),
+       (24...26),
+       IntegerNode(27...28)(),
+       :a,
+       :+
      ),
      DefNode(30...53)(
        (34...35),
        nil,
        nil,
        StatementsNode(37...48)(
-         [OperatorAssignmentNode(37...48)(
-            ClassVariableWriteNode(37...42)((37...42), nil, nil),
-            PIPE_EQUAL(43...45)("|="),
-            IntegerNode(46...48)()
+         [ClassVariableOperatorWriteNode(37...48)(
+            (37...42),
+            (43...45),
+            IntegerNode(46...48)(),
+            :|
           )]
        ),
        [],

--- a/test/snapshots/whitequark/var_op_asgn_cmd.txt
+++ b/test/snapshots/whitequark/var_op_asgn_cmd.txt
@@ -1,9 +1,9 @@
 ProgramNode(0...12)(
   [:foo],
   StatementsNode(0...12)(
-    [OperatorAssignmentNode(0...12)(
-       LocalVariableWriteNode(0...3)(:foo, 0, nil, (0...3), nil),
-       PLUS_EQUAL(4...6)("+="),
+    [LocalVariableOperatorWriteNode(0...12)(
+       (0...3),
+       (4...6),
        CallNode(7...12)(
          nil,
          nil,
@@ -14,7 +14,9 @@ ProgramNode(0...12)(
          nil,
          0,
          "m"
-       )
+       ),
+       :foo,
+       :+
      )]
   )
 )

--- a/test/snapshots/whitequark/var_or_asgn.txt
+++ b/test/snapshots/whitequark/var_or_asgn.txt
@@ -1,10 +1,11 @@
 ProgramNode(0...7)(
   [:a],
   StatementsNode(0...7)(
-    [OperatorOrAssignmentNode(0...7)(
-       LocalVariableWriteNode(0...1)(:a, 0, nil, (0...1), nil),
+    [LocalVariableOperatorOrWriteNode(0...7)(
+       (0...1),
+       (2...5),
        IntegerNode(6...7)(),
-       (2...5)
+       :a
      )]
   )
 )


### PR DESCRIPTION
This is a relatively big change in order to make operator assignments easier to compile.

Right now in order to tell what is actually happening within an `OperatorAssignmentNode`, `OperatorAndAssignmentNode`, and `OperatorOrAssignmentNode`, you have to descend into the target node and figure out its type. This is not great. Furthermore for the `OperatorAssignmentNode` you have to switch on the token type of the operator to figure out the operation to perform.

To remedy all of this, all three of these nodes are getting split up, and the various operator assignment nodes are getting a constant id that contains the operation to perform. So, this means we now have:

* `CallOperatorAndWriteNode` - `foo.bar &&= value`
* `CallOperatorOrWriteNode` - `foo.bar ||= value`
* `CallOperatorWriteNode` - `foo.bar += baz`
* `ClassVariableOperatorAndWriteNode` - `@@target &&= value`
* `ClassVariableOperatorOrWriteNode` - `@@target ||= value`
* `ClassVariableOperatorWriteNode` - `@@target += value`
* `ConstantOperatorAndWriteNode` - `Target &&= value`
* `ConstantOperatorOrWriteNode` - `Target ||= value`
* `ConstantOperatorWriteNode` - `Target += value`
* `ConstantPathOperatorAndWriteNode` - `Parent::Child &&= value`
* `ConstantPathOperatorOrWriteNode` - `Parent::Child ||= value`
* `ConstantPathOperatorWriteNode` - `Parent::Child += value`
* `GlobalVariableOperatorAndWriteNode` - `$target &&= value`
* `GlobalVariableOperatorOrWriteNode` - `$target ||= value`
* `GlobalVariableOperatorWriteNode` - `$target += value`
* `InstanceVariableOperatorAndWriteNode` - `@target &&= value`
* `InstanceVariableOperatorOrWriteNode` - `@target ||= value`
* `InstanceVariableOperatorWriteNode` - `@target += value`
* `LocalVariableOperatorAndWriteNode` - `target &&= value`
* `LocalVariableOperatorOrWriteNode` - `target ||= value`
* `LocalVariableOperatorWriteNode` - `target += value`

The tree ends up being smaller now, because there are fewer nodes that end up staying in the tree. Previously `target += value` would have been represented as `OperatorAssignmentNode(LocalVariableWriteNode, CallNode)` but is now just `LocalVariableOperatorWriteNode(CallNode)`. Hopefully this makes it much easier to compile.

This also is the last token on the tree, so this means none of the serialization consumers need to know about the token types!