### PR TITLE
Remove redundant ignores in check_manifest.rake

### DIFF
--- a/tasks/check_manifest.rake
+++ b/tasks/check_manifest.rake
@@ -38,10 +38,6 @@ task :check_manifest => [:templates, "configure"] do
     configure.ac
     compile_commands.json
     include/yarp/config.h
-    java/org/yarp/AbstractNodeVisitor.java
-    java/org/yarp/Loader.java
-    java/org/yarp/Nodes.java
-    java/org/yarp/Parser.java
     lib/yarp/yarp.{so,bundle,jar}
     tags
     test.c


### PR DESCRIPTION
Added by https://github.com/ruby/yarp/pull/1146 due to merge conflict most likely