### PR TITLE
Document building, more macro changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ to see the syntax tree for the expression `1 + 2`.
 
 See the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information. We additionally have documentation about the overall design of the project as well as various subtopics.
 
+* [Building](docs/building.md)
 * [Configuration](docs/configuration.md)
 * [Design](docs/design.md)
 * [Encoding](docs/encoding.md)

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,26 @@
+# Building
+
+The following describes how to build YARP from source.
+
+## Common
+
+All of the source files match `src/**/*.c` and all of the headers match `include/**/*.h`.
+
+The following flags should be used to compile YARP:
+
+* `-std=c99` - Use the C99 standard
+* `-Wall -Wconversion -Wextra -Wpedantic -Wundef` - Enable the warnings we care about
+* `-Werror` - Treat warnings as errors
+* `-fvisibility=hidden` - Hide all symbols by default
+
+The following flags can be used to compile YARP:
+
+* `-DHAVE_MMAP` - Should be passed if the system has the `mmap` function
+* `-DHAVE_SNPRINTF` - Should be passed if the system has the `snprintf` function
+
+## Shared
+
+If you want to build YARP as a shared library and link against it, you should compile with:
+
+* `-fPIC -shared` - Compile as a shared library
+* `-DYP_EXPORT_SYMBOLS` - Export the symbols (by default nothing is exported)

--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -12,18 +12,16 @@
 #include <string.h>
 
 // YP_EXPORTED_FUNCTION
-#if defined(_WIN32)
-#   define YP_EXPORTED_FUNCTION __declspec(dllexport) extern
-#elif defined(YP_EXPORT_SYMBOLS)
-#   ifndef YP_EXPORTED_FUNCTION
-#       ifndef RUBY_FUNC_EXPORTED
-#           define YP_EXPORTED_FUNCTION __attribute__((__visibility__("default"))) extern
+#ifndef YP_EXPORTED_FUNCTION
+#   ifdef YP_EXPORT_SYMBOLS
+#       ifdef _WIN32
+#          define YP_EXPORTED_FUNCTION __declspec(dllexport) extern
 #       else
-#           define YP_EXPORTED_FUNCTION RUBY_FUNC_EXPORTED
+#          define YP_EXPORTED_FUNCTION __attribute__((__visibility__("default"))) extern
 #       endif
+#   else
+#       define YP_EXPORTED_FUNCTION
 #   endif
-#else
-#   define YP_EXPORTED_FUNCTION
 #endif
 
 // YP_ATTRIBUTE_UNUSED

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
     "config.h.in",
     "config.yml",
     "configure",
+    "docs/building.md",
     "docs/configuration.md",
     "docs/design.md",
     "docs/encoding.md",


### PR DESCRIPTION
Add a document outlining which flags should be passed to the compiler.

Also revisiting symbol exports _again_. I think this is much more correct this time. I'm going to lay out my understanding here for posterity.

First, let's define a couple of concepts:

* `__attribute__((__visibility__("default")))` - GCC/Clang compiler directive to export a symbol
* `__declspec(dllexport)` - MSVC compiler directive to export a symbol
* `_WIN32` - Macro defined by MSVC to indicate that the target is Windows
* `RUBY_FUNC_EXPORTED` - Macro defined by Ruby to indicate that a symbol should be exported
* `YP_EXPORT_SYMBOLS` - Macro defined by YARP to indicate that some symbols should be exported
* `YP_EXPORTED_FUNCTION` - Macro defined by YARP to indicate that a symbol should be exported

Next, let's define the use cases:

1. You're compiling YARP vendored into something else
2. You're compiling YARP as a shared library

For case 1, you never want symbols to be exported. We are explicitly saying here we do not support the use case of embedding YARP into another project and then exporting YARP symbols from that project. For now, I think this is a good stance to take as it still supports all of our use cases.

For case 2, you always want the symbols to be exported, since you're going to load it as a shared library. We're assuming in this case that you are not _also_ building CRuby as a part of this build. Again, I think this is a good stance to take.

To tell YARP that you want to compile symbols as exported, then, we look for the `YP_EXPORT_SYMBOLS` macro. If it's defined, we will export symbols. In all cases we determine how to export symbols by defining `YP_EXPORTED_FUNCTION` to be some prefix (in some cases it is empty). Based on the information above, that now results in this table:

| `_WIN32` | `YP_EXPORT_SYMBOLS` | `YP_EXPORTED_FUNCTION` |
| --- | --- | --- |
| undefined | undefined | |
| defined | undefined | |
| undefined | defined | `__attribute__((__visibility__("default")))` |
| defined | defined | `__declspec(dllexport)` |

From my understanding, this PR should fix the issue of symbols being exported on `_WIN32` systems no matter what value `YP_EXPORT_SYMBOLS` was set to. (We haven't run into this because none of us are using windows machines for dev.) It also removes the combination of `YP_EXPORT_SYMBOLS` and `RUBY_FUNC_EXPORTED` because those two should never be defined at the same time. (We would never want to export symbols while building Ruby.)