### PR TITLE
Do not define _XOPEN_SOURCE, it is not needed anymore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 AC_INIT([YARP],[_YP_VERSION],[https://github.com/ruby/yarp/issues/new],[yarp],[https://github.com/ruby/yarp])
 
 AC_PROG_CC
-AC_DEFINE([_XOPEN_SOURCE], [700], [_XOPEN_SOURCE])
 
 AC_CHECK_FUNCS([mmap])
 AC_CHECK_FUNCS([snprintf])


### PR DESCRIPTION
* It used to be needed for strnlen() and strncasecmp(), but we don't use both of these anymore. See https://github.com/ruby/yarp/pull/1164#issuecomment-1646565625
* It causes warnings in clang on macOS, see https://github.com/ruby/yarp/pull/1164