### PR TITLE
Test Java Loader in build-java job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,20 +74,28 @@ jobs:
     - name: Run Ruby tests
       run: bundle exec rake compile_no_debug
 
-  build-jruby:
+  build-java:
     runs-on: ubuntu-latest
     env:
       JRUBY_OPTS: "--dev"
     steps:
     - uses: actions/checkout@v3
+    - name: Set up CRuby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+    - name: Serialize fixtures on CRuby
+      run: bundle exec rake compile test:serialize_fixtures
     - name: Set up JRuby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby
         bundler-cache: true
     - name: Compile generated Java files
-      run: jruby --dev -S bundle exec rake compile
-      shell: bash
+      run: bundle exec rake compile
+    - name: Run Java Loader test
+      run: JRUBY_OPTS="-J-ea" bundle exec rake test:java_loader
 
   lex-ruby:
     runs-on: ubuntu-latest

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -5,10 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * *'
 
 jobs:
   # Inspired from https://github.com/oracle/truffleruby/blob/master/.github/workflows/ci.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/test/serialized/
 /top-100-gems/
 /tmp/
 /vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
 
 PLATFORMS
   ruby
+  universal-java-17
 
 DEPENDENCIES
   rake

--- a/rakelib/serialization.rake
+++ b/rakelib/serialization.rake
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+known_failures = %w[seattlerb/heredoc_nested.txt]
+fixtures = File.expand_path("../test/fixtures", __dir__)
+serialized_dir = File.expand_path("../serialized", fixtures)
+
+desc "Serialize test fixtures and save it to .serialized files"
+task "test:serialize_fixtures" do
+  $:.unshift(File.expand_path("../lib", __dir__))
+  require "yarp"
+  require "fileutils"
+
+  Dir["**/*.txt", base: fixtures].each do |relative|
+    next if known_failures.include?(relative)
+    path = "#{fixtures}/#{relative}"
+    serialized_path = "#{serialized_dir}/#{relative}"
+
+    serialized = YARP.dump_file(path)
+    FileUtils.mkdir_p(File.dirname(serialized_path))
+    File.write(serialized_path, serialized)
+  end
+end
+
+task "test:java_loader" do
+  require 'java'
+  require_relative '../tmp/yarp.jar'
+  java_import 'org.yarp.Nodes$Source'
+
+  Dir["**/*.txt", base: fixtures].each do |relative|
+    next if known_failures.include?(relative)
+    path = "#{fixtures}/#{relative}"
+    serialized_path = "#{serialized_dir}/#{relative}"
+    serialized = File.binread(serialized_path).unpack('c*')
+
+    puts
+    puts path
+    source_bytes = File.binread(path).unpack('c*')
+    source = Source.new(source_bytes.to_java(:byte))
+    parse_result = org.yarp.Loader.load(serialized, source)
+    puts parse_result.value
+  end
+end

--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -82,10 +82,30 @@ public abstract class Nodes {
         public final byte[] bytes;
         private final int[] lineOffsets;
 
+        public Source(byte[] bytes) {
+            this(bytes, computeLineOffsets(bytes));
+        }
+
         public Source(byte[] bytes, int[] lineOffsets) {
             assert lineOffsets[0] == 0;
             this.bytes = bytes;
             this.lineOffsets = lineOffsets;
+        }
+
+        public static int[] computeLineOffsets(byte[] bytes) {
+            int[] lineOffsets = new int[8];
+            int lineOffsetsSize = 0;
+            lineOffsets[lineOffsetsSize++] = 0;
+
+            for (int i = 0; i < bytes.length; i++) {
+                if (bytes[i] == '\n') {
+                    if (lineOffsetsSize == lineOffsets.length) {
+                        lineOffsets = Arrays.copyOf(lineOffsets, lineOffsets.length * 2);
+                    }
+                    lineOffsets[lineOffsetsSize++] = i + 1;
+                }
+            }
+            return Arrays.copyOf(lineOffsets, lineOffsetsSize);
         }
 
         public int line(int byteOffset) {


### PR DESCRIPTION
As we discussed on Slack.
This change in CI means e.g. node names and field names and other similar breaking changes can be merged with a green CI here.
The modified CI job now runs Loader.java and ensures it can deserialize fine, in addition to just javac-building `.java` files before.
That uses JRuby for convenience, so the file walking logic can be shared in Ruby instead of having to duplicate it in Java, cc @enebo 