### PR TITLE
Free resources in heisenbug

### DIFF
--- a/fuzz/heisenbug.c
+++ b/fuzz/heisenbug.c
@@ -18,5 +18,6 @@ LLVMFuzzerTestOneInput(const char *input, size_t size) {
         mutation_buffer[size] = (char)i;
         harness(mutation_buffer, size);
     }
+    free(mutation_buffer);
     return 0;
 }


### PR DESCRIPTION
ASAN may detect a memory leak if we don't free ```mutation_buffer```.