### PR TITLE
Revert "Partially fix `rake test` on Mac"

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -239,7 +239,7 @@ require_relative "yarp/node"
 require_relative "yarp/ripper_compat"
 require_relative "yarp/serialize"
 require_relative "yarp/pack"
-require "yarp.#{RbConfig::CONFIG["DLEXT"]}"
+require "yarp.so"
 
 module YARP
   class << self


### PR DESCRIPTION
This reverts commit 7cc29c2d1230d6b503ebd6739431f58468988afb.

This commit was unnecessary, and breaks builds on ruby/ruby. I think this commit is necessary if using an old ruby version. But if running `rake` with latest ruby, it's not necessary to have this config suffix and `.so` should suffice. Tested on mac