### PR TITLE
Exclude heredoc_nested test for Rubies < 3.3

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -30,6 +30,10 @@ class ParseTest < Test::Unit::TestCase
     seattlerb/heredoc_nested.txt
   ]
 
+  if RUBY_VERSION < "3.3.0"
+    known_failures << "seattlerb/pct_w_heredoc_interp_nested.txt"
+  end
+
   def find_source_file_node(node)
     if node.is_a?(YARP::SourceFileNode)
       node


### PR DESCRIPTION
Ripper's lexemes were slightly different in Ruby 3.2 for Heredocs. We ignored this complex heredoc test in this case because Ripper's output has changed