### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,39 @@
+name: Windows
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  push:
+    #branches:
+    #  - main
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ucrt
+        bundler-cache: true
+    - name: build
+      id: build
+      run: bundle exec rake compile
+      continue-on-error: true
+      if: success()
+    - name: >-
+        Build outcome: ${{ steps.build.outcome }}
+      # every step must define a `uses` or `run` key
+      run: echo NOOP
+
+    #- name: test
+    #  run: bundle exec rake test
+

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,9 @@
 ifeq ($(shell uname), Darwin)
 	SOEXT := dylib
-else
+else ifeq ($(shell uname), Linux)
 	SOEXT := so
+else
+	SOEXT := dll
 endif
 
 CFLAGS := @CFLAGS@ -std=c99

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ require "rake/clean"
 require "rdoc/task"
 require "ruby_memcheck"
 
+# true for either ucrt or mingw builds, will not include mswin builds
+IS_WINDOWS = RUBY_PLATFORM.include?('mingw')
+
 Rake.add_rakelib("tasks")
 
 RubyMemcheck.config(binary_name: "yarp")
@@ -40,11 +43,13 @@ desc "Generate all ERB template based files"
 task templates: TEMPLATES
 
 file "configure" do
-  sh "autoconf"
+  cmd = IS_WINDOWS ? "sh autoconf" : "autoconf" 
+  sh cmd
 end
 
 file "Makefile" => "configure" do
-  sh "./configure"
+  cmd = IS_WINDOWS ? "sh ./configure" : "./configure"
+  sh cmd
 end
 
 task make: [:templates, "Makefile"] do


### PR DESCRIPTION
Adds a GitHub Actions workflow that only runs `bundle exec rake compile`.  It has code to always pass, so it won't 'fail' a PR.

Several errors/warnings are shown, some were fixed in #966.

Notes:
1. This is only using a Ruby built with the MSYS2 UCRT64 gcc tool chain.  I believe additional code is needed to even try to build with a mswin (MSVC) Ruby.
2. First time this runs, installing/compiling Nokogiri takes several minutes.  Subsequent builds can make use of the cache, so they're much quicker.
3. Once it compiles, addtional code is needed to load `librubyparser.dll`.  Something similar to the below:
```ruby
require 'fiddle'
kernel32 = Fiddle.dlopen 'kernel32'
load_library = Fiddle::Function.new(
  kernel32['LoadLibraryW'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT,
)
dll_path = File.absolute_path('../build/librubyparser.dll', __dir__)
if load_library.call(dll_path.encode('utf-16le')).zero?
  abort "Failed to load librubyparser.dll from\n  #{dll_path}"
end
```