### PR TITLE
Allow the gem to be used from a Gemfile "git:" source

### DIFF
--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -61,11 +61,11 @@ module Yarp
           if !File.exist?("configure") && Dir.exist?(".git")
             # this block only exists to support building the gem from a "git" source,
             # normally we package up the configure and other files in the gem itself
-            Rake.sh("sh autoconf")
-            Rake.sh("sh autoheader")
-            Rake.sh("rake templates")
+            Rake.sh("sh", "autoconf")
+            Rake.sh("sh", "autoheader")
+            Rake.sh("rake","templates")
           end
-          Rake.sh("sh configure")
+          Rake.sh("sh", "configure")
           Rake.sh("make", target)
         end
       end

--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -56,8 +56,16 @@ module Yarp
       end
 
       def build_target_rubyparser(target)
+        # explicit "sh" is used for Windows where shebangs are not supported
         Dir.chdir(root_dir) do
-          Rake.sh("sh configure") # explicit "sh" for Windows where shebangs are not supported
+          if !File.exist?("configure") && Dir.exist?(".git")
+            # this block only exists to support building the gem from a "git" source,
+            # normally we package up the configure and other files in the gem itself
+            Rake.sh("sh autoconf")
+            Rake.sh("sh autoheader")
+            Rake.sh("rake templates")
+          end
+          Rake.sh("sh configure")
           Rake.sh("make", target)
         end
       end


### PR DESCRIPTION
This, naturally, means that we need to run autoconf and generate the template files, which increases the requirements on the installation target system.