### PR TITLE
Fix up the gemspec and the manifest check

### DIFF
--- a/tasks/check_manifest.rake
+++ b/tasks/check_manifest.rake
@@ -36,7 +36,7 @@ task :check_manifest => [:templates, "configure"] do
     java/org/yarp/Loader.java
     java/org/yarp/Nodes.java
     java/org/yarp/Parser.java
-    lib/yarp.{jar,so}
+    lib/yarp.{jar,so,bundle}
   ]
 
   intended_directories = Dir.children(".")
@@ -64,3 +64,5 @@ task :check_manifest => [:templates, "configure"] do
 
   puts "☑  manifest looks good"
 end
+
+task test: :check_manifest

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -101,7 +101,6 @@ Gem::Specification.new do |spec|
     "src/util/yp_list.c",
     "src/util/yp_memchr.c",
     "src/util/yp_newline_list.c",
-    "src/util/yp_snprintf.c",
     "src/util/yp_state_stack.c",
     "src/util/yp_string.c",
     "src/util/yp_string_list.c",


### PR DESCRIPTION
- ignore lib/yarp.bundle
- :check_manifest task is a dependency of :test
- remove yp_snprintf.c from the gemspec (see 4793b1ce / #962)