### PR TITLE
Windows build, static linking of the gem, improve extconf.rb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@ test/fixtures/seattlerb/**/*.txt linguist-vendored
 test/fixtures/unparser/**/*.txt linguist-vendored
 test/fixtures/whitequark/**/*.txt linguist-vendored
 test/snapshots/**/*.txt linguist-generated
+
+test/fixtures/**/*.txt -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -26,8 +26,10 @@ jobs:
         bundler-cache: true
     - name: Lint config.yml
       run: bundle exec rake lint
+      shell: bash
     - name: Run Ruby tests
       run: bundle exec rake
+      shell: bash
 
   build-without-assertions:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /build/
 /lib/yarp/yarp.*
 /lib/yarp.bundle
+/lib/yarp.so
 test.rb
 *.dSYM
 
@@ -27,6 +28,7 @@ test.rb
 /src/prettyprint.c
 /src/serialize.c
 /src/token_type.c
+/src/**/*.o
 
 compile_commands.json
 .cache/

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,8 +1,4 @@
-ifeq ($(shell uname), Darwin)
-	SOEXT := dylib
-else
-	SOEXT := so
-endif
+SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 CFLAGS := @CFLAGS@ -std=c99
 DEFS := @DEFS@

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,13 +1,26 @@
 SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
-CFLAGS := @CFLAGS@ -std=c99
 DEFS := @DEFS@
+CPPFLAGS := @DEFS@ -Iinclude
+CFLAGS := @CFLAGS@ -std=c99 -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC	-fvisibility=hidden
 CC := @CC@
 
-all: build/librubyparser.$(SOEXT)
+HEADERS := $(shell find src -name '*.h') include/yarp/ast.h
+SOURCES := $(shell find src -name '*.c')
+OBJECTS := $(SOURCES:.c=.o)
 
-build/librubyparser.$(SOEXT): $(shell find src -name '*.c') $(shell find src -name '*.h') Makefile build include/yarp/ast.h
-	$(CC) $(DEBUG_FLAGS) $(CFLAGS) $(DEFS) -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC -g -fvisibility=hidden -shared -Iinclude -o $@ $(shell find src -name '*.c')
+all: shared static
+
+shared: build/librubyparser.$(SOEXT)
+static: build/librubyparser.a
+
+OBJECTS: Makefile $(HEADERS)
+
+build/librubyparser.$(SOEXT): Makefile build $(OBJECTS)
+	$(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(OBJECTS)
+
+build/librubyparser.a: Makefile build $(OBJECTS)
+	$(AR) $(ARFLAGS) $@	$(OBJECTS)
 
 build:
 	mkdir -p build
@@ -16,13 +29,14 @@ include/yarp/ast.h: templates/include/yarp/ast.h.erb
 	rake $@
 
 clean:
-	rm -f \
-		build/librubyparser.$(SOEXT) \
+	@rm -v -f \
+		build/librubyparser.* \
 		ext/yarp/node.c \
 		include/{ast.h,node.h} \
 		java/org/yarp/{AbstractNodeVisitor.java,Loader.java,Nodes.java} \
 		lib/yarp/{node,serialize}.rb \
-		src/{node.c,prettyprint.c,serialize.c,token_type.c}
+		src/{node.c,prettyprint.c,serialize.c,token_type.c} \
+		$(OBJECTS)
 
 .PHONY: clean
 

--- a/Rakefile
+++ b/Rakefile
@@ -39,12 +39,21 @@ require_relative "templates/template"
 desc "Generate all ERB template based files"
 task templates: TEMPLATES
 
+def windows?
+  RUBY_PLATFORM.include?("mingw")
+end
+
+def run_script(command)
+  command = "sh #{command}" if windows?
+  sh command
+end
+
 file "configure" do
-  sh "autoconf"
+  run_script "autoconf"
 end
 
 file "Makefile" => "configure" do
-  sh "./configure"
+  run_script "./configure"
 end
 
 task make: [:templates, "Makefile"] do

--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -21,8 +21,16 @@ module Yarp
       def configure_rubyparser
         find_header("yarp.h", include_dir)
 
-        unless find_library("rubyparser", "yp_parser_init", build_dir)
-          raise "Please run make to build librubyparser.so"
+        if static_link?
+          static_archive_path = File.join(build_dir, "librubyparser.a")
+          unless File.exist?(static_archive_path)
+            raise "Please run make to build librubyparser.a"
+          end
+          append_ldflags(static_archive_path)
+        else
+          unless find_library("rubyparser", "yp_parser_init", build_dir)
+            raise "Please run make to build librubyparser.so"
+          end
         end
       end
 

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -41,7 +41,7 @@ source_file_load(source_t *source, VALUE filepath) {
     source->source = malloc(file_size);
 
     DWORD bytes_read;
-    BOOL success = ReadFile(file, source->source, file_size, &bytes_read, NULL);
+    BOOL success = ReadFile(file, DISCARD_CONST_QUAL(void *, source->source), file_size, &bytes_read, NULL);
     CloseHandle(file);
 
     if (!success) {

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -27,4 +27,6 @@ void Init_yarp_pack(void);
 
 YP_EXPORTED_FUNCTION void Init_yarp(void);
 
+#define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))
+
 #endif // YARP_EXT_NODE_H

--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -17,10 +17,10 @@
 #   endif
 #endif
 
-#if defined(_WIN32)
-# define YP_ATTRIBUTE_UNUSED
-#else
+#if defined(__GNUC__)
 # define YP_ATTRIBUTE_UNUSED __attribute__((unused))
+#else
+# define YP_ATTRIBUTE_UNUSED
 #endif
 
 #endif

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -7,7 +7,7 @@
 static void
 prettyprint_location(yp_buffer_t *buffer, yp_parser_t *parser, yp_location_t *location) {
     char printed[] = "[0000-0000]";
-    sprintf(printed, "[%04ld-%04ld]", location->start - parser->start, location->end - parser->start);
+    sprintf(printed, "[%04ld-%04ld]", (long int)(location->start - parser->start), (long int)(location->end - parser->start));
     yp_buffer_append_str(buffer, printed, strlen(printed));
 }
 

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -6,7 +6,7 @@
 
 static inline uint32_t
 yp_long_to_u32(long value) {
-    assert(value >= 0 && value < UINT32_MAX);
+    assert(value >= 0 && (unsigned long)value < UINT32_MAX);
     return (uint32_t) value;
 }
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -57,10 +57,12 @@ class ParseTest < Test::Unit::TestCase
     FileUtils.mkdir_p(directory) unless File.directory?(directory)
 
     define_method "test_filepath_#{filepath}" do
-      # First, read the source from the filepath and make sure that it can be
-      # correctly parsed by Ripper. If it can't, then we have a fixture that is
-      # invalid Ruby.
-      source = File.read(filepath)
+      # First, read the source from the filepath. Use binmode to avoid converting CRLF on Windows,
+      # and explicitly set the external encoding to UTF-8 to override the binmode default.
+      source = File.read(filepath, binmode: true, external_encoding: Encoding::UTF_8)
+
+      # Make sure that it can be correctly parsed by Ripper. If it can't, then we have a fixture
+      # that is invalid Ruby.
       refute_nil Ripper.sexp_raw(source)
 
       # Next, parse the source and print the value.


### PR DESCRIPTION
### Summary

Apologies for the large changeset, but the changes are all closely related.

In this PR:

- a Windows build CI job is added to `main.yml`
- Windows compilation warnings are addressed
- the SOEXT shared object file extension is fixed on Windows
- `ext/yarp/extconf.rb` is overhauled to be a self-documenting PORO
- `Makefile` generates both a dynamic shared library and a static archive for `librubyparser`
- the C extension now statically links librubyparser by default (can override with `--disable-static`)
- fixture files now have `.gitattributes` set so git won't munge line endings on Windows
- fixtures are read in binary mode to avoid CRLF autoconversion by File.read

I believe this supersedes (and incorporates pieces of) #1000 and #966. I've credited some commits with co-authors where appropriate.

Closes #980.

cc @MSP-Greg and @jemmaissroff whose work was leveraged in this PR :heart: :heart: :heart: 

### Windows note

~There are a few failures in the Windows build related to line endings. I am pretty confident that this is the same issue described at #985, and I hope that the local test failures are an improvement to the longer build times from `ruby/ruby`.~

_Line endings problem fixed in the test harness._

### Truffleruby note

~This PR runs the Truffleruby build off a personal patched branch of `oracle/truffleruby` to accommodate the changes in this PR.~

~@eregon I'll be sending a PR upstream to `oracle/truffleruby` momentarily to fix the Truffleruby build. `tools/import-yarp.sh` only needs to generate the templates (doing a full build on this branch will result in `src/*.o` files being imported which we absolutely do not want). We should revert that commit once the patch is upstream.~

_Upstream truffleruby PR merged, commit removed._
