### PR TITLE
Introduce Source

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -152,13 +152,7 @@ static VALUE
 dump(VALUE self, VALUE string, VALUE filepath) {
     source_t source;
     source_string_load(&source, string);
-    char *str = NULL;
-
-    if (filepath != Qnil) {
-        str = StringValueCStr(filepath);
-    }
-
-    return dump_source(&source, str);
+    return dump_source(&source, NIL_P(filepath) ? NULL : StringValueCStr(filepath));
 }
 
 // Dump the AST corresponding to the given file to a string.
@@ -537,12 +531,11 @@ Init_yarp(void) {
 
     rb_define_const(rb_cYARP, "VERSION", rb_sprintf("%d.%d.%d", YP_VERSION_MAJOR, YP_VERSION_MINOR, YP_VERSION_PATCH));
 
-    rb_define_singleton_method(rb_cYARP, "dump", dump, 2);
+    // First, the functions that have to do with lexing and parsing.
+    rb_define_singleton_method(rb_cYARP, "_dump", dump, 2);
     rb_define_singleton_method(rb_cYARP, "dump_file", dump_file, 1);
-
     rb_define_singleton_method(rb_cYARP, "_lex", lex, 2);
     rb_define_singleton_method(rb_cYARP, "lex_file", lex_file, 1);
-
     rb_define_singleton_method(rb_cYARP, "_parse", parse, 2);
     rb_define_singleton_method(rb_cYARP, "parse_file", parse_file, 1);
 

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -285,8 +285,8 @@ lex_source(source_t *source, char *filepath) {
     yp_parser_init(&parser, source->source, source->size, filepath);
     yp_parser_register_encoding_changed_callback(&parser, lex_encoding_changed_callback);
 
-    VALUE newlines = rb_ary_new();
-    VALUE source_range_argv[] = { rb_str_new(source->source, source->size), newlines };
+    VALUE offsets = rb_ary_new();
+    VALUE source_range_argv[] = { rb_str_new(source->source, source->size), offsets };
     VALUE source_range = rb_class_new_instance(2, source_range_argv, rb_cYARPSourceRange);
 
     lex_data_t lex_data = {
@@ -308,7 +308,7 @@ lex_source(source_t *source, char *filepath) {
     // offsets. We do it here because we've already created the object and given
     // it over to all of the tokens.
     for (size_t index = 0; index < parser.newline_list.size; index++) {
-        rb_ary_push(newlines, INT2FIX(parser.newline_list.offsets[index]));
+        rb_ary_push(offsets, INT2FIX(parser.newline_list.offsets[index]));
     }
 
     VALUE result_argv[] = {

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -331,11 +331,8 @@ static VALUE
 lex(VALUE self, VALUE string, VALUE filepath) {
     source_t source;
     source_string_load(&source, string);
-    char *filepath_char = NULL;
-    if (filepath) {
-        filepath_char = StringValueCStr(filepath);
-    }
-    return lex_source(&source, filepath_char);
+
+    return lex_source(&source, NIL_P(filepath) ? NULL : StringValueCStr(filepath));
 }
 
 // Return an array of tokens corresponding to the given file.
@@ -377,15 +374,19 @@ static VALUE
 parse(VALUE self, VALUE string, VALUE filepath) {
     source_t source;
     source_string_load(&source, string);
+
 #ifdef YARP_DEBUG_MODE_BUILD
     char* dup = malloc(source.size);
     memcpy(dup, source.source, source.size);
     source.source = dup;
 #endif
+
     VALUE value = parse_source(&source, NIL_P(filepath) ? NULL : StringValueCStr(filepath));
+
 #ifdef YARP_DEBUG_MODE_BUILD
     free(dup);
 #endif
+
     return value;
 }
 
@@ -539,7 +540,7 @@ Init_yarp(void) {
     rb_define_singleton_method(rb_cYARP, "dump", dump, 2);
     rb_define_singleton_method(rb_cYARP, "dump_file", dump_file, 1);
 
-    rb_define_singleton_method(rb_cYARP, "lex", lex, 2);
+    rb_define_singleton_method(rb_cYARP, "_lex", lex, 2);
     rb_define_singleton_method(rb_cYARP, "lex_file", lex_file, 1);
 
     rb_define_singleton_method(rb_cYARP, "_parse", parse, 2);

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -5,11 +5,10 @@
 #include <ruby/encoding.h>
 #include "yarp.h"
 
-#include <fcntl.h>
-
 #ifdef _WIN32
 #include <windows.h>
 #else
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -17,13 +16,11 @@
 
 #define EXPECTED_YARP_VERSION "0.4.0"
 
-VALUE yp_source_range_new(yp_parser_t *parser);
-VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source_range);
+VALUE yp_source_new(yp_parser_t *parser);
+VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source);
 VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
 
 void Init_yarp_pack(void);
 YP_EXPORTED_FUNCTION void Init_yarp(void);
 
-#define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))
-
-#endif // YARP_EXT_NODE_H
+#endif

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -17,12 +17,11 @@
 
 #define EXPECTED_YARP_VERSION "0.4.0"
 
-VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding);
-
+VALUE yp_source_range_new(yp_parser_t *parser);
+VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source_range);
 VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
 
 void Init_yarp_pack(void);
-
 YP_EXPORTED_FUNCTION void Init_yarp(void);
 
 #define DISCARD_CONST_QUAL(t, v) ((t)(uintptr_t)(v))

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -12,6 +12,10 @@ module YARP
       @newlines = newlines
     end
 
+    def slice(offset, length)
+      source.byteslice(offset, length)
+    end
+
     def line(offset)
       newlines.bsearch_index { |newline| newline > offset } || newlines.length
     end
@@ -38,6 +42,11 @@ module YARP
       @source_range = source_range
       @start_offset = start_offset
       @length = length
+    end
+
+    # The source code that this location represents.
+    def slice
+      source_range.slice(start_offset, length)
     end
 
     # The byte offset from the beginning of the source where this location ends.

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -5,23 +5,23 @@ module YARP
   # conjunction with locations to allow them to resolve line numbers and source
   # ranges.
   class SourceRange
-    attr_reader :source, :newlines
+    attr_reader :source, :offsets
 
-    def initialize(source, newlines)
+    def initialize(source, offsets)
       @source = source
-      @newlines = newlines
+      @offsets = offsets
     end
 
     def slice(offset, length)
       source.byteslice(offset, length)
     end
 
-    def line(offset)
-      newlines.bsearch_index { |newline| newline > offset } || newlines.length
+    def line(value)
+      offsets.bsearch_index { |offset| offset > value } || offsets.length
     end
 
-    def column(offset)
-      offset - newlines[line(offset) - 1]
+    def column(value)
+      value - offsets[line(value) - 1]
     end
   end
 

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -1,17 +1,70 @@
 # frozen_string_literal: true
 
 module YARP
-  # This represents a location in the source corresponding to a node or token.
-  class Location
-    attr_reader :start_offset, :length
+  # This represents a source of Ruby code that has been parsed. It is used in
+  # conjunction with locations to allow them to resolve line numbers and source
+  # ranges.
+  class SourceRange
+    attr_reader :source, :newlines
 
-    def initialize(start_offset, length)
+    def initialize(source, newlines)
+      @source = source
+      @newlines = newlines
+    end
+
+    def line(offset)
+      newlines.bsearch_index { |newline| newline > offset } || newlines.length
+    end
+
+    def column(offset)
+      newlines[line_number(offset)] || 0
+    end
+  end
+
+  # This represents a location in the source.
+  class Location
+    # A SourceRange object that is used to determine more information from the
+    # given offset and length.
+    attr_reader :source_range
+
+    # The byte offset from the beginning of the source where this location
+    # starts.
+    attr_reader :start_offset
+
+    # The length of this location in bytes.
+    attr_reader :length
+
+    def initialize(source_range, start_offset, length)
+      @source_range = source_range
       @start_offset = start_offset
       @length = length
     end
 
+    # The byte offset from the beginning of the source where this location ends.
     def end_offset
-      @start_offset + @length
+      start_offset + length
+    end
+
+    # The line number where this location starts.
+    def start_line
+      source_range.line(start_offset)
+    end
+
+    # The line number where this location ends.
+    def end_line
+      source_range.line(end_offset)
+    end
+
+    # The column number in bytes where this location starts from the start of
+    # the line.
+    def start_column
+      source_range.column(start_offset)
+    end
+
+    # The column number in bytes where this location ends from the start of the
+    # line.
+    def end_column
+      source_range.column(end_offset)
     end
 
     def deconstruct_keys(keys)
@@ -101,21 +154,12 @@ module YARP
 
   # This represents a token from the Ruby source.
   class Token
-    attr_reader :type, :value, :start_offset, :length
+    attr_reader :type, :value, :location
 
-    def initialize(type, value, start_offset, length)
+    def initialize(type, value, location)
       @type = type
       @value = value
-      @start_offset = start_offset
-      @length = length
-    end
-
-    def end_offset
-      @start_offset + @length
-    end
-
-    def location
-      Location.new(@start_offset, @length)
+      @location = location
     end
 
     def deconstruct_keys(keys)
@@ -143,20 +187,12 @@ module YARP
 
   # This represents a node in the tree.
   class Node
-    attr_reader :start_offset, :length
-
-    def end_offset
-      @start_offset + @length
-    end
-
-    def location
-      Location.new(@start_offset, @length)
-    end
+    attr_reader :location
 
     def pretty_print(q)
       q.group do
         q.text(self.class.name.split("::").last)
-        self.location.pretty_print(q)
+        location.pretty_print(q)
         q.text("(")
         q.nest(2) do
           deconstructed = deconstruct_keys([])

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -216,21 +216,28 @@ module YARP
     end
   end
 
-  # Load the serialized AST using the source as a reference into a tree.
-  def self.load(source, serialized)
-    Serialize.load(source, serialized)
-  end
+  class << self
+    # Lex the given source into tokens. Optionally provide a filepath that this
+    # source comes from.
+    def lex(source, filepath = nil)
+      _lex(source, filepath)
+    end
 
-  # Lex the given source into tokens. Optionally provide a filepath that this
-  # source comes from.
-  def self.lex(source, filepath = nil)
-    _lex(source, filepath)
-  end
+    # Parse the given source into an AST. Optionally provide a filepath that
+    # this source comes from.
+    def parse(source, filepath = nil)
+      _parse(source, filepath)
+    end
 
-  # Parse the given source into an AST. Optionally provide a filepath that this
-  # source comes from.
-  def self.parse(source, filepath = nil)
-    _parse(source, filepath)
+    # Dump the given source into a serialized format.
+    def dump(source, filepath = nil)
+      _dump(source, filepath)
+    end
+
+    # Load the serialized AST using the source as a reference into a tree.
+    def load(source, serialized)
+      Serialize.load(source, serialized)
+    end
   end
 end
 
@@ -246,6 +253,6 @@ module YARP
     # These methods comes from the C extension. Calling them this way makes it
     # easier to handle default arguments in Ruby, and provides a source location
     # for each method.
-    private :_lex, :_parse
+    private :_lex, :_parse, :_dump
   end
 end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -221,6 +221,12 @@ module YARP
     Serialize.load(source, serialized)
   end
 
+  # Lex the given source into tokens. Optionally provide a filepath that this
+  # source comes from.
+  def self.lex(source, filepath = nil)
+    _lex(source, filepath)
+  end
+
   # Parse the given source into an AST. Optionally provide a filepath that this
   # source comes from.
   def self.parse(source, filepath = nil)
@@ -237,9 +243,9 @@ require "yarp.so"
 
 module YARP
   class << self
-    # This method comes from the C extension. Calling it this way makes it
+    # These methods comes from the C extension. Calling them this way makes it
     # easier to handle default arguments in Ruby, and provides a source location
-    # for the method.
-    private :_parse
+    # for each method.
+    private :_lex, :_parse
   end
 end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -216,24 +216,6 @@ module YARP
     end
   end
 
-  # A class that knows how to walk down the tree. None of the individual visit
-  # methods are implemented on this visitor, so it forces the consumer to
-  # implement each one that they need. For a default implementation that
-  # continues walking the tree, see the Visitor class.
-  class BasicVisitor
-    def visit(node)
-      node&.accept(self)
-    end
-
-    def visit_all(nodes)
-      nodes.map { |node| visit(node) }
-    end
-
-    def visit_child_nodes(node)
-      visit_all(node.child_nodes)
-    end
-  end
-
   # Load the serialized AST using the source as a reference into a tree.
   def self.load(source, serialized)
     Serialize.load(source, serialized)

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -234,47 +234,12 @@ module YARP
     end
   end
 
-  # This lexes with the Ripper lex. It drops any space events but otherwise
-  # returns the same tokens.
-  # [raises SyntaxError] if the syntax in source is invalid
-  def self.lex_ripper(source)
-    previous = []
-    results = []
-
-    Ripper.lex(source, raise_errors: true).each do |token|
-      case token[1]
-      when :on_sp
-        # skip
-      when :on_tstring_content
-        if previous[1] == :on_tstring_content &&
-            (token[2].start_with?("\#$") || token[2].start_with?("\#@"))
-          previous[2] << token[2]
-        else
-          results << token
-          previous = token
-        end
-      when :on_words_sep
-        if previous[1] == :on_words_sep
-          previous[2] << token[2]
-        else
-          results << token
-          previous = token
-        end
-      else
-        results << token
-        previous = token
-      end
-    end
-
-    results
-  end
-
   # Load the serialized AST using the source as a reference into a tree.
   def self.load(source, serialized)
     Serialize.load(source, serialized)
   end
 
-  def self.parse(source, filepath=nil)
+  def self.parse(source, filepath = nil)
     _parse(source, filepath)
   end
 end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -239,6 +239,8 @@ module YARP
     Serialize.load(source, serialized)
   end
 
+  # Parse the given source into an AST. Optionally provide a filepath that this
+  # source comes from.
   def self.parse(source, filepath = nil)
     _parse(source, filepath)
   end
@@ -253,6 +255,9 @@ require "yarp.so"
 
 module YARP
   class << self
+    # This method comes from the C extension. Calling it this way makes it
+    # easier to handle default arguments in Ruby, and provides a source location
+    # for the method.
     private :_parse
   end
 end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -21,7 +21,7 @@ module YARP
     end
 
     def column(offset)
-      newlines[line_number(offset)] || 0
+      offset - newlines[line(offset) - 1]
     end
   end
 
@@ -29,7 +29,7 @@ module YARP
   class Location
     # A SourceRange object that is used to determine more information from the
     # given offset and length.
-    attr_reader :source_range
+    private attr_reader :source_range
 
     # The byte offset from the beginning of the source where this location
     # starts.
@@ -61,7 +61,7 @@ module YARP
 
     # The line number where this location ends.
     def end_line
-      source_range.line(end_offset)
+      source_range.line(end_offset - 1)
     end
 
     # The column number in bytes where this location starts from the start of
@@ -73,7 +73,7 @@ module YARP
     # The column number in bytes where this location ends from the start of the
     # line.
     def end_column
-      source_range.column(end_offset)
+      source_range.column(end_offset - 1)
     end
 
     def deconstruct_keys(keys)

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -714,4 +714,39 @@ module YARP
   def self.lex_compat(source, filepath = "")
     LexCompat.new(source, filepath).result
   end
+
+  # This lexes with the Ripper lex. It drops any space events but otherwise
+  # returns the same tokens. Raises SyntaxError if the syntax in source is
+  # invalid.
+  def self.lex_ripper(source)
+    previous = []
+    results = []
+
+    Ripper.lex(source, raise_errors: true).each do |token|
+      case token[1]
+      when :on_sp
+        # skip
+      when :on_tstring_content
+        if previous[1] == :on_tstring_content &&
+            (token[2].start_with?("\#$") || token[2].start_with?("\#@"))
+          previous[2] << token[2]
+        else
+          results << token
+          previous = token
+        end
+      when :on_words_sep
+        if previous[1] == :on_words_sep
+          previous[2] << token[2]
+        else
+          results << token
+          previous = token
+        end
+      else
+        results << token
+        previous = token
+      end
+    end
+
+    results
+  end
 end

--- a/src/util/yp_newline_list.c
+++ b/src/util/yp_newline_list.c
@@ -31,7 +31,7 @@ yp_newline_list_append(yp_newline_list_t *list, const char *cursor) {
     }
 
     assert(cursor >= list->start);
-    list->offsets[list->size++] = (size_t) (cursor - list->start);
+    list->offsets[list->size++] = (size_t) (cursor - list->start + 1);
 
     return true;
 }

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -2,13 +2,14 @@
 #include "yarp/extension.h"
 
 extern VALUE rb_cYARP;
+extern VALUE rb_cYARPSourceRange;
 extern VALUE rb_cYARPToken;
 extern VALUE rb_cYARPLocation;
 
 static VALUE
-location_new(yp_parser_t *parser, const char *start, const char *end) {
-    VALUE argv[] = { LONG2FIX(start - parser->start), LONG2FIX(end - start) };
-    return rb_class_new_instance(2, argv, rb_cYARPLocation);
+location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source_range) {
+    VALUE argv[] = { source_range, LONG2FIX(start - parser->start), LONG2FIX(end - start) };
+    return rb_class_new_instance(3, argv, rb_cYARPLocation);
 }
 
 static VALUE
@@ -16,21 +17,8 @@ yp_string_new(yp_string_t *string, rb_encoding *encoding) {
     return rb_enc_str_new(yp_string_source(string), yp_string_length(string), encoding);
 }
 
-VALUE
-yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding) {
-    ID type = rb_intern(yp_token_type_to_str(token->type));
-    VALUE argv[] = {
-        ID2SYM(type),
-        rb_enc_str_new(token->start, token->end - token->start, encoding),
-        LONG2FIX(token->start - parser->start),
-        LONG2FIX(token->end - token->start)
-    };
-
-    return rb_class_new_instance(4, argv, rb_cYARPToken);
-}
-
-VALUE
-yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *constants) {
+static VALUE
+yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encoding *encoding, ID *constants) {
     switch (node->type) {
         <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
@@ -38,19 +26,19 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
             <%- if node.params.any? -%>
             yp_<%= node.human %>_t *cast = (yp_<%= node.human %>_t *) node;
             <%- end -%>
-            VALUE argv[<%= node.params.length + 2 %>];
+            VALUE argv[<%= node.params.length + 1 %>];
             <%- node.params.each_with_index do |param, index| -%>
 
             // <%= param.name %>
             <%- case param -%>
             <%- when NodeParam -%>
-            argv[<%= index %>] = yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, encoding, constants);
+            argv[<%= index %>] = yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source_range, encoding, constants);
             <%- when OptionalNodeParam -%>
-            argv[<%= index %>] = cast-><%= param.name %> == NULL ? Qnil : yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, encoding, constants);
+            argv[<%= index %>] = cast-><%= param.name %> == NULL ? Qnil : yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source_range, encoding, constants);
             <%- when NodeListParam -%>
             argv[<%= index %>] = rb_ary_new();
             for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
-                rb_ary_push(argv[<%= index %>], yp_node_new(parser, cast-><%= param.name %>.nodes[index], encoding, constants));
+                rb_ary_push(argv[<%= index %>], yp_node_new(parser, cast-><%= param.name %>.nodes[index], source_range, encoding, constants));
             }
             <%- when StringParam -%>
             argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
@@ -58,7 +46,7 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
             argv[<%= index %>] = rb_ary_new();
             for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
                 yp_location_t location = cast-><%= param.name %>.locations[index];
-                rb_ary_push(argv[<%= index %>], location_new(parser, location.start, location.end));
+                rb_ary_push(argv[<%= index %>], location_new(parser, location.start, location.end, source_range));
             }
             <%- when ConstantParam -%>
             argv[<%= index %>] = rb_id2sym(constants[cast-><%= param.name %> - 1]);
@@ -68,9 +56,9 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
                 rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= param.name %>.ids[index] - 1]));
             }
             <%- when LocationParam -%>
-            argv[<%= index %>] = location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end);
+            argv[<%= index %>] = location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source_range);
             <%- when OptionalLocationParam -%>
-            argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end);
+            argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source_range);
             <%- when UInt32Param -%>
             argv[<%= index %>] = ULONG2NUM(cast-><%= param.name %>);
             <%- else -%>
@@ -79,10 +67,8 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
             <%- end -%>
 
             // location
-            argv[<%= node.params.length %>] = LONG2FIX(node->location.start - parser->start);
-            argv[<%= node.params.length + 1 %>] = LONG2FIX(node->location.end - node->location.start);
-
-            return rb_class_new_instance(<%= node.params.length + 2 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>")));
+            argv[<%= node.params.length %>] = location_new(parser, node->location.start, node->location.end, source_range);
+            return rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>")));
         }
         <%- end -%>
         default:
@@ -91,7 +77,36 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding, ID *con
 }
 
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
+VALUE
+yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source_range) {
+    ID type = rb_intern(yp_token_type_to_str(token->type));
+    VALUE location = location_new(parser, token->start, token->end, source_range);
+
+    VALUE argv[] = {
+        ID2SYM(type),
+        rb_enc_str_new(token->start, token->end - token->start, encoding),
+        location
+    };
+
+    return rb_class_new_instance(3, argv, rb_cYARPToken);
+}
+
+// Create a YARP::Source object from the given parser.
+VALUE
+yp_source_range_new(yp_parser_t *parser) {
+    VALUE source = rb_str_new(parser->start, parser->end - parser->start);
+    VALUE newlines = rb_ary_new_capa(parser->newline_list.size);
+
+    for (size_t index = 0; index < parser->newline_list.size; index++) {
+        rb_ary_push(newlines, INT2FIX(parser->newline_list.offsets[index]));
+    }
+
+    VALUE source_argv[] = { source, newlines };
+    return rb_class_new_instance(2, source_argv, rb_cYARPSourceRange);
+}
+
 VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
+    VALUE source = yp_source_range_new(parser);
     ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
 
     for (size_t index = 0; index < parser->constant_pool.capacity; index++) {
@@ -102,7 +117,7 @@ VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
         }
     }
 
-    VALUE res_node = yp_node_new(parser, node, encoding, constants);
+    VALUE res_node = yp_node_new(parser, node, source, encoding, constants);
     free(constants);
     return res_node;
 }

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -2,13 +2,13 @@
 #include "yarp/extension.h"
 
 extern VALUE rb_cYARP;
-extern VALUE rb_cYARPSourceRange;
+extern VALUE rb_cYARPSource;
 extern VALUE rb_cYARPToken;
 extern VALUE rb_cYARPLocation;
 
 static VALUE
-location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source_range) {
-    VALUE argv[] = { source_range, LONG2FIX(start - parser->start), LONG2FIX(end - start) };
+location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source) {
+    VALUE argv[] = { source, LONG2FIX(start - parser->start), LONG2FIX(end - start) };
     return rb_class_new_instance(3, argv, rb_cYARPLocation);
 }
 
@@ -18,7 +18,7 @@ yp_string_new(yp_string_t *string, rb_encoding *encoding) {
 }
 
 static VALUE
-yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encoding *encoding, ID *constants) {
+yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source, rb_encoding *encoding, ID *constants) {
     switch (node->type) {
         <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
@@ -32,13 +32,13 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encodin
             // <%= param.name %>
             <%- case param -%>
             <%- when NodeParam -%>
-            argv[<%= index %>] = yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source_range, encoding, constants);
+            argv[<%= index %>] = yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source, encoding, constants);
             <%- when OptionalNodeParam -%>
-            argv[<%= index %>] = cast-><%= param.name %> == NULL ? Qnil : yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source_range, encoding, constants);
+            argv[<%= index %>] = cast-><%= param.name %> == NULL ? Qnil : yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source, encoding, constants);
             <%- when NodeListParam -%>
             argv[<%= index %>] = rb_ary_new();
             for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
-                rb_ary_push(argv[<%= index %>], yp_node_new(parser, cast-><%= param.name %>.nodes[index], source_range, encoding, constants));
+                rb_ary_push(argv[<%= index %>], yp_node_new(parser, cast-><%= param.name %>.nodes[index], source, encoding, constants));
             }
             <%- when StringParam -%>
             argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
@@ -46,7 +46,7 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encodin
             argv[<%= index %>] = rb_ary_new();
             for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
                 yp_location_t location = cast-><%= param.name %>.locations[index];
-                rb_ary_push(argv[<%= index %>], location_new(parser, location.start, location.end, source_range));
+                rb_ary_push(argv[<%= index %>], location_new(parser, location.start, location.end, source));
             }
             <%- when ConstantParam -%>
             argv[<%= index %>] = rb_id2sym(constants[cast-><%= param.name %> - 1]);
@@ -56,9 +56,9 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encodin
                 rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= param.name %>.ids[index] - 1]));
             }
             <%- when LocationParam -%>
-            argv[<%= index %>] = location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source_range);
+            argv[<%= index %>] = location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
             <%- when OptionalLocationParam -%>
-            argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source_range);
+            argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
             <%- when UInt32Param -%>
             argv[<%= index %>] = ULONG2NUM(cast-><%= param.name %>);
             <%- else -%>
@@ -67,7 +67,7 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encodin
             <%- end -%>
 
             // location
-            argv[<%= node.params.length %>] = location_new(parser, node->location.start, node->location.end, source_range);
+            argv[<%= node.params.length %>] = location_new(parser, node->location.start, node->location.end, source);
             return rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>")));
         }
         <%- end -%>
@@ -78,9 +78,9 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source_range, rb_encodin
 
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
 VALUE
-yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source_range) {
+yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source) {
     ID type = rb_intern(yp_token_type_to_str(token->type));
-    VALUE location = location_new(parser, token->start, token->end, source_range);
+    VALUE location = location_new(parser, token->start, token->end, source);
 
     VALUE argv[] = {
         ID2SYM(type),
@@ -93,7 +93,7 @@ yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALU
 
 // Create a YARP::Source object from the given parser.
 VALUE
-yp_source_range_new(yp_parser_t *parser) {
+yp_source_new(yp_parser_t *parser) {
     VALUE source = rb_str_new(parser->start, parser->end - parser->start);
     VALUE offsets = rb_ary_new_capa(parser->newline_list.size);
 
@@ -102,11 +102,11 @@ yp_source_range_new(yp_parser_t *parser) {
     }
 
     VALUE source_argv[] = { source, offsets };
-    return rb_class_new_instance(2, source_argv, rb_cYARPSourceRange);
+    return rb_class_new_instance(2, source_argv, rb_cYARPSource);
 }
 
 VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
-    VALUE source = yp_source_range_new(parser);
+    VALUE source = yp_source_new(parser);
     ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
 
     for (size_t index = 0; index < parser->constant_pool.capacity; index++) {

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -95,13 +95,13 @@ yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALU
 VALUE
 yp_source_range_new(yp_parser_t *parser) {
     VALUE source = rb_str_new(parser->start, parser->end - parser->start);
-    VALUE newlines = rb_ary_new_capa(parser->newline_list.size);
+    VALUE offsets = rb_ary_new_capa(parser->newline_list.size);
 
     for (size_t index = 0; index < parser->newline_list.size; index++) {
-        rb_ary_push(newlines, INT2FIX(parser->newline_list.offsets[index]));
+        rb_ary_push(offsets, INT2FIX(parser->newline_list.offsets[index]));
     }
 
-    VALUE source_argv[] = { source, newlines };
+    VALUE source_argv[] = { source, offsets };
     return rb_class_new_instance(2, source_argv, rb_cYARPSourceRange);
 }
 

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -6,13 +6,12 @@ module YARP
     attr_reader :<%= param.name %>
 
     <%- end -%>
-    # def initialize: (<%= (node.params.map { |param| "#{param.name}: #{param.rbs_class}" } + ["start_offset: Integer", "length: Integer"]).join(", ") %>) -> void
-    def initialize(<%= (node.params.map(&:name) + ["start_offset", "length"]).join(", ") %>)
+    # def initialize: (<%= (node.params.map { |param| "#{param.name}: #{param.rbs_class}" } + ["location: Location"]).join(", ") %>) -> void
+    def initialize(<%= (node.params.map(&:name) + ["location"]).join(", ") %>)
       <%- node.params.each do |param| -%>
       @<%= param.name %> = <%= param.name %>
       <%- end -%>
-      @start_offset = start_offset
-      @length = length
+      @location = location
     end
 
     # def accept: (visitor: Visitor) -> void
@@ -62,14 +61,14 @@ module YARP
     private
 
     # Create a new Location object
-    def Location(start_offset = 0, length = 0)
-      Location.new(start_offset, length)
+    def Location(source = nil, start_offset = 0, length = 0)
+      Location.new(source, start_offset, length)
     end
     <%- nodes.each do |node| -%>
 
     # Create a new <%= node.name %> node
-    def <%= node.name %>(<%= node.params.map(&:name).join(", ") %>)
-      <%= node.name %>.new(<%= (node.params.map(&:name) + ["0", "0"]).join(", ") %>)
+    def <%= node.name %>(<%= (node.params.map(&:name) + ["location = Location()"]).join(", ") %>)
+      <%= node.name %>.new(<%= (node.params.map(&:name) + ["location"]).join(", ") %>)
     end
     <%- end -%>
   end

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -69,6 +69,24 @@ module YARP
   end
 
   <%- end -%>
+  # A class that knows how to walk down the tree. None of the individual visit
+  # methods are implemented on this visitor, so it forces the consumer to
+  # implement each one that they need. For a default implementation that
+  # continues walking the tree, see the Visitor class.
+  class BasicVisitor
+    def visit(node)
+      node&.accept(self)
+    end
+
+    def visit_all(nodes)
+      nodes.map { |node| visit(node) }
+    end
+
+    def visit_child_nodes(node)
+      visit_all(node.child_nodes)
+    end
+  end
+
   class Visitor < BasicVisitor
     <%- nodes.each do |node| -%>
     # Visit a <%= node.name %> node

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -36,6 +36,24 @@ module YARP
     def deconstruct_keys(keys)
       { <%= (node.params.map { |param| "#{param.name}: #{param.name}" } + ["location: location"]).join(", ") %> }
     end
+    <%- node.params.each do |param| -%>
+    <%- case param -%>
+    <%- when LocationParam -%>
+    <%- raise unless param.name.end_with?("_loc") -%>
+
+    # def <%= param.name.delete_suffix("_loc") %>: () -> String
+    def <%= param.name.delete_suffix("_loc") %>
+      <%= param.name %>.slice
+    end
+    <%- when OptionalLocationParam -%>
+    <%- raise unless param.name.end_with?("_loc") -%>
+
+    # def <%= param.name.delete_suffix("_loc") %>: () -> String?
+    def <%= param.name.delete_suffix("_loc") %>
+      <%= param.name %>&.slice
+    end
+    <%- end -%>
+    <%- end -%>
   end
 
   <%- end -%>

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -40,6 +40,7 @@ module YARP
     <%- case param -%>
     <%- when LocationParam -%>
     <%- raise unless param.name.end_with?("_loc") -%>
+    <%- next if node.params.any? { |other| other.name == param.name.delete_suffix("_loc") } -%>
 
     # def <%= param.name.delete_suffix("_loc") %>: () -> String
     def <%= param.name.delete_suffix("_loc") %>
@@ -47,6 +48,7 @@ module YARP
     end
     <%- when OptionalLocationParam -%>
     <%- raise unless param.name.end_with?("_loc") -%>
+    <%- next if node.params.any? { |other| other.name == param.name.delete_suffix("_loc") } -%>
 
     # def <%= param.name.delete_suffix("_loc") %>: () -> String?
     def <%= param.name.delete_suffix("_loc") %>

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -23,9 +23,9 @@ module YARP
         @constant_pool_offset = nil
         @constant_pool = nil
 
-        newlines = [0]
-        source.b.scan("\n") { newlines << $~.offset(0)[0] + 1 }
-        @source_range = SourceRange.new(source, newlines)
+        offsets = [0]
+        source.b.scan("\n") { offsets << $~.offset(0)[0] + 1 }
+        @source_range = SourceRange.new(source, offsets)
       end
 
       def load

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -2,21 +2,21 @@ require "stringio"
 
 module YARP
   module Serialize
-    def self.load(source, serialized)
+    def self.load(input, serialized)
       io = StringIO.new(serialized)
       io.set_encoding(Encoding::BINARY)
 
-      Loader.new(source, serialized, io).load
+      Loader.new(input, serialized, io).load
     end
 
     class Loader
-      attr_reader :encoding, :source, :serialized, :io
-      attr_reader :constant_pool_offset, :constant_pool, :source_range
+      attr_reader :encoding, :input, :serialized, :io
+      attr_reader :constant_pool_offset, :constant_pool, :source
 
-      def initialize(source, serialized, io)
+      def initialize(input, serialized, io)
         @encoding = Encoding::UTF_8
 
-        @source = source.dup
+        @input = input.dup
         @serialized = serialized
         @io = io
 
@@ -24,8 +24,8 @@ module YARP
         @constant_pool = nil
 
         offsets = [0]
-        source.b.scan("\n") { offsets << $~.offset(0)[0] + 1 }
-        @source_range = SourceRange.new(source, offsets)
+        input.b.scan("\n") { offsets << $~.offset(0)[0] + 1 }
+        @source = Source.new(input, offsets)
       end
 
       def load
@@ -33,7 +33,7 @@ module YARP
         io.read(3).unpack("C3") => [0, 4, 0]
 
         @encoding = Encoding.find(io.read(load_varint))
-        @source = source.force_encoding(@encoding).freeze
+        @input = input.force_encoding(@encoding).freeze
 
         @constant_pool_offset = io.read(4).unpack1("L")
         @constant_pool = Array.new(load_varint, nil)
@@ -75,7 +75,7 @@ module YARP
       end
 
       def load_location
-        Location.new(source_range, load_varint, load_varint)
+        Location.new(source, load_varint, load_varint)
       end
 
       def load_optional_location
@@ -92,7 +92,7 @@ module YARP
           start = serialized.unpack1("L", offset: offset)
           length = serialized.unpack1("L", offset: offset + 4)
 
-          constant = source.byteslice(start, length).to_sym
+          constant = input.byteslice(start, length).to_sym
           constant_pool[index] = constant
         end
 

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -24,7 +24,7 @@ module YARP
         @constant_pool = nil
 
         newlines = [0]
-        source.b.scan("\n") { newlines << $~.offset(0)[0] }
+        source.b.scan("\n") { newlines << $~.offset(0)[0] + 1 }
         @source_range = SourceRange.new(source, newlines)
       end
 

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -11,7 +11,7 @@ module YARP
 
     class Loader
       attr_reader :encoding, :source, :serialized, :io
-      attr_reader :constant_pool_offset, :constant_pool
+      attr_reader :constant_pool_offset, :constant_pool, :source_range
 
       def initialize(source, serialized, io)
         @encoding = Encoding::UTF_8
@@ -22,6 +22,7 @@ module YARP
 
         @constant_pool_offset = nil
         @constant_pool = nil
+        @source_range = SourceRange.new(source, [])
       end
 
       def load
@@ -71,7 +72,7 @@ module YARP
       end
 
       def load_location
-        Location.new(load_varint, load_varint)
+        Location.new(source_range, load_varint, load_varint)
       end
 
       def load_optional_location
@@ -97,7 +98,7 @@ module YARP
 
       def load_node
         type = io.getbyte
-        start_offset, length = load_varint, load_varint
+        location = load_location
 
         case type
         <%- nodes.each_with_index do |node, index| -%>
@@ -119,7 +120,7 @@ module YARP
             when UInt32Param then "load_varint"
             else raise
             end
-          } + ["start_offset", "length"]).join(", ") -%>)
+          } + ["location"]).join(", ") -%>)
           <%- end -%>
         end
       end

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -22,7 +22,10 @@ module YARP
 
         @constant_pool_offset = nil
         @constant_pool = nil
-        @source_range = SourceRange.new(source, [])
+
+        newlines = [0]
+        source.b.scan("\n") { newlines << $~.offset(0)[0] }
+        @source_range = SourceRange.new(source, newlines)
       end
 
       def load

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -84,7 +84,7 @@ class ParseTest < Test::Unit::TestCase
 
       # Next, assert that the newlines are in the expected places.
       expected_newlines = [0]
-      source.b.scan("\n") { expected_newlines << $~.offset(0)[0] }
+      source.b.scan("\n") { expected_newlines << $~.offset(0)[0] + 1 }
       assert_equal expected_newlines, YARP.newlines(source)
 
       # Finally, assert that we can lex the source and get the same tokens as


### PR DESCRIPTION
This PR adds a bunch of functionality to the Ruby extension.

Every `YARP::Node`, `YARP::Token`, `YARP::Comment`, `YARP::Error`, and `YARP::Warning` now have a `YARP::Location` instance. (We were previously relatively inconsistent between using a location vs using start_offset + length. Now we just have a single object.)

`YARP::Location` instances now have the following instance variables. They are all given in the initializer/constructed by the parser in the extension:

* `@source` - a `YARP::Source` object
* `@start_offset` - the start offset of the node in the source
* `@length` - the length of the node in the source

`YARP::Location` instances now have the following methods:

* `#start_offset` - returns the instance variable
* `#end_offset` - returns the instance variable + the length
* `#length` - returns the instance variable
* `#start_line` - queries the source range object for a line number with the start offset
* `#end_line` - queries the source range object for a line number with the end offset
* `#start_column` - queries the source range object for a column number with the start offset
* `#end_column` - queries the source range object for a column number with the end offset
* `#slice` - returns a slice of the source string represented by the location

`YARP::SourceRange` instances are generally shared between all of the locations within a tree. They are constructed by the parser in the extension. They have the following instance variables:

* `@source` - the source string
* `@offsets` - an array of line offsets (the offset of the start of each line)

`YARP::Source` instances have the following methods:

* `#line(value)` - returns the line number of the given offset
* `#column(value)` - returns the column number of the given offset
* `#slice(offset, length)` - returns a slice of the source string

Built on top of all of this are some nice convenience APIs that we template onto each node now whenever you have location parameters. For example, now you can call `IfNode#if_keyword` to receive back a string that is sliced from the source (typically either `"if"` or `"elsif"`). This is also nice in places like `SymbolNode#content` that returns a string that is sliced from the source.

These APIs could be improved by using a better data structure like a succinct bit vector to store the line offsets (https://techlife.cookpad.com/entry/2018/10/17/115126), but fortunately the user-facing side would not need to change. cc @mame