### PR TITLE
fix static symbol resolution

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,12 +2,13 @@ SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 DEFS := @DEFS@
 CPPFLAGS := @DEFS@ -Iinclude
-CFLAGS := @CFLAGS@ -std=c99 -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC	-fvisibility=hidden
+CFLAGS := @CFLAGS@ -std=c99 -Wall -Werror -Wextra -Wpedantic -Wsign-conversion -fPIC -fvisibility=hidden
 CC := @CC@
 
 HEADERS := $(shell find include -name '*.h') include/yarp/ast.h
 SOURCES := $(shell find src -name '*.c')
-OBJECTS := $(subst src/,build/x/,$(SOURCES:.c=.o))
+SHARED_OBJECTS := $(subst src/,build/shared/,$(SOURCES:.c=.o))
+STATIC_OBJECTS := $(subst src/,build/static/,$(SOURCES:.c=.o))
 
 all: shared static
 
@@ -16,15 +17,19 @@ static: build/librubyparser.a
 
 $(OBJECTS): Makefile $(HEADERS)
 
-build/librubyparser.$(SOEXT): Makefile $(OBJECTS)
-	$(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(OBJECTS)
+build/librubyparser.$(SOEXT): $(SHARED_OBJECTS)
+	$(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(SHARED_OBJECTS)
 
-build/librubyparser.a: Makefile $(OBJECTS)
-	$(AR) $(ARFLAGS) $@ $(OBJECTS)
+build/librubyparser.a: $(STATIC_OBJECTS)
+	$(AR) $(ARFLAGS) $@ $(STATIC_OBJECTS)
 
-build/x/%.o: src/%.c
+build/shared/%.o: src/%.c
 	mkdir -p $(@D)
 	$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+build/static/%.o: src/%.c
+	mkdir -p $(@D)
+	$(CC) $(DEBUG_FLAGS) -DYP_STATIC $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 include/yarp/ast.h: templates/include/yarp/ast.h.erb
 	rake $@

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,7 +7,7 @@ CC := @CC@
 
 HEADERS := $(shell find include -name '*.h') include/yarp/ast.h
 SOURCES := $(shell find src -name '*.c')
-OBJECTS := $(SOURCES:.c=.o)
+OBJECTS := $(subst src/,build/x/,$(SOURCES:.c=.o))
 
 all: shared static
 
@@ -16,21 +16,22 @@ static: build/librubyparser.a
 
 $(OBJECTS): Makefile $(HEADERS)
 
-build/librubyparser.$(SOEXT): Makefile build $(OBJECTS)
+build/librubyparser.$(SOEXT): Makefile $(OBJECTS)
 	$(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(OBJECTS)
 
-build/librubyparser.a: Makefile build $(OBJECTS)
-	$(AR) $(ARFLAGS) $@	$(OBJECTS)
+build/librubyparser.a: Makefile $(OBJECTS)
+	$(AR) $(ARFLAGS) $@ $(OBJECTS)
 
-build:
-	mkdir -p build
+build/x/%.o: src/%.c
+	mkdir -p $(@D)
+	$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 include/yarp/ast.h: templates/include/yarp/ast.h.erb
 	rake $@
 
 clean:
-	@rm -v -f \
-		build/librubyparser.* \
+	@rm -v -f -r \
+		build \
 		ext/yarp/node.c \
 		include/{ast.h,node.h} \
 		java/org/yarp/{AbstractNodeVisitor.java,Loader.java,Nodes.java} \

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,12 @@
+
+# V=0 quiet, V=1 verbose.  other values don't work.
+V = 0
+V0 = $(V:0=)
+Q1 = $(V:1=)
+Q = $(Q1:0=@)
+ECHO1 = $(V:1=@ :)
+ECHO = $(ECHO1:0=@ echo)
+
 SOEXT := $(shell ruby -e 'puts RbConfig::CONFIG["SOEXT"]')
 
 DEFS := @DEFS@
@@ -18,24 +27,29 @@ static: build/librubyparser.a
 $(OBJECTS): Makefile $(HEADERS)
 
 build/librubyparser.$(SOEXT): $(SHARED_OBJECTS)
-	$(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(SHARED_OBJECTS)
+	$(ECHO) "linking $@"
+	$(Q) $(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(SHARED_OBJECTS)
 
 build/librubyparser.a: $(STATIC_OBJECTS)
-	$(AR) $(ARFLAGS) $@ $(STATIC_OBJECTS)
+	$(ECHO) "building $@"
+	$(Q) $(AR) $(ARFLAGS) $@ $(STATIC_OBJECTS) $(Q1:0=>/dev/null)
 
 build/shared/%.o: src/%.c
-	mkdir -p $(@D)
-	$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(ECHO) "compiling $@"
+	$(Q) mkdir -p $(@D)
+	$(Q) $(CC) $(DEBUG_FLAGS) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 build/static/%.o: src/%.c
-	mkdir -p $(@D)
-	$(CC) $(DEBUG_FLAGS) -DYP_STATIC $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(ECHO) "compiling $@"
+	$(Q) mkdir -p $(@D)
+	$(Q) $(CC) $(DEBUG_FLAGS) -DYP_STATIC $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 include/yarp/ast.h: templates/include/yarp/ast.h.erb
-	rake $@
+	$(ECHO) "generating $@"
+	$(Q) rake $@
 
 clean:
-	@rm -v -f -r \
+	$(Q) rm -f -r \
 		build \
 		ext/yarp/node.c \
 		include/{ast.h,node.h} \

--- a/Rakefile
+++ b/Rakefile
@@ -62,9 +62,7 @@ end
 
 # So `rake clobber` will delete generated files
 CLOBBER.concat(TEMPLATES)
-CLOBBER.concat(["configure", "Makefile"])
-
-CLOBBER << "build/librubyparser.#{RbConfig::CONFIG["SOEXT"]}"
+CLOBBER.concat(["configure", "Makefile", "build"])
 CLOBBER << "lib/yarp.#{RbConfig::CONFIG["DLEXT"]}"
 
 TEMPLATES.each do |filepath|

--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -8,7 +8,9 @@
 #include <string.h>
 
 // YP_EXPORTED_FUNCTION
-#if defined(_WIN32)
+#if defined(YP_STATIC)
+#   define YP_EXPORTED_FUNCTION
+#elif defined(_WIN32)
 #   define YP_EXPORTED_FUNCTION __declspec(dllexport) extern
 #else
 #   ifndef YP_EXPORTED_FUNCTION


### PR DESCRIPTION
Closes #1067

This PR introduces separate object files (and build directories) for the dll (`librubyparser.so`) and the static archive (`librubyparser.a`) to ensure the dll makes public symbols public and the static archive does not.

I've also made the Makefile much quieter by default, but provide support for a `V=1` argument for verbose mode (just like mkmf Makefiles).

This makes the difference between (uppercase `T`):

```
$ nm lib/yarp.so | fgrep yp_parse
0000000000031210 T yp_parse
0000000000003e1d t yp_parse.cold
00000000000313d0 T yp_parse_serialize
0000000000031160 T yp_parser_free
0000000000030ee0 T yp_parser_init
0000000000015520 t yp_parser_local_depth.isra.0
0000000000015450 t yp_parser_parameter_name_check
0000000000031140 T yp_parser_register_encoding_changed_callback
0000000000031150 T yp_parser_register_encoding_decode_callback
```

and (lowercase `t`):

```
$ nm lib/yarp.so | fgrep yp_parse
0000000000031050 t yp_parse
00000000000310d0 t yp_parse_serialize
0000000000030fa0 t yp_parser_free
0000000000030d20 t yp_parser_init
0000000000015200 t yp_parser_local_depth.isra.0
0000000000015130 t yp_parser_parameter_name_check
0000000000030f80 t yp_parser_register_encoding_changed_callback
0000000000030f90 t yp_parser_register_encoding_decode_callback
```
