### PR TITLE
Make lone splat on RHS an array

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -12195,18 +12195,18 @@ static inline yp_node_t *
 parse_assignment_value(yp_parser_t *parser, yp_binding_power_t previous_binding_power, yp_binding_power_t binding_power, const char *message) {
     yp_node_t *value = parse_starred_expression(parser, binding_power, message);
 
-    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && accept(parser, YP_TOKEN_COMMA)) {
+    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && (YP_NODE_TYPE_P(value, YP_NODE_SPLAT_NODE) || match_type_p(parser, YP_TOKEN_COMMA))) {
         yp_token_t opening = not_provided(parser);
         yp_array_node_t *array = yp_array_node_create(parser, &opening);
 
         yp_array_node_elements_append(array, value);
         value = (yp_node_t *) array;
 
-        do {
+        while (accept(parser, YP_TOKEN_COMMA)) {
             yp_node_t *element = parse_starred_expression(parser, binding_power, "Expected an element for the array.");
             yp_array_node_elements_append(array, element);
             if (YP_NODE_TYPE_P(element, YP_NODE_MISSING_NODE)) break;
-        } while (accept(parser, YP_TOKEN_COMMA));
+        }
     }
 
     return value;

--- a/test/snapshots/variables.txt
+++ b/test/snapshots/variables.txt
@@ -173,9 +173,13 @@ ProgramNode(0...293)(
      LocalVariableWriteNode(260...270)(
        :foo,
        0,
-       SplatNode(266...270)(
-         (266...267),
-         LocalVariableReadNode(267...270)(:bar, 0)
+       ArrayNode(266...270)(
+         [SplatNode(266...270)(
+            (266...267),
+            LocalVariableReadNode(267...270)(:bar, 0)
+          )],
+         nil,
+         nil
        ),
        (260...263),
        (264...265)

--- a/test/snapshots/whitequark/asgn_mrhs.txt
+++ b/test/snapshots/whitequark/asgn_mrhs.txt
@@ -4,9 +4,13 @@ ProgramNode(0...41)(
     [LocalVariableWriteNode(0...10)(
        :foo,
        0,
-       SplatNode(6...10)(
-         (6...7),
-         CallNode(7...10)(nil, nil, (7...10), nil, nil, nil, nil, 2, "bar")
+       ArrayNode(6...10)(
+         [SplatNode(6...10)(
+            (6...7),
+            CallNode(7...10)(nil, nil, (7...10), nil, nil, nil, nil, 2, "bar")
+          )],
+         nil,
+         nil
        ),
        (0...3),
        (4...5)

--- a/test/snapshots/whitequark/masgn_splat.txt
+++ b/test/snapshots/whitequark/masgn_splat.txt
@@ -54,9 +54,23 @@ ProgramNode(0...139)(
        [InstanceVariableWriteNode(47...51)((47...51), nil, nil),
         ClassVariableWriteNode(53...58)((53...58), nil, nil)],
        (59...60),
-       SplatNode(61...65)(
-         (61...62),
-         CallNode(62...65)(nil, nil, (62...65), nil, nil, nil, nil, 2, "foo")
+       ArrayNode(61...65)(
+         [SplatNode(61...65)(
+            (61...62),
+            CallNode(62...65)(
+              nil,
+              nil,
+              (62...65),
+              nil,
+              nil,
+              nil,
+              nil,
+              2,
+              "foo"
+            )
+          )],
+         nil,
+         nil
        ),
        nil,
        nil


### PR DESCRIPTION
Implicitly, when you have `foo = *bar`, you're assigning an array. Previously we would only have a splat node on the RHS, but it's more clear to just make it an array.