### PR TITLE
Ignore LSP related files from manifest

### DIFF
--- a/tasks/check_manifest.rake
+++ b/tasks/check_manifest.rake
@@ -7,6 +7,8 @@ task :check_manifest => [:templates, "configure"] do
     .idea
     .git
     .github
+    .cache
+    .ruby-lsp
     autom4te.cache
     bin
     build
@@ -33,6 +35,7 @@ task :check_manifest => [:templates, "configure"] do
     config.log
     config.status
     configure.ac
+    compile_commands.json
     include/yarp/config.h
     java/org/yarp/AbstractNodeVisitor.java
     java/org/yarp/Loader.java


### PR DESCRIPTION
Files that are auto-generated by language servers make the manifest check fail. I suggest we ignore the folders/files related to those.

- The .cache folder and compile_commands.json comes from clangd, which is very useful for working on the C part of the code
- The .ruby-lsp folder comes from the Ruby LSP