### PR TITLE
YARP gem sets `required_ruby_version` to `>= 3.0.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "head"]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby ">= 2.7.0"
+ruby ">= 3.0.0"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby ">= 3.1.0"
+ruby ">= 2.7.0"
 
 gemspec
 

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -89,8 +89,13 @@ module YARP
         unless constant
           offset = constant_pool_offset + index * 8
 
-          start = serialized.unpack1("L", offset: offset)
-          length = serialized.unpack1("L", offset: offset + 4)
+          if RUBY_VERSION >= "3.1"
+            start = serialized.unpack1("L", offset: offset)
+            length = serialized.unpack1("L", offset: offset + 4)
+          else
+            start = serialized[offset..].unpack1("L")
+            length = serialized[offset+4..].unpack1("L")
+          end
 
           constant = input.byteslice(start, length).to_sym
           constant_pool[index] = constant

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/ruby/yarp"
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 2.7.0"
+
   spec.require_paths = ["lib"]
   spec.files = [
     "CODE_OF_CONDUCT.md",

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/ruby/yarp"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.require_paths = ["lib"]
   spec.files = [


### PR DESCRIPTION
This PR suggests that YARP gem should support being run by Ruby >= 3.0. It also adds test coverage to ensure compatibility.

I'm not sure what the YARP project committers want to support, so (hopefully obviously) I'm not expressing a strong opinion here.

_Note: this PR was originally attempting support for running with 2.7, I changed to 3.0 to attempt a more modest goal._