### PR TITLE
Import local headers before standard headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,23 +31,11 @@ jobs:
       run: bundle exec rake
       shell: bash
 
-  build-without-assertions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: head
-        bundler-cache: true
-    - name: Run Ruby tests
-      run: bundle exec rake compile_no_debug
-
   build-debug-mode:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -60,6 +48,18 @@ jobs:
       run: bundle exec rake
       env:
         YARP_DEBUG_MODE_BUILD: "1"
+
+  build-without-assertions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: head
+        bundler-cache: true
+    - name: Run Ruby tests
+      run: bundle exec rake compile_no_debug
 
   lex-ruby:
     runs-on: ubuntu-latest

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -2,18 +2,6 @@
 #define YARP_H
 
 #include "yarp/defines.h"
-
-#include <assert.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#ifndef _WIN32
-#include <strings.h>
-#endif
-
 #include "yarp/ast.h"
 #include "yarp/diagnostic.h"
 #include "yarp/node.h"
@@ -24,6 +12,18 @@
 #include "yarp/util/yp_buffer.h"
 #include "yarp/util/yp_char.h"
 #include "yarp/util/yp_strpbrk.h"
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <strings.h>
+#endif
 
 #define YP_VERSION_MAJOR 0
 #define YP_VERSION_MINOR 4
@@ -55,20 +55,6 @@ YP_EXPORTED_FUNCTION void yp_parser_free(yp_parser_t *parser);
 
 // Parse the Ruby source associated with the given parser and return the tree.
 YP_EXPORTED_FUNCTION yp_node_t * yp_parse(yp_parser_t *parser);
-
-// Deallocate a node and all of its children.
-YP_EXPORTED_FUNCTION void yp_node_destroy(yp_parser_t *parser, struct yp_node *node);
-
-// This struct stores the information gathered by the yp_node_memsize function.
-// It contains both the memory footprint and additionally metadata about the
-// shape of the tree.
-typedef struct {
-    size_t memsize;
-    size_t node_count;
-} yp_memsize_t;
-
-// Calculates the memory footprint of a given node.
-YP_EXPORTED_FUNCTION void yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize);
 
 // Pretty-prints the AST represented by the given node to the given buffer.
 YP_EXPORTED_FUNCTION void yp_prettyprint(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);

--- a/include/yarp/diagnostic.h
+++ b/include/yarp/diagnostic.h
@@ -2,11 +2,10 @@
 #define YARP_DIAGNOSTIC_H
 
 #include "yarp/defines.h"
+#include "yarp/util/yp_list.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
-
-#include "yarp/util/yp_list.h"
 
 // This struct represents a diagnostic found during parsing.
 typedef struct {

--- a/include/yarp/node.h
+++ b/include/yarp/node.h
@@ -2,8 +2,6 @@
 #define YARP_NODE_H
 
 #include "yarp/defines.h"
-
-#include "yarp.h"
 #include "yarp/parser.h"
 
 // Append a token to the given list.
@@ -14,6 +12,20 @@ void yp_node_list_append(yp_node_list_t *list, yp_node_t *node);
 
 // Clear the node but preserves the location.
 void yp_node_clear(yp_node_t *node);
+
+// Deallocate a node and all of its children.
+YP_EXPORTED_FUNCTION void yp_node_destroy(yp_parser_t *parser, struct yp_node *node);
+
+// This struct stores the information gathered by the yp_node_memsize function.
+// It contains both the memory footprint and additionally metadata about the
+// shape of the tree.
+typedef struct {
+    size_t memsize;
+    size_t node_count;
+} yp_memsize_t;
+
+// Calculates the memory footprint of a given node.
+YP_EXPORTED_FUNCTION void yp_node_memsize(yp_node_t *node, yp_memsize_t *memsize);
 
 #define YP_EMPTY_NODE_LIST ((yp_node_list_t) { .nodes = NULL, .size = 0, .capacity = 0 })
 #define YP_EMPTY_LOCATION_LIST ((yp_location_list_t) { .locations = NULL, .size = 0, .capacity = 0 })

--- a/include/yarp/pack.h
+++ b/include/yarp/pack.h
@@ -3,8 +3,8 @@
 
 #include "yarp/defines.h"
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 typedef enum yp_pack_version {
     YP_PACK_VERSION_3_2_0

--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -1,16 +1,15 @@
 #ifndef YARP_PARSER_H
 #define YARP_PARSER_H
 
-#include "yarp/defines.h"
-
-#include <stdbool.h>
-
 #include "yarp/ast.h"
+#include "yarp/defines.h"
 #include "yarp/enc/yp_encoding.h"
 #include "yarp/util/yp_constant_pool.h"
 #include "yarp/util/yp_list.h"
 #include "yarp/util/yp_newline_list.h"
 #include "yarp/util/yp_state_stack.h"
+
+#include <stdbool.h>
 
 // This enum provides various bits that represent different kinds of states that
 // the lexer can track. This is used to determine which kind of token to return

--- a/include/yarp/regexp.h
+++ b/include/yarp/regexp.h
@@ -2,14 +2,13 @@
 #define YARP_REGEXP_H
 
 #include "yarp/defines.h"
-
 #include "yarp/parser.h"
+#include "yarp/util/yp_string_list.h"
+#include "yarp/util/yp_string.h"
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-
-#include "yarp/util/yp_string_list.h"
-#include "yarp/util/yp_string.h"
 
 // Parse a regular expression and extract the names of all of the named capture
 // groups.

--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -2,16 +2,15 @@
 #define YARP_UNESCAPE_H
 
 #include "yarp/defines.h"
+#include "yarp/diagnostic.h"
+#include "yarp/util/yp_char.h"
+#include "yarp/util/yp_list.h"
+#include "yarp/util/yp_string.h"
 
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-
-#include "yarp/diagnostic.h"
-#include "yarp/util/yp_char.h"
-#include "yarp/util/yp_list.h"
-#include "yarp/util/yp_string.h"
 
 // The type of unescape we are performing.
 typedef enum {

--- a/include/yarp/util/yp_char.h
+++ b/include/yarp/util/yp_char.h
@@ -2,11 +2,10 @@
 #define YP_CHAR_H
 
 #include "yarp/defines.h"
+#include "yarp/util/yp_newline_list.h"
 
 #include <stdbool.h>
 #include <stddef.h>
-
-#include "yarp/util/yp_newline_list.h"
 
 // Returns the number of characters at the start of the string that are
 // whitespace. Disallows searching past the given maximum number of characters.

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -6,12 +6,12 @@
 #ifndef YP_CONSTANT_POOL_H
 #define YP_CONSTANT_POOL_H
 
+#include "yarp/defines.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "yarp/defines.h"
 
 typedef uint32_t yp_constant_id_t;
 

--- a/include/yarp/util/yp_newline_list.h
+++ b/include/yarp/util/yp_newline_list.h
@@ -9,12 +9,12 @@
 #ifndef YP_NEWLINE_LIST_H
 #define YP_NEWLINE_LIST_H
 
-#include <assert.h>
-#include <stddef.h>
-#include <stdbool.h>
-#include <stdlib.h>
-
 #include "yarp/defines.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
 
 // A list of offsets of newlines in a string. The offsets are assumed to be
 // sorted/inserted in ascending order.

--- a/include/yarp/util/yp_string.h
+++ b/include/yarp/util/yp_string.h
@@ -29,9 +29,6 @@ typedef struct {
     } as;
 } yp_string_t;
 
-// Allocate a new yp_string_t.
-yp_string_t * yp_string_alloc(void);
-
 // Initialize a shared string that is based on initial input.
 void yp_string_shared_init(yp_string_t *string, const char *start, const char *end);
 

--- a/include/yarp/util/yp_string_list.h
+++ b/include/yarp/util/yp_string_list.h
@@ -2,11 +2,10 @@
 #define YARP_STRING_LIST_H
 
 #include "yarp/defines.h"
+#include "yarp/util/yp_string.h"
 
 #include <stddef.h>
 #include <stdlib.h>
-
-#include "yarp/util/yp_string.h"
 
 typedef struct {
     yp_string_t *strings;

--- a/src/util/yp_string.c
+++ b/src/util/yp_string.c
@@ -1,11 +1,5 @@
 #include "yarp/util/yp_string.h"
 
-// Allocate a new yp_string_t.
-yp_string_t *
-yp_string_alloc(void) {
-    return (yp_string_t *) malloc(sizeof(yp_string_t));
-}
-
 // Initialize a shared string that is based on initial input.
 void
 yp_string_shared_init(yp_string_t *string, const char *start, const char *end) {

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -2,13 +2,12 @@
 #define YARP_AST_H
 
 #include "yarp/defines.h"
+#include "yarp/util/yp_constant_pool.h"
+#include "yarp/util/yp_string.h"
 
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
-
-#include "yarp/util/yp_constant_pool.h"
-#include "yarp/util/yp_string.h"
 
 // This enum represents every type of token in the Ruby source.
 typedef enum yp_token_type {


### PR DESCRIPTION
Just implementing consistency here. From now on, we should always import local headers first to make sure our defines are correctly established.

Also remove `yp_string_alloc` because it's not used.

In general these kinds of things should eventually go into a `style.md` file, but for now I'm not taking that on.