### PR TITLE
Allow JRuby to run Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,13 @@ require "rake/extensiontask"
 require "rake/testtask"
 require "rake/clean"
 require "rdoc/task"
-require "ruby_memcheck"
 
 Rake.add_rakelib("tasks")
 
-RubyMemcheck.config(binary_name: "yarp")
+if RUBY_ENGINE != "jruby"
+  require "ruby_memcheck"
+  RubyMemcheck.config(binary_name: "yarp")
+end
 
 task compile: :make
 task compile_no_debug: :make_no_debug
@@ -61,11 +63,26 @@ task build: [:templates, :check_manifest]
 
 # the C extension
 task "compile:yarp" => ["configure", "templates"] # must be before the ExtensionTask is created
-Rake::ExtensionTask.new(:compile) do |ext|
-  ext.name = "yarp"
-  ext.ext_dir = "ext/yarp"
-  ext.lib_dir = "lib"
-  ext.gem_spec = Gem::Specification.load("yarp.gemspec")
+
+if RUBY_ENGINE == 'jruby'
+  require 'rake/javaextensiontask'
+
+  # This compiles java to make sure any templating changes produces valid code.
+  Rake::JavaExtensionTask.new(:compile) do |ext|
+    ext.name = "yarp"
+    ext.ext_dir = "java"
+    ext.lib_dir = "tmp"
+    ext.source_version = "1.8"
+    ext.target_version = "1.8"
+    ext.gem_spec = Gem::Specification.load("yarp.gemspec")
+  end
+else
+  Rake::ExtensionTask.new(:compile) do |ext|
+    ext.name = "yarp"
+    ext.ext_dir = "ext/yarp"
+    ext.lib_dir = "lib"
+    ext.gem_spec = Gem::Specification.load("yarp.gemspec")
+  end
 end
 
 # So `rake clobber` will delete generated files


### PR DESCRIPTION
This PR allows:
  1. JRuby to run rake tasks
  2. Allow Java to compile any generated template code

For near term use this means for development work in YARP I can change a template and know with a rake run that I generated something which is at least valid Java.  Note: The yarp.jar created is just put into tmp since there is no immediate plan for JRuby to consume this code as a jar (it will be imported into JRuby repo).

Longer term (when fiddle impl of the gem side of YARP has landed) it will allow JRuby to test like MRI does.