### PR TITLE
Encoding boundaries

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -58,20 +58,24 @@ If the user-provided callback function returns `NULL` (the value also provided b
 // invalid for the encoding and type.
 typedef struct {
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding.
-    size_t (*char_width)(const char *c);
+    // in the encoding. Does not read more than n bytes. It is assumed that n is
+    // at least 1.
+    size_t (*char_width)(const char *c, ptrdiff_t n);
 
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding and is alphabetical.
-    size_t (*alpha_char)(const char *c);
+    // in the encoding and is alphabetical. Does not read more than n bytes. It
+    // is assumed that n is at least 1.
+    size_t (*alpha_char)(const char *c, ptrdiff_t n);
 
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding and is alphanumeric.
-    size_t (*alnum_char)(const char *c);
+    // in the encoding and is alphanumeric. Does not read more than n bytes. It
+    // is assumed that n is at least 1.
+    size_t (*alnum_char)(const char *c, ptrdiff_t n);
 
     // Return true if the next character is valid in the encoding and is an
-    // uppercase character.
-    bool (*isupper_char)(const char *c);
+    // uppercase character. Does not read more than n bytes. It is assumed that
+    // n is at least 1.
+    bool (*isupper_char)(const char *c, ptrdiff_t n);
 
     // The name of the encoding. This should correspond to a value that can be
     // passed to Encoding.find in Ruby.

--- a/include/yarp/enc/yp_encoding.h
+++ b/include/yarp/enc/yp_encoding.h
@@ -3,6 +3,7 @@
 
 #include "yarp/defines.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -13,20 +14,24 @@
 // invalid for the encoding and type.
 typedef struct {
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding.
-    size_t (*char_width)(const char *c);
+    // in the encoding. Does not read more than n bytes. It is assumed that n is
+    // at least 1.
+    size_t (*char_width)(const char *c, ptrdiff_t n);
 
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding and is alphabetical.
-    size_t (*alpha_char)(const char *c);
+    // in the encoding and is alphabetical. Does not read more than n bytes. It
+    // is assumed that n is at least 1.
+    size_t (*alpha_char)(const char *c, ptrdiff_t n);
 
     // Return the number of bytes that the next character takes if it is valid
-    // in the encoding and is alphanumeric.
-    size_t (*alnum_char)(const char *c);
+    // in the encoding and is alphanumeric. Does not read more than n bytes. It
+    // is assumed that n is at least 1.
+    size_t (*alnum_char)(const char *c, ptrdiff_t n);
 
     // Return true if the next character is valid in the encoding and is an
-    // uppercase character.
-    bool (*isupper_char)(const char *c);
+    // uppercase character. Does not read more than n bytes. It is assumed that
+    // n is at least 1.
+    bool (*isupper_char)(const char *c, ptrdiff_t n);
 
     // The name of the encoding. This should correspond to a value that can be
     // passed to Encoding.find in Ruby.
@@ -45,18 +50,18 @@ typedef struct {
 // The function is shared between all of the encodings that use single bytes to
 // represent characters. They don't have need of a dynamic function to determine
 // their width.
-size_t yp_encoding_single_char_width(YP_ATTRIBUTE_UNUSED const char *c);
+size_t yp_encoding_single_char_width(YP_ATTRIBUTE_UNUSED const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n);
 
 // These functions are reused by some other encodings, so they are defined here
 // so they can be shared.
-size_t yp_encoding_ascii_alpha_char(const char *c);
-size_t yp_encoding_ascii_alnum_char(const char *c);
-bool yp_encoding_ascii_isupper_char(const char *c);
+size_t yp_encoding_ascii_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n);
+size_t yp_encoding_ascii_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n);
+bool yp_encoding_ascii_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n);
 
 // These functions are shared between the actual encoding and the fast path in
 // the parser so they need to be internally visible.
-size_t yp_encoding_utf_8_alpha_char(const char *c);
-size_t yp_encoding_utf_8_alnum_char(const char *c);
+size_t yp_encoding_utf_8_alpha_char(const char *c, ptrdiff_t n);
+size_t yp_encoding_utf_8_alnum_char(const char *c, ptrdiff_t n);
 
 // This lookup table is referenced in both the UTF-8 encoding file and the
 // parser directly in order to speed up the default encoding processing.

--- a/src/enc/ascii.c
+++ b/src/enc/ascii.c
@@ -23,25 +23,25 @@ static unsigned char yp_encoding_ascii_table[256] = {
 };
 
 static size_t
-yp_encoding_ascii_char_width(const char *c) {
+yp_encoding_ascii_char_width(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return v < 0x80 ? 1 : 0;
 }
 
 size_t
-yp_encoding_ascii_alpha_char(const char *c) {
+yp_encoding_ascii_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_ascii_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 size_t
-yp_encoding_ascii_alnum_char(const char *c) {
+yp_encoding_ascii_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_ascii_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 bool
-yp_encoding_ascii_isupper_char(const char *c) {
+yp_encoding_ascii_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_ascii_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/big5.c
+++ b/src/enc/big5.c
@@ -3,7 +3,7 @@
 typedef uint16_t big5_codepoint_t;
 
 static big5_codepoint_t
-big5_codepoint(const char *c, size_t *width) {
+big5_codepoint(const char *c, ptrdiff_t n, size_t *width) {
     const unsigned char *uc = (const unsigned char *) c;
 
     // These are the single byte characters.
@@ -13,7 +13,7 @@ big5_codepoint(const char *c, size_t *width) {
     }
 
     // These are the double byte characters.
-    if ((uc[0] >= 0xA1 && uc[0] <= 0xFE) && (uc[1] >= 0x40 && uc[1] <= 0xFE)) {
+    if ((n > 1) && (uc[0] >= 0xA1 && uc[0] <= 0xFE) && (uc[1] >= 0x40 && uc[1] <= 0xFE)) {
         *width = 2;
         return (big5_codepoint_t) (uc[0] << 8 | uc[1]);
     }
@@ -23,47 +23,47 @@ big5_codepoint(const char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_big5_char_width(const char *c) {
+yp_encoding_big5_char_width(const char *c, ptrdiff_t n) {
     size_t width;
-    big5_codepoint(c, &width);
+    big5_codepoint(c, n, &width);
 
     return width;
 }
 
 static size_t
-yp_encoding_big5_alpha_char(const char *c) {
+yp_encoding_big5_alpha_char(const char *c, ptrdiff_t n) {
     size_t width;
-    big5_codepoint_t codepoint = big5_codepoint(c, &width);
+    big5_codepoint_t codepoint = big5_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alpha_char(&value);
+        return yp_encoding_ascii_alpha_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static size_t
-yp_encoding_big5_alnum_char(const char *c) {
+yp_encoding_big5_alnum_char(const char *c, ptrdiff_t n) {
     size_t width;
-    big5_codepoint_t codepoint = big5_codepoint(c, &width);
+    big5_codepoint_t codepoint = big5_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alnum_char(&value);
+        return yp_encoding_ascii_alnum_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static bool
-yp_encoding_big5_isupper_char(const char *c) {
+yp_encoding_big5_isupper_char(const char *c, ptrdiff_t n) {
     size_t width;
-    big5_codepoint_t codepoint = big5_codepoint(c, &width);
+    big5_codepoint_t codepoint = big5_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_isupper_char(&value);
+        return yp_encoding_ascii_isupper_char(&value, n);
     } else {
         return false;
     }

--- a/src/enc/euc_jp.c
+++ b/src/enc/euc_jp.c
@@ -3,7 +3,7 @@
 typedef uint16_t euc_jp_codepoint_t;
 
 static euc_jp_codepoint_t
-euc_jp_codepoint(const char *c, size_t *width) {
+euc_jp_codepoint(const char *c, ptrdiff_t n, size_t *width) {
     const unsigned char *uc = (const unsigned char *) c;
 
     // These are the single byte characters.
@@ -14,8 +14,11 @@ euc_jp_codepoint(const char *c, size_t *width) {
 
     // These are the double byte characters.
     if (
-        ((uc[0] == 0x8E) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) ||
-        ((uc[0] >= 0xA1 && uc[0] <= 0xFE) && (uc[1] >= 0xA1 && uc[1] <= 0xFE))
+        (n > 1) &&
+        (
+            ((uc[0] == 0x8E) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) ||
+            ((uc[0] >= 0xA1 && uc[0] <= 0xFE) && (uc[1] >= 0xA1 && uc[1] <= 0xFE))
+        )
     ) {
         *width = 2;
         return (euc_jp_codepoint_t) (uc[0] << 8 | uc[1]);
@@ -26,47 +29,47 @@ euc_jp_codepoint(const char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_euc_jp_char_width(const char *c) {
+yp_encoding_euc_jp_char_width(const char *c, ptrdiff_t n) {
     size_t width;
-    euc_jp_codepoint(c, &width);
+    euc_jp_codepoint(c, n, &width);
 
     return width;
 }
 
 static size_t
-yp_encoding_euc_jp_alpha_char(const char *c) {
+yp_encoding_euc_jp_alpha_char(const char *c, ptrdiff_t n) {
     size_t width;
-    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, &width);
+    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alpha_char(&value);
+        return yp_encoding_ascii_alpha_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static size_t
-yp_encoding_euc_jp_alnum_char(const char *c) {
+yp_encoding_euc_jp_alnum_char(const char *c, ptrdiff_t n) {
     size_t width;
-    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, &width);
+    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alnum_char(&value);
+        return yp_encoding_ascii_alnum_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static bool
-yp_encoding_euc_jp_isupper_char(const char *c) {
+yp_encoding_euc_jp_isupper_char(const char *c, ptrdiff_t n) {
     size_t width;
-    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, &width);
+    euc_jp_codepoint_t codepoint = euc_jp_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_isupper_char(&value);
+        return yp_encoding_ascii_isupper_char(&value, n);
     } else {
         return 0;
     }

--- a/src/enc/gbk.c
+++ b/src/enc/gbk.c
@@ -3,7 +3,7 @@
 typedef uint16_t gbk_codepoint_t;
 
 static gbk_codepoint_t
-gbk_codepoint(const char *c, size_t *width) {
+gbk_codepoint(const char *c, ptrdiff_t n, size_t *width) {
     const unsigned char *uc = (const unsigned char *) c;
 
     // These are the single byte characters.
@@ -14,11 +14,14 @@ gbk_codepoint(const char *c, size_t *width) {
 
     // These are the double byte characters.
     if (
-        ((uc[0] >= 0xA1 && uc[0] <= 0xA9) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) || // GBK/1
-        ((uc[0] >= 0xB0 && uc[0] <= 0xF7) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) || // GBK/2
-        ((uc[0] >= 0x81 && uc[0] <= 0xA0) && (uc[1] >= 0x40 && uc[1] <= 0xFE) && (uc[1] != 0x7F)) || // GBK/3
-        ((uc[0] >= 0xAA && uc[0] <= 0xFE) && (uc[1] >= 0x40 && uc[1] <= 0xA0) && (uc[1] != 0x7F)) || // GBK/4
-        ((uc[0] >= 0xA8 && uc[0] <= 0xA9) && (uc[1] >= 0x40 && uc[1] <= 0xA0) && (uc[1] != 0x7F)) // GBK/5
+        (n > 1) &&
+        (
+            ((uc[0] >= 0xA1 && uc[0] <= 0xA9) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) || // GBK/1
+            ((uc[0] >= 0xB0 && uc[0] <= 0xF7) && (uc[1] >= 0xA1 && uc[1] <= 0xFE)) || // GBK/2
+            ((uc[0] >= 0x81 && uc[0] <= 0xA0) && (uc[1] >= 0x40 && uc[1] <= 0xFE) && (uc[1] != 0x7F)) || // GBK/3
+            ((uc[0] >= 0xAA && uc[0] <= 0xFE) && (uc[1] >= 0x40 && uc[1] <= 0xA0) && (uc[1] != 0x7F)) || // GBK/4
+            ((uc[0] >= 0xA8 && uc[0] <= 0xA9) && (uc[1] >= 0x40 && uc[1] <= 0xA0) && (uc[1] != 0x7F)) // GBK/5
+        )
     ) {
         *width = 2;
         return (gbk_codepoint_t) (uc[0] << 8 | uc[1]);
@@ -29,47 +32,47 @@ gbk_codepoint(const char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_gbk_char_width(const char *c) {
+yp_encoding_gbk_char_width(const char *c, ptrdiff_t n) {
     size_t width;
-    gbk_codepoint(c, &width);
+    gbk_codepoint(c, n, &width);
 
     return width;
 }
 
 static size_t
-yp_encoding_gbk_alpha_char(const char *c) {
+yp_encoding_gbk_alpha_char(const char *c, ptrdiff_t n) {
     size_t width;
-    gbk_codepoint_t codepoint = gbk_codepoint(c, &width);
+    gbk_codepoint_t codepoint = gbk_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alpha_char(&value);
+        return yp_encoding_ascii_alpha_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static size_t
-yp_encoding_gbk_alnum_char(const char *c) {
+yp_encoding_gbk_alnum_char(const char *c, ptrdiff_t n) {
     size_t width;
-    gbk_codepoint_t codepoint = gbk_codepoint(c, &width);
+    gbk_codepoint_t codepoint = gbk_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alnum_char(&value);
+        return yp_encoding_ascii_alnum_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static bool
-yp_encoding_gbk_isupper_char(const char *c) {
+yp_encoding_gbk_isupper_char(const char *c, ptrdiff_t n) {
     size_t width;
-    gbk_codepoint_t codepoint = gbk_codepoint(c, &width);
+    gbk_codepoint_t codepoint = gbk_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_isupper_char(&value);
+        return yp_encoding_ascii_isupper_char(&value, n);
     } else {
         return false;
     }

--- a/src/enc/iso_8859_1.c
+++ b/src/enc/iso_8859_1.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_1_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_1_alpha_char(const char *c) {
+yp_encoding_iso_8859_1_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_1_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_1_alnum_char(const char *c) {
+yp_encoding_iso_8859_1_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_1_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_1_isupper_char(const char *c) {
+yp_encoding_iso_8859_1_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_1_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_10.c
+++ b/src/enc/iso_8859_10.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_10_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_10_alpha_char(const char *c) {
+yp_encoding_iso_8859_10_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_10_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_10_alnum_char(const char *c) {
+yp_encoding_iso_8859_10_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_10_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_10_isupper_char(const char *c) {
+yp_encoding_iso_8859_10_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_10_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_11.c
+++ b/src/enc/iso_8859_11.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_11_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_11_alpha_char(const char *c) {
+yp_encoding_iso_8859_11_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_11_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_11_alnum_char(const char *c) {
+yp_encoding_iso_8859_11_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_11_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_11_isupper_char(const char *c) {
+yp_encoding_iso_8859_11_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_11_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_13.c
+++ b/src/enc/iso_8859_13.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_13_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_13_alpha_char(const char *c) {
+yp_encoding_iso_8859_13_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_13_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_13_alnum_char(const char *c) {
+yp_encoding_iso_8859_13_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_13_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_13_isupper_char(const char *c) {
+yp_encoding_iso_8859_13_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_13_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_14.c
+++ b/src/enc/iso_8859_14.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_14_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_14_alpha_char(const char *c) {
+yp_encoding_iso_8859_14_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_14_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_14_alnum_char(const char *c) {
+yp_encoding_iso_8859_14_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_14_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_14_isupper_char(const char *c) {
+yp_encoding_iso_8859_14_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_14_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_15.c
+++ b/src/enc/iso_8859_15.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_15_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_15_alpha_char(const char *c) {
+yp_encoding_iso_8859_15_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_15_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_15_alnum_char(const char *c) {
+yp_encoding_iso_8859_15_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_15_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_15_isupper_char(const char *c) {
+yp_encoding_iso_8859_15_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_15_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_16.c
+++ b/src/enc/iso_8859_16.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_16_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_16_alpha_char(const char *c) {
+yp_encoding_iso_8859_16_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_16_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_16_alnum_char(const char *c) {
+yp_encoding_iso_8859_16_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_16_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_16_isupper_char(const char *c) {
+yp_encoding_iso_8859_16_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_16_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_2.c
+++ b/src/enc/iso_8859_2.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_2_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_2_alpha_char(const char *c) {
+yp_encoding_iso_8859_2_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_2_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_2_alnum_char(const char *c) {
+yp_encoding_iso_8859_2_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_2_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_2_isupper_char(const char *c) {
+yp_encoding_iso_8859_2_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_2_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_3.c
+++ b/src/enc/iso_8859_3.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_3_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_3_alpha_char(const char *c) {
+yp_encoding_iso_8859_3_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_3_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_3_alnum_char(const char *c) {
+yp_encoding_iso_8859_3_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_3_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_3_isupper_char(const char *c) {
+yp_encoding_iso_8859_3_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_3_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_4.c
+++ b/src/enc/iso_8859_4.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_4_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_4_alpha_char(const char *c) {
+yp_encoding_iso_8859_4_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_4_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_4_alnum_char(const char *c) {
+yp_encoding_iso_8859_4_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_4_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_4_isupper_char(const char *c) {
+yp_encoding_iso_8859_4_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_4_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_5.c
+++ b/src/enc/iso_8859_5.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_5_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_5_alpha_char(const char *c) {
+yp_encoding_iso_8859_5_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_5_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_5_alnum_char(const char *c) {
+yp_encoding_iso_8859_5_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_5_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_5_isupper_char(const char *c) {
+yp_encoding_iso_8859_5_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_5_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_6.c
+++ b/src/enc/iso_8859_6.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_6_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_6_alpha_char(const char *c) {
+yp_encoding_iso_8859_6_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_6_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_6_alnum_char(const char *c) {
+yp_encoding_iso_8859_6_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_6_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_6_isupper_char(const char *c) {
+yp_encoding_iso_8859_6_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_6_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_7.c
+++ b/src/enc/iso_8859_7.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_7_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_7_alpha_char(const char *c) {
+yp_encoding_iso_8859_7_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_7_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_7_alnum_char(const char *c) {
+yp_encoding_iso_8859_7_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_7_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_7_isupper_char(const char *c) {
+yp_encoding_iso_8859_7_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_7_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_8.c
+++ b/src/enc/iso_8859_8.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_8_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_8_alpha_char(const char *c) {
+yp_encoding_iso_8859_8_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_8_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_8_alnum_char(const char *c) {
+yp_encoding_iso_8859_8_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_8_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_8_isupper_char(const char *c) {
+yp_encoding_iso_8859_8_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_8_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/iso_8859_9.c
+++ b/src/enc/iso_8859_9.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_iso_8859_9_table[256] = {
 };
 
 static size_t
-yp_encoding_iso_8859_9_alpha_char(const char *c) {
+yp_encoding_iso_8859_9_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_9_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_iso_8859_9_alnum_char(const char *c) {
+yp_encoding_iso_8859_9_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_9_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_iso_8859_9_isupper_char(const char *c) {
+yp_encoding_iso_8859_9_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_iso_8859_9_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/koi8_r.c
+++ b/src/enc/koi8_r.c
@@ -23,25 +23,25 @@ static unsigned char yp_encoding_koi8_r_table[256] = {
 };
 
 static size_t
-yp_encoding_koi8_r_char_width(const char *c) {
+yp_encoding_koi8_r_char_width(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return ((v >= 0x20 && v <= 0x7E) || (v >= 0x80)) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_koi8_r_alpha_char(const char *c) {
+yp_encoding_koi8_r_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_koi8_r_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_koi8_r_alnum_char(const char *c) {
+yp_encoding_koi8_r_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_koi8_r_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_koi8_r_isupper_char(const char *c) {
+yp_encoding_koi8_r_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_koi8_r_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/shared.c
+++ b/src/enc/shared.c
@@ -4,6 +4,6 @@
 // represent characters. They don't have need of a dynamic function to determine
 // their width.
 size_t
-yp_encoding_single_char_width(YP_ATTRIBUTE_UNUSED const char *c) {
+yp_encoding_single_char_width(YP_ATTRIBUTE_UNUSED const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     return 1;
 }

--- a/src/enc/shift_jis.c
+++ b/src/enc/shift_jis.c
@@ -3,7 +3,7 @@
 typedef uint16_t shift_jis_codepoint_t;
 
 static shift_jis_codepoint_t
-shift_jis_codepoint(const char *c, size_t *width) {
+shift_jis_codepoint(const char *c, ptrdiff_t n, size_t *width) {
     const unsigned char *uc = (const unsigned char *) c;
 
     // These are the single byte characters.
@@ -14,6 +14,7 @@ shift_jis_codepoint(const char *c, size_t *width) {
 
     // These are the double byte characters.
     if (
+        (n > 1) &&
         ((uc[0] >= 0x81 && uc[0] <= 0x9F) || (uc[0] >= 0xE0 && uc[0] <= 0xFC)) &&
         (uc[1] >= 0x40 && uc[1] <= 0xFC)
     ) {
@@ -26,47 +27,47 @@ shift_jis_codepoint(const char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_shift_jis_char_width(const char *c) {
+yp_encoding_shift_jis_char_width(const char *c, ptrdiff_t n) {
     size_t width;
-    shift_jis_codepoint(c, &width);
+    shift_jis_codepoint(c, n, &width);
 
     return width;
 }
 
 static size_t
-yp_encoding_shift_jis_alpha_char(const char *c) {
+yp_encoding_shift_jis_alpha_char(const char *c, ptrdiff_t n) {
     size_t width;
-    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, &width);
+    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alpha_char(&value);
+        return yp_encoding_ascii_alpha_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static size_t
-yp_encoding_shift_jis_alnum_char(const char *c) {
+yp_encoding_shift_jis_alnum_char(const char *c, ptrdiff_t n) {
     size_t width;
-    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, &width);
+    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alnum_char(&value);
+        return yp_encoding_ascii_alnum_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static bool
-yp_encoding_shift_jis_isupper_char(const char *c) {
+yp_encoding_shift_jis_isupper_char(const char *c, ptrdiff_t n) {
     size_t width;
-    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, &width);
+    shift_jis_codepoint_t codepoint = shift_jis_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_isupper_char(&value);
+        return yp_encoding_ascii_isupper_char(&value, n);
     } else {
         return 0;
     }

--- a/src/enc/unicode.c
+++ b/src/enc/unicode.c
@@ -2220,11 +2220,14 @@ static const uint8_t utf_8_dfa[] = {
 };
 
 static unicode_codepoint_t
-utf_8_codepoint(const unsigned char *c, size_t *width) {
+utf_8_codepoint(const unsigned char *c, ptrdiff_t n, size_t *width) {
+    assert(n >= 1);
+    size_t maximum = (size_t) n;
+
     uint32_t codepoint;
     uint32_t state = 0;
 
-    for (size_t index = 0; index < 4; index++) {
+    for (size_t index = 0; index < 4 && index < maximum; index++) {
         uint32_t byte = c[index];
         uint32_t type = utf_8_dfa[byte];
 
@@ -2244,23 +2247,23 @@ utf_8_codepoint(const unsigned char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_utf_8_char_width(const char *c) {
+yp_encoding_utf_8_char_width(const char *c, ptrdiff_t n) {
     size_t width;
     const unsigned char *v = (const unsigned char *) c;
 
-    utf_8_codepoint(v, &width);
+    utf_8_codepoint(v, n, &width);
     return width;
 }
 
 size_t
-yp_encoding_utf_8_alpha_char(const char *c) {
+yp_encoding_utf_8_alpha_char(const char *c, ptrdiff_t n) {
     const unsigned char *v = (const unsigned char *) c;
     if (*v < 0x80) {
         return (yp_encoding_unicode_table[*v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
     }
 
     size_t width;
-    unicode_codepoint_t codepoint = utf_8_codepoint(v, &width);
+    unicode_codepoint_t codepoint = utf_8_codepoint(v, n, &width);
 
     if (codepoint <= 0xFF) {
         return (yp_encoding_unicode_table[(unsigned char) codepoint] & YP_ENCODING_ALPHABETIC_BIT) ? width : 0;
@@ -2270,14 +2273,14 @@ yp_encoding_utf_8_alpha_char(const char *c) {
 }
 
 size_t
-yp_encoding_utf_8_alnum_char(const char *c) {
+yp_encoding_utf_8_alnum_char(const char *c, ptrdiff_t n) {
     const unsigned char *v = (const unsigned char *) c;
     if (*v < 0x80) {
         return (yp_encoding_unicode_table[*v] & (YP_ENCODING_ALPHANUMERIC_BIT)) ? 1 : 0;
     }
 
     size_t width;
-    unicode_codepoint_t codepoint = utf_8_codepoint(v, &width);
+    unicode_codepoint_t codepoint = utf_8_codepoint(v, n, &width);
 
     if (codepoint <= 0xFF) {
         return (yp_encoding_unicode_table[(unsigned char) codepoint] & (YP_ENCODING_ALPHANUMERIC_BIT)) ? width : 0;
@@ -2287,14 +2290,14 @@ yp_encoding_utf_8_alnum_char(const char *c) {
 }
 
 static bool
-yp_encoding_utf_8_isupper_char(const char *c) {
+yp_encoding_utf_8_isupper_char(const char *c, ptrdiff_t n) {
     const unsigned char *v = (const unsigned char *) c;
     if (*v < 0x80) {
         return (yp_encoding_unicode_table[*v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
     }
 
     size_t width;
-    unicode_codepoint_t codepoint = utf_8_codepoint(v, &width);
+    unicode_codepoint_t codepoint = utf_8_codepoint(v, n, &width);
 
     if (codepoint <= 0xFF) {
         return (yp_encoding_unicode_table[(unsigned char) codepoint] & YP_ENCODING_UPPERCASE_BIT) ? true : false;

--- a/src/enc/windows_1251.c
+++ b/src/enc/windows_1251.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_windows_1251_table[256] = {
 };
 
 static size_t
-yp_encoding_windows_1251_alpha_char(const char *c) {
+yp_encoding_windows_1251_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1251_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_windows_1251_alnum_char(const char *c) {
+yp_encoding_windows_1251_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1251_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_windows_1251_isupper_char(const char *c) {
+yp_encoding_windows_1251_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1251_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/windows_1252.c
+++ b/src/enc/windows_1252.c
@@ -23,19 +23,19 @@ static unsigned char yp_encoding_windows_1252_table[256] = {
 };
 
 static size_t
-yp_encoding_windows_1252_alpha_char(const char *c) {
+yp_encoding_windows_1252_alpha_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1252_table[v] & YP_ENCODING_ALPHABETIC_BIT) ? 1 : 0;
 }
 
 static size_t
-yp_encoding_windows_1252_alnum_char(const char *c) {
+yp_encoding_windows_1252_alnum_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1252_table[v] & YP_ENCODING_ALPHANUMERIC_BIT) ? 1 : 0;
 }
 
 static bool
-yp_encoding_windows_1252_isupper_char(const char *c) {
+yp_encoding_windows_1252_isupper_char(const char *c, YP_ATTRIBUTE_UNUSED ptrdiff_t n) {
     const unsigned char v = (const unsigned char) *c;
     return (yp_encoding_windows_1252_table[v] & YP_ENCODING_UPPERCASE_BIT) ? true : false;
 }

--- a/src/enc/windows_31j.c
+++ b/src/enc/windows_31j.c
@@ -3,7 +3,7 @@
 typedef uint16_t windows_31j_codepoint_t;
 
 static windows_31j_codepoint_t
-windows_31j_codepoint(const char *c, size_t *width) {
+windows_31j_codepoint(const char *c, ptrdiff_t n, size_t *width) {
     const unsigned char *uc = (const unsigned char *) c;
 
     // These are the single byte characters.
@@ -14,6 +14,7 @@ windows_31j_codepoint(const char *c, size_t *width) {
 
     // These are the double byte characters.
     if (
+        (n > 1) &&
         ((uc[0] >= 0x81 && uc[0] <= 0x9F) || (uc[0] >= 0xE0 && uc[0] <= 0xFC)) &&
         (uc[1] >= 0x40 && uc[1] <= 0xFC)
     ) {
@@ -26,47 +27,47 @@ windows_31j_codepoint(const char *c, size_t *width) {
 }
 
 static size_t
-yp_encoding_windows_31j_char_width(const char *c) {
+yp_encoding_windows_31j_char_width(const char *c, ptrdiff_t n) {
     size_t width;
-    windows_31j_codepoint(c, &width);
+    windows_31j_codepoint(c, n, &width);
 
     return width;
 }
 
 static size_t
-yp_encoding_windows_31j_alpha_char(const char *c) {
+yp_encoding_windows_31j_alpha_char(const char *c, ptrdiff_t n) {
     size_t width;
-    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, &width);
+    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alpha_char(&value);
+        return yp_encoding_ascii_alpha_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static size_t
-yp_encoding_windows_31j_alnum_char(const char *c) {
+yp_encoding_windows_31j_alnum_char(const char *c, ptrdiff_t n) {
     size_t width;
-    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, &width);
+    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_alnum_char(&value);
+        return yp_encoding_ascii_alnum_char(&value, n);
     } else {
         return 0;
     }
 }
 
 static bool
-yp_encoding_windows_31j_isupper_char(const char *c) {
+yp_encoding_windows_31j_isupper_char(const char *c, ptrdiff_t n) {
     size_t width;
-    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, &width);
+    windows_31j_codepoint_t codepoint = windows_31j_codepoint(c, n, &width);
 
     if (width == 1) {
         const char value = (const char) codepoint;
-        return yp_encoding_ascii_isupper_char(&value);
+        return yp_encoding_ascii_isupper_char(&value, n);
     } else {
         return false;
     }

--- a/src/util/yp_memchr.c
+++ b/src/util/yp_memchr.c
@@ -16,7 +16,7 @@ yp_memchr(yp_parser_t *parser, const void *memory, int character, size_t number)
                 return (void *) (source + index);
             }
 
-            size_t width = parser->encoding.char_width(source + index);
+            size_t width = parser->encoding.char_width(source + index, (ptrdiff_t) (number - index));
             if (width == 0) {
                 return NULL;
             }

--- a/src/util/yp_strpbrk.c
+++ b/src/util/yp_strpbrk.c
@@ -10,7 +10,7 @@ yp_strpbrk_multi_byte(yp_parser_t *parser, const char *source, const char *chars
             return source + index;
         }
 
-        size_t width = parser->encoding.char_width(source + index);
+        size_t width = parser->encoding.char_width(source + index, (ptrdiff_t) (maximum - index));
         if (width == 0) {
             return NULL;
         }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5333,11 +5333,15 @@ lex_question_mark(yp_parser_t *parser) {
         return YP_TOKEN_CHARACTER_LITERAL;
     } else {
         size_t encoding_width = parser->encoding.char_width(parser->current.end);
+
         // We only want to return a character literal if there's exactly one
         // alphanumeric character right after the `?`
         if (
             !parser->encoding.alnum_char(parser->current.end) ||
-            !parser->encoding.alnum_char(parser->current.end + encoding_width)
+            (
+                (parser->current.end + encoding_width >= parser->end) ||
+                !parser->encoding.alnum_char(parser->current.end + encoding_width)
+            )
         ) {
             lex_state_set(parser, YP_LEX_STATE_END);
             parser->current.end += encoding_width;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4312,12 +4312,13 @@ static inline size_t
 char_is_identifier_start(yp_parser_t *parser, const char *c) {
     const unsigned char uc = (unsigned char) *c;
 
-    return (
-        (parser->encoding_changed
-            ? parser->encoding.alpha_char(c)
-            : (uc < 0x80 ? (yp_encoding_unicode_table[uc] & YP_ENCODING_ALPHABETIC_BIT ? 1 : 0) : yp_encoding_utf_8_alpha_char(c))
-        ) || (uc == '_') || (uc >= 0x80)
-    );
+    if (parser->encoding_changed) {
+        return parser->encoding.alpha_char(c, parser->end - c) || (uc == '_') || (uc >= 0x80);
+    } else if (uc < 0x80) {
+        return (yp_encoding_unicode_table[uc] & YP_ENCODING_ALPHABETIC_BIT ? 1 : 0) || (uc == '_');
+    } else {
+        return (size_t) (yp_encoding_utf_8_alpha_char(c, parser->end - c) || 1u);
+    }
 }
 
 // Like the above, this function is also used extremely frequently to lex all of
@@ -4327,12 +4328,13 @@ static inline size_t
 char_is_identifier(yp_parser_t *parser, const char *c) {
     const unsigned char uc = (unsigned char) *c;
 
-    return (
-        (parser->encoding_changed
-            ? parser->encoding.alnum_char(c)
-            : (uc < 0x80 ? (yp_encoding_unicode_table[uc] & YP_ENCODING_ALPHANUMERIC_BIT ? 1 : 0) : yp_encoding_utf_8_alnum_char(c))
-        ) || (uc == '_') || (uc >= 0x80)
-    );
+    if (parser->encoding_changed) {
+        return parser->encoding.alnum_char(c, parser->end - c) || (uc == '_') || (uc >= 0x80);
+    } else if (uc < 0x80) {
+        return (yp_encoding_unicode_table[uc] & YP_ENCODING_ALPHANUMERIC_BIT ? 1 : 0) || (uc == '_');
+    } else {
+        return (size_t) (yp_encoding_utf_8_alnum_char(c, parser->end - c) || 1u);
+    }
 }
 
 // Here we're defining a perfect hash for the characters that are allowed in
@@ -5138,7 +5140,7 @@ lex_identifier(yp_parser_t *parser, bool previous_command_start) {
         }
     }
 
-    return parser->encoding.isupper_char(parser->current.start) ? YP_TOKEN_CONSTANT : YP_TOKEN_IDENTIFIER;
+    return parser->encoding.isupper_char(parser->current.start, parser->end - parser->current.start) ? YP_TOKEN_CONSTANT : YP_TOKEN_IDENTIFIER;
 }
 
 // Returns true if the current token that the parser is considering is at the
@@ -5332,15 +5334,15 @@ lex_question_mark(yp_parser_t *parser) {
         parser->current.end += yp_unescape_calculate_difference(parser->current.start + 1, parser->end, YP_UNESCAPE_ALL, true, &parser->error_list);
         return YP_TOKEN_CHARACTER_LITERAL;
     } else {
-        size_t encoding_width = parser->encoding.char_width(parser->current.end);
+        size_t encoding_width = parser->encoding.char_width(parser->current.end, parser->end - parser->current.end);
 
         // We only want to return a character literal if there's exactly one
         // alphanumeric character right after the `?`
         if (
-            !parser->encoding.alnum_char(parser->current.end) ||
+            !parser->encoding.alnum_char(parser->current.end, parser->end - parser->current.end) ||
             (
                 (parser->current.end + encoding_width >= parser->end) ||
-                !parser->encoding.alnum_char(parser->current.end + encoding_width)
+                !parser->encoding.alnum_char(parser->current.end + encoding_width, parser->end - (parser->current.end + encoding_width))
             )
         ) {
             lex_state_set(parser, YP_LEX_STATE_END);
@@ -6422,7 +6424,7 @@ parser_lex(yp_parser_t *parser) {
                         (lex_state_p(parser, YP_LEX_STATE_FITEM) && (*parser->current.end == 's')) ||
                         lex_state_spcarg_p(parser, space_seen)
                     ) {
-                        if (!parser->encoding.alnum_char(parser->current.end)) {
+                        if (!parser->encoding.alnum_char(parser->current.end, parser->end - parser->current.end)) {
                             lex_mode_push_string(parser, true, false, lex_mode_incrementor(*parser->current.end), lex_mode_terminator(*parser->current.end));
 
                             if (*parser->current.end == '\r') {


### PR DESCRIPTION
Before this PR, all of the encodings could read off the end of the source string. This didn't matter for single-byte encodings since we always check the length before calling into these functions. But for multi-byte encodings like the default UTF-8, if a multi-byte character was at the end of the buffer it would happily read off the end trying to finish out the codepoint.

This PR changes all of the signatures of all of the encodings to include a length parameter. That parameter dictates how many characters can be read from the end of the string. We then use this in all of the multi-byte encodings to limit how far they can read.

This fixes the out-of-bounds reads described in #463.