### PR TITLE
extconf.rb: avoid invoking "rake" to generate templates

### DIFF
--- a/ext/yarp/extconf.rb
+++ b/ext/yarp/extconf.rb
@@ -56,14 +56,13 @@ module Yarp
       end
 
       def build_target_rubyparser(target)
-        # explicit "sh" is used for Windows where shebangs are not supported
         Dir.chdir(root_dir) do
           if !File.exist?("configure") && Dir.exist?(".git")
             # this block only exists to support building the gem from a "git" source,
             # normally we package up the configure and other files in the gem itself
             Rake.sh("autoconf")
             Rake.sh("autoheader")
-            Rake.sh("rake", "templates")
+            Rake.sh("templates/template.rb")
           end
           Rake.sh("sh", "configure") # explicit "sh" for Windows where shebangs are not supported
           Rake.sh("make", target)


### PR DESCRIPTION
because we can not rely on development dependencies being present at install time (like ruby_memcheck).