### PR TITLE
Fix wrong conversion and cast

### DIFF
--- a/ext/yarp/api_pack.c
+++ b/ext/yarp/api_pack.c
@@ -188,7 +188,7 @@ pack_parse(VALUE self, VALUE version_symbol, VALUE variant_symbol, VALUE format_
         const char *directive_start = format;
 
         yp_pack_result parse_result = yp_pack_parse(variant, &format, format_end, &type, &signed_type, &endian,
-                                                                                                &size, &length_type, &length, &encoding);
+                                                    &size, &length_type, &length, &encoding);
 
         const char *directive_end = format;
 
@@ -214,14 +214,14 @@ pack_parse(VALUE self, VALUE version_symbol, VALUE variant_symbol, VALUE format_
         }
 
         VALUE directive_args[9] = { version_symbol,
-                                                                variant_symbol,
-                                                                rb_usascii_str_new(directive_start, directive_end - directive_start),
-                                                                pack_type_to_symbol(type),
-                                                                pack_signed_to_symbol(signed_type),
-                                                                pack_endian_to_symbol(endian),
-                                                                pack_size_to_symbol(size),
-                                                                pack_length_type_to_symbol(length_type),
-                                                                (long) LONG2NUM(length) };
+                                    variant_symbol,
+                                    rb_usascii_str_new(directive_start, directive_end - directive_start),
+                                    pack_type_to_symbol(type),
+                                    pack_signed_to_symbol(signed_type),
+                                    pack_endian_to_symbol(endian),
+                                    pack_size_to_symbol(size),
+                                    pack_length_type_to_symbol(length_type),
+                                    (long) LONG2NUM(length) };
 
         rb_ary_push(directives_array, rb_class_new_instance(9, directive_args, rb_cYARPPackDirective));
     }

--- a/ext/yarp/api_pack.c
+++ b/ext/yarp/api_pack.c
@@ -9,6 +9,16 @@ static VALUE v3_2_0_symbol;
 static VALUE pack_symbol;
 static VALUE unpack_symbol;
 
+#if SIZEOF_UINT64_T == SIZEOF_LONG_LONG
+# define UINT64T2NUM(x) ULL2NUM(x)
+# define NUM2UINT64T(x) (uint64_t)NUM2ULL(x)
+#elif SIZEOF_UINT64_T == SIZEOF_LONG
+# define UINT64T2NUM(x) ULONG2NUM(x)
+# define NUM2UINT64T(x) (uint64_t)NUM2ULONG(x)
+#else
+// error No uint64_t conversion
+#endif
+
 static VALUE
 pack_type_to_symbol(yp_pack_type type) {
     switch (type) {
@@ -221,7 +231,7 @@ pack_parse(VALUE self, VALUE version_symbol, VALUE variant_symbol, VALUE format_
                                     pack_endian_to_symbol(endian),
                                     pack_size_to_symbol(size),
                                     pack_length_type_to_symbol(length_type),
-                                    (long) LONG2NUM(length) };
+                                    UINT64T2NUM(length) };
 
         rb_ary_push(directives_array, rb_class_new_instance(9, directive_args, rb_cYARPPackDirective));
     }


### PR DESCRIPTION
Conversions from `uint64_t`/`VALUE` to `long` may loose upper bits.
