### PR TITLE
Fix header dependency in Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,6 +25,9 @@ all: shared static
 shared: build/librubyparser.$(SOEXT)
 static: build/librubyparser.a
 
+$(SHARED_OBJECTS): Makefile $(HEADERS)
+$(STATIC_OBJECTS): Makefile $(HEADERS)
+
 build/librubyparser.$(SOEXT): $(SHARED_OBJECTS)
 	$(ECHO) "linking $@"
 	$(Q) $(CC) $(DEBUG_FLAGS) $(CFLAGS) -shared -o $@ $(SHARED_OBJECTS)


### PR DESCRIPTION
Fix header dependency to ensure that `include/yarp/ast.h` is generated when running 'make'.

Also remove template files from the Makefile `clean` target because these aren't generated by the Makefile, and are more robustly removed by `rake clobber` anyway.
