### PR TITLE
Remove recursion in rb_ast_new

### DIFF
--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -7,80 +7,15 @@ extern VALUE rb_cYARPToken;
 extern VALUE rb_cYARPLocation;
 
 static VALUE
-location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source) {
+yp_location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source) {
     VALUE argv[] = { source, LONG2FIX(start - parser->start), LONG2FIX(end - start) };
     return rb_class_new_instance(3, argv, rb_cYARPLocation);
 }
 
-static VALUE
-yp_string_new(yp_string_t *string, rb_encoding *encoding) {
-    return rb_enc_str_new(yp_string_source(string), yp_string_length(string), encoding);
-}
-
-static VALUE
-yp_node_new(yp_parser_t *parser, yp_node_t *node, VALUE source, rb_encoding *encoding, ID *constants) {
-    switch (YP_NODE_TYPE(node)) {
-        <%- nodes.each do |node| -%>
-#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
-        case <%= node.type %>: {
-            <%- if node.params.any? -%>
-            yp_<%= node.human %>_t *cast = (yp_<%= node.human %>_t *) node;
-            <%- end -%>
-            VALUE argv[<%= node.params.length + 1 %>];
-            <%- node.params.each_with_index do |param, index| -%>
-
-            // <%= param.name %>
-            <%- case param -%>
-            <%- when NodeParam -%>
-            argv[<%= index %>] = yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source, encoding, constants);
-            <%- when OptionalNodeParam -%>
-            argv[<%= index %>] = cast-><%= param.name %> == NULL ? Qnil : yp_node_new(parser, (yp_node_t *) cast-><%= param.name %>, source, encoding, constants);
-            <%- when NodeListParam -%>
-            argv[<%= index %>] = rb_ary_new();
-            for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
-                rb_ary_push(argv[<%= index %>], yp_node_new(parser, cast-><%= param.name %>.nodes[index], source, encoding, constants));
-            }
-            <%- when StringParam -%>
-            argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
-            <%- when LocationListParam -%>
-            argv[<%= index %>] = rb_ary_new();
-            for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
-                yp_location_t location = cast-><%= param.name %>.locations[index];
-                rb_ary_push(argv[<%= index %>], location_new(parser, location.start, location.end, source));
-            }
-            <%- when ConstantParam -%>
-            argv[<%= index %>] = rb_id2sym(constants[cast-><%= param.name %> - 1]);
-            <%- when ConstantListParam -%>
-            argv[<%= index %>] = rb_ary_new();
-            for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
-                rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= param.name %>.ids[index] - 1]));
-            }
-            <%- when LocationParam -%>
-            argv[<%= index %>] = location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
-            <%- when OptionalLocationParam -%>
-            argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
-            <%- when UInt32Param -%>
-            argv[<%= index %>] = ULONG2NUM(cast-><%= param.name %>);
-            <%- else -%>
-            <%- raise -%>
-            <%- end -%>
-            <%- end -%>
-
-            // location
-            argv[<%= node.params.length %>] = location_new(parser, node->location.start, node->location.end, source);
-            return rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>")));
-        }
-        <%- end -%>
-        default:
-            rb_raise(rb_eRuntimeError, "unknown node type: %d", YP_NODE_TYPE(node));
-    }
-}
-
-#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
 VALUE
 yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source) {
     ID type = rb_intern(yp_token_type_to_str(token->type));
-    VALUE location = location_new(parser, token->start, token->end, source);
+    VALUE location = yp_location_new(parser, token->start, token->end, source);
 
     VALUE argv[] = {
         ID2SYM(type),
@@ -89,6 +24,11 @@ yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALU
     };
 
     return rb_class_new_instance(3, argv, rb_cYARPToken);
+}
+
+static VALUE
+yp_string_new(yp_string_t *string, rb_encoding *encoding) {
+    return rb_enc_str_new(yp_string_source(string), yp_string_length(string), encoding);
 }
 
 // Create a YARP::Source object from the given parser.
@@ -105,7 +45,34 @@ yp_source_new(yp_parser_t *parser) {
     return rb_class_new_instance(2, source_argv, rb_cYARPSource);
 }
 
-VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
+typedef struct yp_node_stack_node {
+    struct yp_node_stack_node *prev;
+    yp_node_t *visit;
+    bool visited;
+} yp_node_stack_node_t;
+
+static void
+yp_node_stack_push(yp_node_stack_node_t **stack, yp_node_t *visit) {
+    yp_node_stack_node_t *node = malloc(sizeof(yp_node_stack_node_t));
+    node->prev = *stack;
+    node->visit = visit;
+    node->visited = false;
+    *stack = node;
+}
+
+static yp_node_t *
+yp_node_stack_pop(yp_node_stack_node_t **stack) {
+    yp_node_stack_node_t *current = *stack;
+    yp_node_t *visit = current->visit;
+
+    *stack = current->prev;
+    free(current);
+
+    return visit;
+}
+
+VALUE
+yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
     VALUE source = yp_source_new(parser);
     ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
 
@@ -117,7 +84,107 @@ VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
         }
     }
 
-    VALUE res_node = yp_node_new(parser, node, source, encoding, constants);
+    yp_node_stack_node_t *node_stack = NULL;
+    yp_node_stack_push(&node_stack, node);
+    VALUE value_stack = rb_ary_new();
+
+    while (node_stack != NULL) {
+        if (!node_stack->visited) {
+            if (node_stack->visit == NULL) {
+                yp_node_stack_pop(&node_stack);
+                rb_ary_push(value_stack, Qnil);
+                continue;
+            }
+
+            yp_node_t *node = node_stack->visit;
+            node_stack->visited = true;
+
+            switch (YP_NODE_TYPE(node)) {
+                <%- nodes.each do |node| -%>
+                <%- if node.params.any? { |param| [NodeParam, OptionalNodeParam, NodeListParam].include?(param.class) } -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
+                case <%= node.type %>: {
+                    yp_<%= node.human %>_t *cast = (yp_<%= node.human %>_t *) node;
+                    <%- node.params.each do |param| -%>
+                    <%- case param -%>
+                    <%- when NodeParam, OptionalNodeParam -%>
+                    yp_node_stack_push(&node_stack, (yp_node_t *) cast-><%= param.name %>);
+                    <%- when NodeListParam -%>
+                    for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
+                        yp_node_stack_push(&node_stack, (yp_node_t *) cast-><%= param.name %>.nodes[index]);
+                    }
+                    <%- end -%>
+                    <%- end -%>
+                    break;
+                }
+                <%- end -%>
+                <%- end -%>
+                default:
+                    break;
+            }
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
+        } else {
+            yp_node_t *node = yp_node_stack_pop(&node_stack);
+
+            switch (YP_NODE_TYPE(node)) {
+                <%- nodes.each do |node| -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
+                case <%= node.type %>: {
+                    <%- if node.params.any? { |param| ![NodeParam, OptionalNodeParam].include?(param.class) } -%>
+                    yp_<%= node.human %>_t *cast = (yp_<%= node.human %>_t *) node;
+                    <%- end -%>
+                    VALUE argv[<%= node.params.length + 1 %>];
+                    <%- node.params.each_with_index do |param, index| -%>
+
+                    // <%= param.name %>
+                    <%- case param -%>
+                    <%- when NodeParam, OptionalNodeParam -%>
+                    argv[<%= index %>] = rb_ary_pop(value_stack);
+                    <%- when NodeListParam -%>
+                    argv[<%= index %>] = rb_ary_new();
+                    for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
+                        rb_ary_push(argv[<%= index %>], rb_ary_pop(value_stack));
+                    }
+                    <%- when StringParam -%>
+                    argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
+                    <%- when LocationListParam -%>
+                    argv[<%= index %>] = rb_ary_new();
+                    for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
+                        yp_location_t location = cast-><%= param.name %>.locations[index];
+                        rb_ary_push(argv[<%= index %>], yp_location_new(parser, location.start, location.end, source));
+                    }
+                    <%- when ConstantParam -%>
+                    argv[<%= index %>] = rb_id2sym(constants[cast-><%= param.name %> - 1]);
+                    <%- when ConstantListParam -%>
+                    argv[<%= index %>] = rb_ary_new();
+                    for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
+                        rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= param.name %>.ids[index] - 1]));
+                    }
+                    <%- when LocationParam -%>
+                    argv[<%= index %>] = yp_location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
+                    <%- when OptionalLocationParam -%>
+                    argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : yp_location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
+                    <%- when UInt32Param -%>
+                    argv[<%= index %>] = ULONG2NUM(cast-><%= param.name %>);
+                    <%- else -%>
+                    <%- raise -%>
+                    <%- end -%>
+                    <%- end -%>
+
+                    // location
+                    argv[<%= node.params.length %>] = yp_location_new(parser, node->location.start, node->location.end, source);
+
+                    rb_ary_push(value_stack, rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>"))));
+                    break;
+                }
+                <%- end -%>
+                default:
+                    rb_raise(rb_eRuntimeError, "unknown node type: %d", YP_NODE_TYPE(node));
+            }
+        }
+    }
+
+    VALUE result = rb_ary_pop(value_stack);
     free(constants);
-    return res_node;
+    return result;
 }

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -35,26 +35,32 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
             yp_buffer_append_str(buffer, yp_string_source(&((yp_<%= node.human %>_t *)node)-><%= param.name %>), yp_string_length(&((yp_<%= node.human %>_t *)node)-><%= param.name %>));
             yp_buffer_append_str(buffer, "\"", 1);
             <%- when NodeListParam -%>
+            yp_buffer_append_str(buffer, "[", 1);
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= param.name %>.size; index++) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);
                 prettyprint_node(buffer, parser, (yp_node_t *) ((yp_<%= node.human %>_t *) node)-><%= param.name %>.nodes[index]);
             }
+            yp_buffer_append_str(buffer, "]", 1);
             <%- when LocationListParam -%>
+            yp_buffer_append_str(buffer, "[", 1);
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= param.name %>.size; index++) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);
                 prettyprint_location(buffer, parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>.locations[index]);
             }
+            yp_buffer_append_str(buffer, "]", 1);
             <%- when ConstantParam -%>
             char <%= param.name %>_buffer[12];
             yp_snprintf(<%= param.name %>_buffer, sizeof(<%= param.name %>_buffer), "%u", ((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
             <%- when ConstantListParam -%>
+            yp_buffer_append_str(buffer, "[", 1);
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= param.name %>.size; index++) {
                 if (index != 0) yp_buffer_append_str(buffer, ", ", 2);
                 char <%= param.name %>_buffer[12];
                 yp_snprintf(<%= param.name %>_buffer, sizeof(<%= param.name %>_buffer), "%u", ((yp_<%= node.human %>_t *)node)-><%= param.name %>.ids[index]);
                 yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
             }
+            yp_buffer_append_str(buffer, "]", 1);
             <%- when LocationParam -%>
             prettyprint_location(buffer, parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             <%- when OptionalLocationParam -%>


### PR DESCRIPTION
Currently when we convert from the C structs to the Ruby objects we recurse down the tree and create each node. This means we're limited in the size of the tree that we can convert by the system stack limit.

Instead, this commits changes the behavior to build up a stack of nodes, and store their created value as we go. Effectively this is an adaptation of the shunting yard algorithm but for creating Ruby objects.

This change means we can now convert much larger trees into Ruby objects without worrying about stack size.