### PR TITLE
Separate yp_node_flags_t from yp_node_type_t

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2284,8 +2284,8 @@ yp_if_node_create(yp_parser_t *parser,
 
     *node = (yp_if_node_t) {
         {
-            .flags = YP_NODE_FLAG_NEWLINE,
             .type = YP_NODE_IF_NODE,
+            .flags = YP_NODE_FLAG_NEWLINE,
             .location = {
                 .start = if_keyword->start,
                 .end = end
@@ -2311,8 +2311,8 @@ yp_if_node_modifier_create(yp_parser_t *parser, yp_node_t *statement, const yp_t
 
     *node = (yp_if_node_t) {
         {
-            .flags = YP_NODE_FLAG_NEWLINE,
             .type = YP_NODE_IF_NODE,
+            .flags = YP_NODE_FLAG_NEWLINE,
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end
@@ -2344,8 +2344,8 @@ yp_if_node_ternary_create(yp_parser_t *parser, yp_node_t *predicate, yp_node_t *
 
     *node = (yp_if_node_t) {
         {
-            .flags = YP_NODE_FLAG_NEWLINE,
             .type = YP_NODE_IF_NODE,
+            .flags = YP_NODE_FLAG_NEWLINE,
             .location = {
                 .start = predicate->location.start,
                 .end = false_expression->location.end,
@@ -4007,8 +4007,8 @@ yp_unless_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t 
 
     *node = (yp_unless_node_t) {
         {
-            .flags = YP_NODE_FLAG_NEWLINE,
             .type = YP_NODE_UNLESS_NODE,
+            .flags = YP_NODE_FLAG_NEWLINE,
             .location = {
                 .start = keyword->start,
                 .end = end
@@ -4034,8 +4034,8 @@ yp_unless_node_modifier_create(yp_parser_t *parser, yp_node_t *statement, const 
 
     *node = (yp_unless_node_t) {
         {
-            .flags = YP_NODE_FLAG_NEWLINE,
             .type = YP_NODE_UNLESS_NODE,
+            .flags = YP_NODE_FLAG_NEWLINE,
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -505,7 +505,7 @@ yp_statements_node_body_append(yp_statements_node_t *node, yp_node_t *statement)
 // implement our own arena allocation.
 static inline void *
 yp_alloc_node(YP_ATTRIBUTE_UNUSED yp_parser_t *parser, size_t size) {
-    void *memory = malloc(size);
+    void *memory = calloc(1, size);
     if (memory == NULL) {
         fprintf(stderr, "Failed to allocate %zu bytes\n", size);
         abort();
@@ -2284,7 +2284,8 @@ yp_if_node_create(yp_parser_t *parser,
 
     *node = (yp_if_node_t) {
         {
-            .type = YP_NODE_IF_NODE | YP_NODE_FLAG_NEWLINE,
+            .flags = YP_NODE_FLAG_NEWLINE,
+            .type = YP_NODE_IF_NODE,
             .location = {
                 .start = if_keyword->start,
                 .end = end
@@ -2310,7 +2311,8 @@ yp_if_node_modifier_create(yp_parser_t *parser, yp_node_t *statement, const yp_t
 
     *node = (yp_if_node_t) {
         {
-            .type = YP_NODE_IF_NODE | YP_NODE_FLAG_NEWLINE,
+            .flags = YP_NODE_FLAG_NEWLINE,
+            .type = YP_NODE_IF_NODE,
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end
@@ -2342,7 +2344,8 @@ yp_if_node_ternary_create(yp_parser_t *parser, yp_node_t *predicate, yp_node_t *
 
     *node = (yp_if_node_t) {
         {
-            .type = YP_NODE_IF_NODE | YP_NODE_FLAG_NEWLINE,
+            .flags = YP_NODE_FLAG_NEWLINE,
+            .type = YP_NODE_IF_NODE,
             .location = {
                 .start = predicate->location.start,
                 .end = false_expression->location.end,
@@ -3746,7 +3749,7 @@ yp_statements_node_body_append(yp_statements_node_t *node, yp_node_t *statement)
     node->base.location.end = statement->location.end;
 
     // Every statement gets marked as a place where a newline can occur.
-    statement->type |= YP_NODE_FLAG_NEWLINE;
+    statement->flags = YP_NODE_FLAG_NEWLINE;
 }
 
 // Allocate a new StringConcatNode node.
@@ -4004,7 +4007,8 @@ yp_unless_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t 
 
     *node = (yp_unless_node_t) {
         {
-            .type = YP_NODE_UNLESS_NODE | YP_NODE_FLAG_NEWLINE,
+            .flags = YP_NODE_FLAG_NEWLINE,
+            .type = YP_NODE_UNLESS_NODE,
             .location = {
                 .start = keyword->start,
                 .end = end
@@ -4030,7 +4034,8 @@ yp_unless_node_modifier_create(yp_parser_t *parser, yp_node_t *statement, const 
 
     *node = (yp_unless_node_t) {
         {
-            .type = YP_NODE_UNLESS_NODE | YP_NODE_FLAG_NEWLINE,
+            .flags = YP_NODE_FLAG_NEWLINE,
+            .type = YP_NODE_UNLESS_NODE,
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -55,25 +55,22 @@ enum yp_node_type {
 typedef uint16_t yp_node_type_t;
 typedef uint16_t yp_node_flags_t;
 
-// We store the node type enum in every node in the tree. We don't have nearly
-// as many node types as we do bits in an enum, so we're going to use the top
-// half of the enum to store flags about the node.
-static const unsigned int YP_NODE_FLAG_NEWLINE = 0x1;
+// We store the flags enum in every node in the tree
+static const uint16_t YP_NODE_FLAG_NEWLINE = 0x1;
 
-// For easy access, we define some macros that manipulate only the bottom half
-// of the node type enum.
+// For easy access, we define some macros to check node type
 #define YP_NODE_TYPE(node) ((enum yp_node_type)node->type)
 #define YP_NODE_TYPE_P(node, type) (YP_NODE_TYPE(node) == (type))
 
 // This is the overall tagged union representing a node in the syntax tree.
 typedef struct yp_node {
-    // This represents any flags on the node. Currently, this is only a newline
-    // flag
-    yp_node_flags_t flags;
-
     // This represents the type of the node. It somewhat maps to the nodes that
     // existed in the original grammar and ripper, but it's not a 1:1 mapping.
     yp_node_type_t type;
+
+    // This represents any flags on the node. Currently, this is only a newline
+    // flag
+    yp_node_flags_t flags;
 
     // This is the location of the node in the source. It's a range of bytes
     // containing a start and an end.

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -46,26 +46,31 @@ typedef struct yp_node_list {
     size_t capacity;
 } yp_node_list_t;
 
-typedef enum {
+enum yp_node_type {
 <%- nodes.each_with_index do |node, index| -%>
     <%= node.type %> = <%= index + 1 %>,
 <%- end -%>
-} yp_node_type_t;
+};
+
+typedef uint16_t yp_node_type_t;
+typedef uint16_t yp_node_flags_t;
 
 // We store the node type enum in every node in the tree. We don't have nearly
 // as many node types as we do bits in an enum, so we're going to use the top
 // half of the enum to store flags about the node.
-#define YP_NODE_FLAGS_SHIFT (sizeof(yp_node_type_t) * 8 / 2)
-#define YP_NODE_FLAG_NEWLINE (1U << YP_NODE_FLAGS_SHIFT)
+static const unsigned int YP_NODE_FLAG_NEWLINE = 0x1;
 
 // For easy access, we define some macros that manipulate only the bottom half
 // of the node type enum.
-static const unsigned int YP_NODE_TYPE_MASK = ((1 << (sizeof(yp_node_type_t) * 8 / 2)) - 1);
-#define YP_NODE_TYPE(node) ((node)->type & YP_NODE_TYPE_MASK)
+#define YP_NODE_TYPE(node) ((enum yp_node_type)node->type)
 #define YP_NODE_TYPE_P(node, type) (YP_NODE_TYPE(node) == (type))
 
 // This is the overall tagged union representing a node in the syntax tree.
 typedef struct yp_node {
+    // This represents any flags on the node. Currently, this is only a newline
+    // flag
+    yp_node_flags_t flags;
+
     // This represents the type of the node. It somewhat maps to the nodes that
     // existed in the original grammar and ripper, but it's not a 1:1 mapping.
     yp_node_type_t type;


### PR DESCRIPTION
Prior to this commit, we folded the flags into the type. This created extra overhead when calculating the type and setting the flags. This commit separates them.

Found this when debugging a direct access to `node->type` working on the compiler. I'm now using `YP_NODE_TYPE` over there regardless, but it seems to add unnecessary overhead to store the flags with the type.