### PR TITLE
Prep for gem release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby ">= 3.1.0"
-
 gemspec
 
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yarp (0.4.0)
+    yarp (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,5 @@ DEPENDENCIES
   test-unit
   yarp!
 
-RUBY VERSION
-   ruby 3.1.0p0
-
 BUNDLED WITH
    2.3.6

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -5,7 +5,7 @@
 #include <ruby/encoding.h>
 #include "yarp.h"
 
-#define EXPECTED_YARP_VERSION "0.4.0"
+#define EXPECTED_YARP_VERSION "0.6.0"
 
 VALUE yp_source_new(yp_parser_t *parser);
 VALUE yp_token_new(yp_parser_t *parser, yp_token_t *token, rb_encoding *encoding, VALUE source);

--- a/include/yarp/version.h
+++ b/include/yarp/version.h
@@ -1,5 +1,5 @@
 #define YP_VERSION_MAJOR 0
-#define YP_VERSION_MINOR 4
+#define YP_VERSION_MINOR 6
 #define YP_VERSION_PATCH 0
 
-#define YP_VERSION "0.4.0"
+#define YP_VERSION "0.6.0"

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -57,7 +57,7 @@ public class Loader {
         expect((byte) 'P');
 
         expect((byte) 0);
-        expect((byte) 4);
+        expect((byte) 6);
         expect((byte) 0);
 
         // This loads the name of the encoding. We don't actually do anything

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -40,8 +40,8 @@ module YARP
       end
 
       def load
-        io.read(4) => "YARP"
-        io.read(3).unpack("C3") => [0, 4, 0]
+        raise "Invalid serialization" if io.read(4) != "YARP"
+        raise "Invalid serialization" if io.read(3).unpack("C3") != [0, 6, 0]
 
         @encoding = Encoding.find(io.read(load_varint))
         @input = input.force_encoding(@encoding).freeze

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -1,5 +1,16 @@
 require "stringio"
 
+# Polyfill for String#unpack1 with the offset parameter.
+if String.instance_method(:unpack1).parameters.none? { |_, name| name == :offset }
+  String.prepend(
+    Module.new {
+      def unpack1(format, offset: 0)
+        offset == 0 ? super(format) : self[offset..].unpack1(format)
+      end
+    }
+  )
+end
+
 module YARP
   module Serialize
     def self.load(input, serialized)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -984,23 +984,27 @@ class ErrorsTest < Test::Unit::TestCase
   end
 
   def test_duplicated_parameter_names
-    expected = DefNode(
-      Location(),
-      nil,
-      ParametersNode([RequiredParameterNode(:a), RequiredParameterNode(:b), RequiredParameterNode(:a)], [], [], nil, [], nil, nil),
-      nil,
-      [:a, :b],
-      Location(),
-      nil,
-      Location(),
-      Location(),
-      nil,
-      Location()
-    )
+    # For some reason, Ripper reports no error for Ruby 3.0 when you have
+    # duplicated parameter names for positional parameters.
+    unless RUBY_VERSION < "3.1.0"
+      expected = DefNode(
+        Location(),
+        nil,
+        ParametersNode([RequiredParameterNode(:a), RequiredParameterNode(:b), RequiredParameterNode(:a)], [], [], nil, [], nil, nil),
+        nil,
+        [:a, :b],
+        Location(),
+        nil,
+        Location(),
+        Location(),
+        nil,
+        Location()
+      )
 
-    assert_errors expected, "def foo(a,b,a);end", [
-      ["Duplicated parameter name.", 12..13]
-    ]
+      assert_errors expected, "def foo(a,b,a);end", [
+        ["Duplicated parameter name.", 12..13]
+      ]
+    end
 
     expected = DefNode(
       Location(),

--- a/test/newline_test.rb
+++ b/test/newline_test.rb
@@ -63,6 +63,9 @@ class NewlineTest < Test::Unit::TestCase
           line.include?('(token[2].start_with?("\#$") || token[2].start_with?("\#@"))')
         end
         actual.delete(index + 1)
+      elsif relative == "test/parse_test.rb"
+        line_number = source.lines.index { |line| line.include?("while (node = queue.shift)") } + 1
+        expected.delete_at(expected.index(line_number))
       end
 
       assert_equal expected, actual

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -138,7 +138,6 @@ class ParseTest < Test::Unit::TestCase
       return node if node.is_a?(YARP::SourceFileNode)
       queue.concat(node.child_nodes.compact)
     end
-    nil
   end
 
   def ignore_warnings

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2,6 +2,10 @@
 
 require "yarp_test_helper"
 
+# To accurately compare against the snapshots, we need to make sure that we're
+# running on Ruby 3.2+.
+return if RUBY_VERSION < "3.2.0"
+
 # It is useful to have a diff even if the strings to compare are big
 # However, ruby/ruby does not have a version of Test::Unit with access to
 # max_diff_target_string_size
@@ -25,38 +29,18 @@ class ParseTest < Test::Unit::TestCase
     ignore_warnings { Encoding.default_external = @previous_default_external }
   end
 
-  def test_Ruby_3_2_plus
-    assert_operator RUBY_VERSION, :>=, "3.2.0", "ParseTest requires Ruby 3.2+"
-  end
-
   def test_empty_string
     YARP.parse("") => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: []]]]
   end
 
-  known_failures = %w[
-    seattlerb/heredoc_nested.txt
-  ]
-
-  if RUBY_VERSION < "3.3.0"
-    known_failures << "seattlerb/pct_w_heredoc_interp_nested.txt"
-  end
-
-  def find_source_file_node(node)
-    if node.is_a?(YARP::SourceFileNode)
-      node
-    else
-      node && node.child_nodes.each do |child_node|
-        source_file_node = find_source_file_node(child_node)
-        return source_file_node if source_file_node
-      end
-    end
-  end
+  known_failures = %w[seattlerb/heredoc_nested.txt]
+  known_failures << "seattlerb/pct_w_heredoc_interp_nested.txt" if RUBY_VERSION < "3.3.0"
 
   def test_parse_takes_file_path
     filepath = "filepath.rb"
-    parsed_result = YARP.parse("def foo; __FILE__; end", filepath)
+    result = YARP.parse("def foo; __FILE__; end", filepath)
 
-    assert_equal filepath, find_source_file_node(parsed_result.value).filepath
+    assert_equal filepath, find_source_file_node(result.value).filepath
   end
 
   base = File.join(__dir__, "fixtures")
@@ -147,6 +131,15 @@ class ParseTest < Test::Unit::TestCase
   end
 
   private
+
+  def find_source_file_node(program)
+    queue = [program]
+    while (node = queue.shift)
+      return node if node.is_a?(YARP::SourceFileNode)
+      queue.concat(node.child_nodes.compact)
+    end
+    nil
+  end
 
   def ignore_warnings
     previous_verbosity = $VERBOSE

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "yarp"
-  spec.version = "0.4.0"
+  spec.version = "0.6.0"
   spec.authors = ["Shopify"]
   spec.email = ["ruby@shopify.com"]
 

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/ruby/yarp"
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.0.0"
+
   spec.require_paths = ["lib"]
   spec.files = [
     "CODE_OF_CONDUCT.md",


### PR DESCRIPTION
* Drop requirement to Ruby 3.0.0
* Bump YARP version to 0.6.0
* Polyfill `unpack1` with the offset parameter for Ruby 3.0
* Remove single-line pattern matching in `serialize.rb` to get rid of warning in Ruby 3.0
* Fix tests so that they pass on Ruby 3.0, 3.1, 3.2, and 3.3

Incorporated work from #1140 so we can close that after this is out.