### PR TITLE
Less const_get

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -4,6 +4,7 @@
 // All non-trivial logic should be in librubyparser so it can be shared its the various callers.
 
 VALUE rb_cYARP;
+VALUE rb_cYARPNode;
 VALUE rb_cYARPSource;
 VALUE rb_cYARPToken;
 VALUE rb_cYARPLocation;
@@ -490,6 +491,7 @@ Init_yarp(void) {
     // Grab up references to all of the constants that we're going to need to
     // reference throughout this extension.
     rb_cYARP = rb_define_module("YARP");
+    rb_cYARPNode = rb_define_class_under(rb_cYARP, "Node", rb_cObject);
     rb_cYARPSource = rb_define_class_under(rb_cYARP, "Source", rb_cObject);
     rb_cYARPToken = rb_define_class_under(rb_cYARP, "Token", rb_cObject);
     rb_cYARPLocation = rb_define_class_under(rb_cYARP, "Location", rb_cObject);
@@ -520,6 +522,7 @@ Init_yarp(void) {
     rb_define_singleton_method(rb_cYARPDebug, "memsize", memsize, 1);
     rb_define_singleton_method(rb_cYARPDebug, "profile_file", profile_file, 1);
 
-    // Next, initialize the pack API.
+    // Next, initialize the other APIs.
+    Init_yarp_api_node();
     Init_yarp_pack();
 }

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -11,6 +11,7 @@ VALUE yp_source_new(yp_parser_t *parser);
 VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source);
 VALUE yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
 
+void Init_yarp_api_node(void);
 void Init_yarp_pack(void);
 YP_EXPORTED_FUNCTION void Init_yarp(void);
 

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -2,9 +2,14 @@
 #include "yarp/extension.h"
 
 extern VALUE rb_cYARP;
+extern VALUE rb_cYARPNode;
 extern VALUE rb_cYARPSource;
 extern VALUE rb_cYARPToken;
 extern VALUE rb_cYARPLocation;
+
+<%- nodes.each do |node| -%>
+static VALUE rb_cYARP<%= node.name %>;
+<%- end -%>
 
 static VALUE
 yp_location_new(yp_parser_t *parser, const char *start, const char *end, VALUE source) {
@@ -174,7 +179,7 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     // location
                     argv[<%= node.params.length %>] = yp_location_new(parser, node->location.start, node->location.end, source);
 
-                    rb_ary_push(value_stack, rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_const_get_at(rb_cYARP, rb_intern("<%= node.name %>"))));
+                    rb_ary_push(value_stack, rb_class_new_instance(<%= node.params.length + 1 %>, argv, rb_cYARP<%= node.name %>));
                     break;
                 }
                 <%- end -%>
@@ -187,4 +192,11 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
     VALUE result = rb_ary_pop(value_stack);
     free(constants);
     return result;
+}
+
+void
+Init_yarp_api_node(void) {
+    <%- nodes.each do |node| -%>
+    rb_cYARP<%= node.name %> = rb_define_class_under(rb_cYARP, "<%= node.name %>", rb_cYARPNode);
+    <%- end -%>
 }


### PR DESCRIPTION
Right now whenever you go to create a Ruby object from a C struct we dynamically look up the constants. This is not great for performance. Now instead we template out a constant for each VALUE that holds the classes, and then directly reference it.