### PR TITLE
Fix location on BeginNode

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8467,6 +8467,22 @@ parse_rescues_as_begin(yp_parser_t *parser, yp_statements_node_t *statements) {
     yp_token_t no_begin_token = not_provided(parser);
     yp_begin_node_t *begin_node = yp_begin_node_create(parser, &no_begin_token, statements);
     parse_rescues(parser, begin_node);
+
+    // All nodes within a begin node are optional, so we look
+    // for the earliest possible node that we can use to set
+    // the BeginNode's start location
+    const char * start = begin_node->base.location.start;
+    if (begin_node->statements) {
+        start = begin_node->statements->base.location.start;
+    } else if (begin_node->rescue_clause) {
+        start = begin_node->rescue_clause->base.location.start;
+    } else if (begin_node->else_clause) {
+        start = begin_node->else_clause->base.location.start;
+    } else if (begin_node->ensure_clause) {
+        start = begin_node->ensure_clause->base.location.start;
+    }
+
+    begin_node->base.location.start = start;
     return begin_node;
 }
 

--- a/test/snapshots/classes.txt
+++ b/test/snapshots/classes.txt
@@ -24,7 +24,7 @@ ProgramNode(0...370)(
        ConstantReadNode(25...26)(),
        nil,
        nil,
-       BeginNode(0...39)(
+       BeginNode(28...39)(
          nil,
          nil,
          nil,
@@ -107,7 +107,7 @@ ProgramNode(0...370)(
             (131...136),
             (137...139),
             SelfNode(140...144)(),
-            BeginNode(0...157)(
+            BeginNode(146...157)(
               nil,
               nil,
               nil,

--- a/test/snapshots/methods.txt
+++ b/test/snapshots/methods.txt
@@ -67,7 +67,7 @@ ProgramNode(0...1194)(
        (81...82),
        nil,
        nil,
-       BeginNode(0...95)(
+       BeginNode(84...95)(
          nil,
          nil,
          nil,

--- a/test/snapshots/modules.txt
+++ b/test/snapshots/modules.txt
@@ -54,7 +54,7 @@ ProgramNode(0...140)(
        [:x],
        (57...63),
        ConstantReadNode(64...65)(),
-       BeginNode(74...85)(
+       BeginNode(67...85)(
          nil,
          StatementsNode(67...72)(
            [LocalVariableWriteNode(67...72)(

--- a/test/snapshots/procs.txt
+++ b/test/snapshots/procs.txt
@@ -24,7 +24,7 @@ ProgramNode(0...266)(
        [],
        (23...25),
        nil,
-       BeginNode(0...39)(
+       BeginNode(29...39)(
          nil,
          nil,
          nil,

--- a/test/snapshots/rescue.txt
+++ b/test/snapshots/rescue.txt
@@ -261,7 +261,7 @@ ProgramNode(0...316)(
        (297...298),
        nil,
        nil,
-       BeginNode(306...316)(
+       BeginNode(301...316)(
          nil,
          StatementsNode(301...305)(
            [CallNode(301...305)(

--- a/test/snapshots/seattlerb/defn_oneliner_rescue.txt
+++ b/test/snapshots/seattlerb/defn_oneliner_rescue.txt
@@ -13,7 +13,7 @@ ProgramNode(0...130)(
          nil,
          nil
        ),
-       BeginNode(28...44)(
+       BeginNode(16...44)(
          nil,
          StatementsNode(16...27)(
            [CallNode(16...27)(

--- a/test/snapshots/seattlerb/defs_oneliner_rescue.txt
+++ b/test/snapshots/seattlerb/defs_oneliner_rescue.txt
@@ -13,7 +13,7 @@ ProgramNode(0...145)(
          nil,
          nil
        ),
-       BeginNode(33...49)(
+       BeginNode(21...49)(
          nil,
          StatementsNode(21...32)(
            [CallNode(21...32)(

--- a/test/snapshots/seattlerb/rescue_do_end_ensure_result.txt
+++ b/test/snapshots/seattlerb/rescue_do_end_ensure_result.txt
@@ -12,7 +12,7 @@ ProgramNode(0...42)(
          BlockNode(5...37)(
            [],
            nil,
-           BeginNode(0...37)(
+           BeginNode(10...37)(
              nil,
              StatementsNode(10...16)(
                [SymbolNode(10...16)((10...11), (11...16), nil, "begin")]

--- a/test/snapshots/seattlerb/rescue_do_end_no_raise.txt
+++ b/test/snapshots/seattlerb/rescue_do_end_no_raise.txt
@@ -11,7 +11,7 @@ ProgramNode(0...66)(
        BlockNode(4...66)(
          [],
          nil,
-         BeginNode(16...66)(
+         BeginNode(9...66)(
            nil,
            StatementsNode(9...15)(
              [SymbolNode(9...15)((9...10), (10...15), nil, "begin")]

--- a/test/snapshots/seattlerb/rescue_do_end_raised.txt
+++ b/test/snapshots/seattlerb/rescue_do_end_raised.txt
@@ -11,7 +11,7 @@ ProgramNode(0...35)(
        BlockNode(4...35)(
          [],
          nil,
-         BeginNode(0...35)(
+         BeginNode(9...35)(
            nil,
            StatementsNode(9...14)(
              [CallNode(9...14)(

--- a/test/snapshots/seattlerb/rescue_do_end_rescued.txt
+++ b/test/snapshots/seattlerb/rescue_do_end_rescued.txt
@@ -11,7 +11,7 @@ ProgramNode(0...65)(
        BlockNode(4...65)(
          [],
          nil,
-         BeginNode(15...65)(
+         BeginNode(9...65)(
            nil,
            StatementsNode(9...14)(
              [CallNode(9...14)(

--- a/test/snapshots/unparser/corpus/literal/block.txt
+++ b/test/snapshots/unparser/corpus/literal/block.txt
@@ -767,7 +767,7 @@ ProgramNode(0...737)(
        BlockNode(393...435)(
          [:bar],
          nil,
-         BeginNode(402...435)(
+         BeginNode(398...435)(
            nil,
            StatementsNode(398...401)(
              [CallNode(398...401)(
@@ -812,7 +812,7 @@ ProgramNode(0...737)(
        BlockNode(438...479)(
          [],
          nil,
-         BeginNode(447...479)(
+         BeginNode(443...479)(
            nil,
            StatementsNode(443...446)(
              [CallNode(443...446)(
@@ -881,7 +881,7 @@ ProgramNode(0...737)(
        BlockNode(482...536)(
          [:exception],
          nil,
-         BeginNode(491...536)(
+         BeginNode(487...536)(
            nil,
            StatementsNode(487...490)(
              [CallNode(487...490)(
@@ -956,7 +956,7 @@ ProgramNode(0...737)(
        BlockNode(539...569)(
          [],
          nil,
-         BeginNode(548...569)(
+         BeginNode(544...569)(
            nil,
            StatementsNode(544...547)(
              [CallNode(544...547)(
@@ -1024,7 +1024,7 @@ ProgramNode(0...737)(
        BlockNode(572...601)(
          [],
          nil,
-         BeginNode(581...601)(
+         BeginNode(577...601)(
            nil,
            StatementsNode(577...580)(
              [CallNode(577...580)(
@@ -1067,7 +1067,7 @@ ProgramNode(0...737)(
        BlockNode(604...634)(
          [],
          nil,
-         BeginNode(613...634)(
+         BeginNode(609...634)(
            nil,
            StatementsNode(609...612)(
              [CallNode(609...612)(
@@ -1119,7 +1119,7 @@ ProgramNode(0...737)(
        BlockNode(637...680)(
          [:exception],
          nil,
-         BeginNode(646...680)(
+         BeginNode(642...680)(
            nil,
            StatementsNode(642...645)(
              [CallNode(642...645)(
@@ -1193,7 +1193,7 @@ ProgramNode(0...737)(
        BlockNode(683...696)(
          [],
          nil,
-         BeginNode(0...696)(
+         BeginNode(686...696)(
            nil,
            nil,
            nil,

--- a/test/snapshots/unparser/corpus/literal/def.txt
+++ b/test/snapshots/unparser/corpus/literal/def.txt
@@ -5,7 +5,7 @@ ProgramNode(0...913)(
        (4...7),
        nil,
        nil,
-       BeginNode(12...46)(
+       BeginNode(10...46)(
          nil,
          StatementsNode(10...11)(
            [CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 0, "a")]
@@ -78,7 +78,7 @@ ProgramNode(0...913)(
        (52...55),
        nil,
        nil,
-       BeginNode(69...103)(
+       BeginNode(58...103)(
          nil,
          StatementsNode(58...68)(
            [RescueModifierNode(58...68)(
@@ -235,7 +235,7 @@ ProgramNode(0...913)(
        (166...169),
        nil,
        nil,
-       BeginNode(176...205)(
+       BeginNode(172...205)(
          nil,
          StatementsNode(172...175)(
            [CallNode(172...175)(
@@ -302,7 +302,7 @@ ProgramNode(0...913)(
        (211...214),
        nil,
        nil,
-       BeginNode(0...237)(
+       BeginNode(217...237)(
          nil,
          StatementsNode(217...220)(
            [CallNode(217...220)(
@@ -350,7 +350,7 @@ ProgramNode(0...913)(
        (243...246),
        nil,
        nil,
-       BeginNode(253...269)(
+       BeginNode(249...269)(
          nil,
          StatementsNode(249...252)(
            [CallNode(249...252)(

--- a/test/snapshots/whitequark/rescue_without_begin_end.txt
+++ b/test/snapshots/whitequark/rescue_without_begin_end.txt
@@ -11,7 +11,7 @@ ProgramNode(0...30)(
        BlockNode(5...30)(
          [],
          nil,
-         BeginNode(14...30)(
+         BeginNode(9...30)(
            nil,
            StatementsNode(9...12)(
              [CallNode(9...12)(


### PR DESCRIPTION
Prior to this commit, the location was incorrect whenever we called `parse_rescues_as_begin` because it was being set to the empty begin_token. This commit sets it to the first non-null child of the begin node (could be statements, rescue clause, else clause or ensure clause)