### PR TITLE
Fix leaked FD for an empty file

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -72,6 +72,7 @@ source_file_load(source_t *source, VALUE filepath) {
 
 #ifdef HAVE_MMAP
     if (!source->size) {
+        close(fd);
         source->source = "";
         return 0;
     }


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/5347722364/jobs/9696622788#step:15:102
```
Leaked file descriptor: ParseTest#test_filepath_/home/runner/work/ruby/ruby/src/test/yarp/fixtures/unparser/corpus/literal/empty.txt: 9 #<File::Stat dev=0x811, ino=783189, mode=0100644, nlink=1, uid=1001, gid=122, rdev=0x0, size=0, blksize=4096, blocks=0, atime=2023-06-22 16:06:29.980038261 +0000, mtime=2023-06-22 16:00:36.372381267 +0000, ctime=2023-06-22 16:00:36.372381267 +0000>
  COMMAND   PID   USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME
  ruby    19337 runner    9r   REG   8,17        0 783189 /home/runner/work/ruby/ruby/src/test/yarp/fixtures/unparser/corpus/literal/empty.txt
```