### PR TITLE
Allow installation of discoverable C API development files

### DIFF
--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -56,7 +56,6 @@ module Yarp
       end
 
       def build_target_rubyparser(target)
-        # explicit "sh" is used for Windows where shebangs are not supported
         Dir.chdir(root_dir) do
           if !File.exist?("configure") && Dir.exist?(".git")
             # this block only exists to support building the gem from a "git" source,

--- a/lib/yarp/c_api.rb
+++ b/lib/yarp/c_api.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+#  this file should only be required when building against YARP's C API
+#
+
+unless Dir.exist?(File.join(__dir__, 'c_api'))
+  raise LoadError, "Yarp's C API is not installed. Please re-install with the --install-c-api flag."
+end
+
+module Yarp
+  module CAPI
+    CPPFLAGS = ["-I#{File.join(__dir__, "c_api", "include")}"]
+    LDFLAGS = [File.join(__dir__, "c_api", "lib", "librubyparser.a")]
+  end
+end

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -187,6 +187,7 @@ end
 # This templates out a file using ERB with the given locals. The locals are
 # derived from the config.yml file.
 def template(name, locals)
+  puts "Generating #{name}..."
   filepath = "templates/#{name}.erb"
   template = File.expand_path("../#{filepath}", __dir__)
   write_to = File.expand_path("../#{name}", __dir__)

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
     "include/yarp/util/yp_strpbrk.h",
     "include/yarp/version.h",
     "lib/yarp.rb",
+    "lib/yarp/c_api.rb",
     "lib/yarp/lex_compat.rb",
     "lib/yarp/node.rb",
     "lib/yarp/pack.rb",


### PR DESCRIPTION
## The problem I'm trying to address

The use case I'm trying to address here is that of a downstream C extension that wishes to integrate with the yarp gem's C API.

We don't export the C API from `yarp.{so,bundle}` and so (for example) downstream C extensions can't resolve the symbol `yp_parse` from that shared object.

## The implementation of this solution

This PR presents one possible solution:

- support for a `--install-c-api` flag at gem install time, which installs header files and librubyparser.a as part of the gem installation footprint
- a standalone ruby file `yarp/c_api` which provides CPPFLAGS and LDFLAGS to allow compilation and linking to happen

So usage might look like this:

```
$ gem install yarp -- --install-c-api
Building native extensions with: '--install-c-api'
This could take a while...
Successfully installed yarp-0.4.0
```

and then the downstream consumer's `extconf.rb` could look something like this:

```ruby
# frozen_string_literal: true
require "mkmf"

require "yarp/c_api"
append_cppflags(*Yarp::CAPI::CPPFLAGS)
append_ldflags(*Yarp::CAPI::LDFLAGS)

append_cflags("-fvisibility=hidden")

create_makefile("ruby_indexer/ruby_indexer")
```

If the gem is installed without `--install-c-api` then requiring `yarp/c_api` will raise a `LoadError` exception:

```
warning: LoadError: Yarp's C API is not installed. Please re-install with the --install-c-api flag.
```

## Alternative solutions

One idea is to ship a separate gem which contains the C API development files, but version it the same as the `yarp` gem so there's a one-to-one correspondence between them. So users of the C API would do:

```
gem "yarp-c-api"
```

## Reasons not to do this?

Is the C API going to be stable enough to package and version like this? @eregon brings up some valid points [below](https://github.com/ruby/yarp/pull/1149#issuecomment-1642833806):

> Node structs might be public currently but I'm not sure they should stay so (except for CRuby of course), I would see them as implementation details and it's definitely much harder to evolve in a compatible way than a Ruby API.
> (note: exposing struct members in a C API is often considered a mistake in terms of API evolution)

