### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.0] - 2023-08-09
+
+### Added
+
+- 🎉 Initial release! 🎉
+
+[unreleased]: https://github.com/ruby/yarp/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/ruby/yarp/compare/d60531...v0.6.0

--- a/yarp.gemspec
+++ b/yarp.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
   spec.files = [
+    "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "LICENSE.md",


### PR DESCRIPTION
Now that we have a public gem, we should do a better job of documenting API changes to make it easier on our consumers to see what's happening.