### PR TITLE
Allow JRuby to run Rakefile and compile Java bits + libparser.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test-native/run-one
 /java/org/yarp/Nodes.java
 /lib/yarp/node.rb
 /lib/yarp/serialize.rb
+/lib/yarp/compile.jar
 /src/node.c
 /src/prettyprint.c
 /src/serialize.c


### PR DESCRIPTION
Does two things for JRuby run to run Rake:
 1. ruby_memcheck is not supported by JRuby so we need to exclude it.
 2. uses rake-javaextensiontask to compile java/* files.

Bonus:
 1. gitignore generated compile.jar

This minimally allows me to verify Java files compile and to generate the lib/rubyparser.{so,dylib,dll}.  Longer term I would like JRuby to be able to properly build and test the gem without having to rely on MRI to run Rake.