### PR TITLE
extconf.rb: using "sh" when unnecessary won't work on some systems

### DIFF
--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -61,11 +61,11 @@ module Yarp
           if !File.exist?("configure") && Dir.exist?(".git")
             # this block only exists to support building the gem from a "git" source,
             # normally we package up the configure and other files in the gem itself
-            Rake.sh("sh", "autoconf")
-            Rake.sh("sh", "autoheader")
-            Rake.sh("rake","templates")
+            Rake.sh("autoconf")
+            Rake.sh("autoheader")
+            Rake.sh("rake", "templates")
           end
-          Rake.sh("sh", "configure")
+          Rake.sh("sh", "configure") # explicit "sh" for Windows where shebangs are not supported
           Rake.sh("make", target)
         end
       end


### PR DESCRIPTION
While running commands with "sh" works on MacOS and Windows, it won't work on some Linux systems (where the command won't be found).

Let's remove it for "autoconf" and "autoheader" until we actually see a need for it.
