### PR TITLE
Refactor flags

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -603,7 +603,8 @@ nodes:
         type: node?
         kind: BlockNode
       - name: flags
-        type: uint32
+        type: flags
+        kind: CallNodeFlags
       - name: name
         type: string
     comment: |
@@ -1323,7 +1324,8 @@ nodes:
       - name: closing_loc
         type: location
       - name: flags
-        type: uint32
+        type: flags
+        kind: RegularExpressionFlags
     newline: parts
     comment: |
       Represents a regular expression literal that contains interpolation.
@@ -1746,7 +1748,8 @@ nodes:
       - name: operator_loc
         type: location
       - name: flags
-        type: uint32
+        type: flags
+        kind: RangeNodeFlags
     comment: |
       Represents the use of the `..` or `...` operators.
 
@@ -1781,7 +1784,8 @@ nodes:
       - name: unescaped
         type: string
       - name: flags
-        type: uint32
+        type: flags
+        kind: RegularExpressionFlags
     comment: |
       Represents a regular expression literal with no interpolation.
 
@@ -2072,7 +2076,8 @@ nodes:
         type: node?
         kind: StatementsNode
       - name: flags
-        type: uint32
+        type: flags
+        kind: LoopFlags
     newline: predicate
     comment: |
       Represents the use of the `until` keyword, either in the block form or the modifier form.
@@ -2106,7 +2111,8 @@ nodes:
         type: node?
         kind: StatementsNode
       - name: flags
-        type: uint32
+        type: flags
+        kind: LoopFlags
     newline: predicate
     comment: |
       Represents the use of the `while` keyword, either in the block form or the modifier form.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -459,7 +459,7 @@ yp_flip_flop(yp_node_t *node) {
         }
         case YP_NODE_RANGE_NODE: {
             yp_range_node_t *cast = (yp_range_node_t *) node;
-            cast->flags |= YP_RANGE_NODE_FLAGS_FLIP_FLOP;
+            cast->base.flags |= YP_RANGE_NODE_FLAGS_FLIP_FLOP;
             break;
         }
         default:
@@ -530,9 +530,9 @@ yp_arguments_validate(yp_parser_t *parser, yp_arguments_t *arguments) {
 /******************************************************************************/
 
 // Parse out the options for a regular expression.
-static inline uint32_t
+static inline uint16_t
 yp_regular_expression_flags_create(const yp_token_t *closing) {
-    uint32_t flags = 0;
+    uint16_t flags = 0;
 
     if (closing->type == YP_TOKEN_REGEXP_END) {
         for (const char *flag = closing->start + 1; flag < closing->end; flag++) {
@@ -1123,8 +1123,7 @@ yp_call_node_create(yp_parser_t *parser) {
         .opening_loc = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE,
         .arguments = NULL,
         .closing_loc = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE,
-        .block = NULL,
-        .flags = 0
+        .block = NULL
     };
 
     return node;
@@ -1200,7 +1199,7 @@ yp_call_node_call_create(yp_parser_t *parser, yp_node_t *receiver, yp_token_t *o
     node->block = arguments->block;
 
     if (operator->type == YP_TOKEN_AMPERSAND_DOT) {
-        node->flags |= YP_CALL_NODE_FLAGS_SAFE_NAVIGATION;
+        node->base.flags |= YP_CALL_NODE_FLAGS_SAFE_NAVIGATION;
     }
 
     yp_string_shared_init(&node->name, message->start, message->end);
@@ -1276,7 +1275,7 @@ yp_call_node_shorthand_create(yp_parser_t *parser, yp_node_t *receiver, yp_token
     node->block = arguments->block;
 
     if (operator->type == YP_TOKEN_AMPERSAND_DOT) {
-        node->flags |= YP_CALL_NODE_FLAGS_SAFE_NAVIGATION;
+        node->base.flags |= YP_CALL_NODE_FLAGS_SAFE_NAVIGATION;
     }
 
     yp_string_constant_init(&node->name, "call", 4);
@@ -1317,7 +1316,7 @@ yp_call_node_variable_call_create(yp_parser_t *parser, yp_token_t *message) {
 // without a receiver that could also have been a local variable read).
 static inline bool
 yp_call_node_variable_call_p(yp_call_node_t *node) {
-    return node->flags & YP_CALL_NODE_FLAGS_VARIABLE_CALL;
+    return node->base.flags & YP_CALL_NODE_FLAGS_VARIABLE_CALL;
 }
 
 // Allocate and initialize a new CallOperatorAndWriteNode node.
@@ -2657,7 +2656,6 @@ yp_interpolated_regular_expression_node_create(yp_parser_t *parser, const yp_tok
         },
         .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
         .closing_loc = YP_LOCATION_TOKEN_VALUE(opening),
-        .flags = 0,
         .parts = YP_EMPTY_NODE_LIST
     };
 
@@ -2674,7 +2672,7 @@ static inline void
 yp_interpolated_regular_expression_node_closing_set(yp_interpolated_regular_expression_node_t *node, const yp_token_t *closing) {
     node->closing_loc = YP_LOCATION_TOKEN_VALUE(closing);
     node->base.location.end = closing->end;
-    node->flags = yp_regular_expression_flags_create(closing);
+    node->base.flags |= yp_regular_expression_flags_create(closing);
 }
 
 // Allocate and initialize a new InterpolatedStringNode node.
@@ -3458,14 +3456,13 @@ yp_range_node_create(yp_parser_t *parser, yp_node_t *left, const yp_token_t *ope
         },
         .left = left,
         .right = right,
-        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
-        .flags = 0,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
     };
 
     switch (operator->type) {
         case YP_TOKEN_DOT_DOT_DOT:
         case YP_TOKEN_UDOT_DOT_DOT:
-            node->flags |= YP_RANGE_NODE_FLAGS_EXCLUDE_END;
+            node->base.flags |= YP_RANGE_NODE_FLAGS_EXCLUDE_END;
             break;
         default:
             break;
@@ -3492,6 +3489,7 @@ yp_regular_expression_node_create(yp_parser_t *parser, const yp_token_t *opening
     *node = (yp_regular_expression_node_t) {
         {
             .type = YP_NODE_REGULAR_EXPRESSION_NODE,
+            .flags = yp_regular_expression_flags_create(closing),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -3500,7 +3498,7 @@ yp_regular_expression_node_create(yp_parser_t *parser, const yp_token_t *opening
         .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
         .content_loc = YP_LOCATION_TOKEN_VALUE(content),
         .closing_loc = YP_LOCATION_TOKEN_VALUE(closing),
-        .flags = yp_regular_expression_flags_create(closing)
+        .unescaped = YP_EMPTY_STRING
     };
 
     return node;
@@ -3813,7 +3811,7 @@ yp_statements_node_body_append(yp_statements_node_t *node, yp_node_t *statement)
     node->base.location.end = statement->location.end;
 
     // Every statement gets marked as a place where a newline can occur.
-    statement->flags = YP_NODE_FLAG_NEWLINE;
+    statement->flags |= YP_NODE_FLAG_NEWLINE;
 }
 
 // Allocate a new StringConcatNode node.
@@ -4125,7 +4123,7 @@ yp_unless_node_end_keyword_loc_set(yp_unless_node_t *node, const yp_token_t *end
 
 // Allocate a new UntilNode node.
 static yp_until_node_t *
-yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint32_t flags) {
+yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint16_t flags) {
     yp_until_node_t *node = YP_ALLOC_NODE(parser, yp_until_node_t);
     bool has_statements = (statements != NULL) && (statements->body.size != 0);
 
@@ -4146,6 +4144,7 @@ yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *
     *node = (yp_until_node_t) {
         {
             .type = YP_NODE_UNTIL_NODE,
+            .flags = flags,
             .location = {
                 .start = start,
                 .end = end,
@@ -4153,8 +4152,7 @@ yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *
         },
         .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
         .predicate = predicate,
-        .statements = statements,
-        .flags = flags
+        .statements = statements
     };
 
     return node;
@@ -4200,7 +4198,7 @@ yp_when_node_statements_set(yp_when_node_t *node, yp_statements_node_t *statemen
 
 // Allocate a new WhileNode node.
 static yp_while_node_t *
-yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint32_t flags) {
+yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint16_t flags) {
     yp_while_node_t *node = YP_ALLOC_NODE(parser, yp_while_node_t);
 
     const char *start = NULL;
@@ -4221,6 +4219,7 @@ yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *
     *node = (yp_while_node_t) {
         {
             .type = YP_NODE_WHILE_NODE,
+            .flags = flags,
             .location = {
                 .start = start,
                 .end = end,
@@ -4228,8 +4227,7 @@ yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *
         },
         .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
         .predicate = predicate,
-        .statements = statements,
-        .flags = flags
+        .statements = statements
     };
 
     return node;
@@ -9433,7 +9431,7 @@ parse_alias_argument(yp_parser_t *parser, bool first) {
 // Parse an identifier into either a local variable read or a call.
 static yp_node_t *
 parse_variable_call(yp_parser_t *parser) {
-    uint32_t flags = 0;
+    uint16_t flags = 0;
 
     if (!match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) && (parser->previous.end[-1] != '!') && (parser->previous.end[-1] != '?')) {
         int depth;
@@ -9445,7 +9443,7 @@ parse_variable_call(yp_parser_t *parser) {
     }
 
     yp_call_node_t *node = yp_call_node_variable_call_create(parser, &parser->previous);
-    node->flags = flags;
+    node->base.flags |= flags;
 
     return (yp_node_t *) node;
 }
@@ -10599,7 +10597,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 if (parse_arguments_list(parser, &arguments, true)) {
                     // Since we found arguments, we need to turn off the
                     // variable call bit in the flags.
-                    call->flags &= (uint32_t) ~YP_CALL_NODE_FLAGS_VARIABLE_CALL;
+                    call->base.flags &= (uint16_t) ~YP_CALL_NODE_FLAGS_VARIABLE_CALL;
 
                     call->opening_loc = arguments.opening_loc;
                     call->arguments = arguments.arguments;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -530,9 +530,9 @@ yp_arguments_validate(yp_parser_t *parser, yp_arguments_t *arguments) {
 /******************************************************************************/
 
 // Parse out the options for a regular expression.
-static inline uint16_t
+static inline yp_node_flags_t
 yp_regular_expression_flags_create(const yp_token_t *closing) {
-    uint16_t flags = 0;
+    yp_node_flags_t flags = 0;
 
     if (closing->type == YP_TOKEN_REGEXP_END) {
         for (const char *flag = closing->start + 1; flag < closing->end; flag++) {
@@ -4123,7 +4123,7 @@ yp_unless_node_end_keyword_loc_set(yp_unless_node_t *node, const yp_token_t *end
 
 // Allocate a new UntilNode node.
 static yp_until_node_t *
-yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint16_t flags) {
+yp_until_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, yp_node_flags_t flags) {
     yp_until_node_t *node = YP_ALLOC_NODE(parser, yp_until_node_t);
     bool has_statements = (statements != NULL) && (statements->body.size != 0);
 
@@ -4198,7 +4198,7 @@ yp_when_node_statements_set(yp_when_node_t *node, yp_statements_node_t *statemen
 
 // Allocate a new WhileNode node.
 static yp_while_node_t *
-yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, uint16_t flags) {
+yp_while_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *predicate, yp_statements_node_t *statements, yp_node_flags_t flags) {
     yp_while_node_t *node = YP_ALLOC_NODE(parser, yp_while_node_t);
 
     const char *start = NULL;
@@ -9431,7 +9431,7 @@ parse_alias_argument(yp_parser_t *parser, bool first) {
 // Parse an identifier into either a local variable read or a call.
 static yp_node_t *
 parse_variable_call(yp_parser_t *parser) {
-    uint16_t flags = 0;
+    yp_node_flags_t flags = 0;
 
     if (!match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) && (parser->previous.end[-1] != '!') && (parser->previous.end[-1] != '?')) {
         int depth;
@@ -10597,7 +10597,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 if (parse_arguments_list(parser, &arguments, true)) {
                     // Since we found arguments, we need to turn off the
                     // variable call bit in the flags.
-                    call->base.flags &= (uint16_t) ~YP_CALL_NODE_FLAGS_VARIABLE_CALL;
+                    call->base.flags &= (yp_node_flags_t) ~YP_CALL_NODE_FLAGS_VARIABLE_CALL;
 
                     call->opening_loc = arguments.opening_loc;
                     call->arguments = arguments.arguments;

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -171,6 +171,8 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     argv[<%= index %>] = cast-><%= param.name %>.start == NULL ? Qnil : yp_location_new(parser, cast-><%= param.name %>.start, cast-><%= param.name %>.end, source);
                     <%- when UInt32Param -%>
                     argv[<%= index %>] = ULONG2NUM(cast-><%= param.name %>);
+                    <%- when FlagsParam -%>
+                    argv[<%= index %>] = ULONG2NUM(node->flags >> <%= COMMON_FLAGS %>);
                     <%- else -%>
                     <%- raise -%>
                     <%- end -%>

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -55,7 +55,8 @@ enum yp_node_type {
 typedef uint16_t yp_node_type_t;
 typedef uint16_t yp_node_flags_t;
 
-// We store the flags enum in every node in the tree
+// We store the flags enum in every node in the tree. Some flags are common to
+// all nodes (the ones listed below). Others are specific to certain node types.
 static const uint16_t YP_NODE_FLAG_NEWLINE = 0x1;
 
 // For easy access, we define some macros to check node type
@@ -81,7 +82,7 @@ typedef struct yp_node {
 // <%= node.name %>
 typedef struct yp_<%= node.human %> {
     yp_node_t base;
-<%- node.params.each do |param| -%>
+<%- node.params.grep_v(FlagsParam).each do |param| -%>
     <%= case param
     in NodeParam | OptionalNodeParam then "struct #{param.c_type} *#{param.name}"
     in NodeListParam then "struct yp_node_list #{param.name}"
@@ -100,7 +101,7 @@ typedef struct yp_<%= node.human %> {
 
 // <%= flag.name %>
 typedef enum {
-    <%- flag.values.each_with_index do |value, index| -%>
+    <%- flag.values.each.with_index(COMMON_FLAGS) do |value, index| -%>
     YP_<%= flag.human.upcase %>_<%= value.name %> = 1 << <%= index %>,
     <%- end -%>
 } yp_<%= flag.human %>_t;

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -57,7 +57,7 @@ typedef uint16_t yp_node_flags_t;
 
 // We store the flags enum in every node in the tree. Some flags are common to
 // all nodes (the ones listed below). Others are specific to certain node types.
-static const uint16_t YP_NODE_FLAG_NEWLINE = 0x1;
+static const yp_node_flags_t YP_NODE_FLAG_NEWLINE = 0x1;
 
 // For easy access, we define some macros to check node type
 #define YP_NODE_TYPE(node) ((enum yp_node_type)node->type)

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -228,7 +228,7 @@ public class Loader {
               when ConstantListParam then "loadConstants()"
               when LocationParam then "loadLocation()"
               when OptionalLocationParam then "loadOptionalLocation()"
-              when UInt32Param then "loadVarInt()"
+              when UInt32Param, FlagsParam then "loadVarInt()"
               else raise
               end
             }

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -1,5 +1,6 @@
 package org.yarp;
 
+import java.lang.Short;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -207,6 +208,12 @@ public class Loader {
         return x;
     }
 
+    private short loadFlags() {
+        int flags = loadVarInt();
+        assert flags >= 0 && flags <= Short.MAX_VALUE;
+        return (short) flags;
+    }
+
     private Nodes.Node loadNode() {
         int type = buffer.get() & 0xFF;
         int startOffset = loadVarInt();
@@ -228,7 +235,8 @@ public class Loader {
               when ConstantListParam then "loadConstants()"
               when LocationParam then "loadLocation()"
               when OptionalLocationParam then "loadOptionalLocation()"
-              when UInt32Param, FlagsParam then "loadVarInt()"
+              when UInt32Param then "loadVarInt()"
+              when FlagsParam then "loadFlags()"
               else raise
               end
             }

--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -12,55 +12,6 @@ public abstract class Nodes {
 
     public static final byte[][] EMPTY_BYTE_ARRAY_ARRAY = {};
 
-<%- flags.each do |group| -%>
-    public static final class <%= group.name %> implements Comparable<<%= group.name %>> {
-        <%- group.values.each_with_index do |value, index| -%>
-
-        // <%= value.comment %>
-        public static final short <%= value.name %> = 1 << <%= index %>;
-        <%- end -%>
-
-        <%- group.values.each do |value| -%>
-        public static boolean is<%= value.camelcase %>(short flags) {
-            return (flags & <%= value.name %>) != 0;
-        }
-
-        <%- end -%>
-        private final short flags;
-
-        public <%= group.name %>(short flags) {
-            this.flags = flags;
-        }
-
-        @Override
-        public int hashCode() {
-            return flags;
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (!(other instanceof <%= group.name %>)) {
-                return false;
-            }
-
-            return flags == ((<%= group.name %>) other).flags;
-        }
-
-        @Override
-        public int compareTo(<%= group.name %> other) {
-            return flags - other.flags;
-        }
-
-        <%- group.values.each do |value| -%>
-        public boolean is<%= value.camelcase %>() {
-            return (flags & <%= value.name %>) != 0;
-        }
-
-        <%- end -%>
-    }
-
-<%- end -%>
-
     public static final class Location {
 
         public static final Location[] EMPTY_ARRAY = {};
@@ -181,7 +132,56 @@ public abstract class Nodes {
             return builder.toString();
         }
     }
+<%# FLAGS -%>
+    <%- flags.each do |group| -%>
 
+    public static final class <%= group.name %> implements Comparable<<%= group.name %>> {
+        <%- group.values.each_with_index do |value, index| -%>
+
+        // <%= value.comment %>
+        public static final short <%= value.name %> = 1 << <%= index %>;
+        <%- end -%>
+
+        <%- group.values.each do |value| -%>
+        public static boolean is<%= value.camelcase %>(short flags) {
+            return (flags & <%= value.name %>) != 0;
+        }
+
+        <%- end -%>
+        private final short flags;
+
+        public <%= group.name %>(short flags) {
+            this.flags = flags;
+        }
+
+        @Override
+        public int hashCode() {
+            return flags;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof <%= group.name %>)) {
+                return false;
+            }
+
+            return flags == ((<%= group.name %>) other).flags;
+        }
+
+        @Override
+        public int compareTo(<%= group.name %> other) {
+            return flags - other.flags;
+        }
+
+        <%- group.values.each do |value| -%>
+        public boolean is<%= value.camelcase %>() {
+            return (flags & <%= value.name %>) != 0;
+        }
+
+        <%- end -%>
+    }
+<%- end -%>
+<%# NODES -%>
     <%- nodes.each do |node| -%>
 
     <%= "#{node.comment.split("\n").map { |line| "// #{line}" }.join("\n    ")}\n" if node.comment -%>

--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -17,18 +17,18 @@ public abstract class Nodes {
         <%- group.values.each_with_index do |value, index| -%>
 
         // <%= value.comment %>
-        public static final int <%= value.name %> = 1 << <%= index %>;
+        public static final short <%= value.name %> = 1 << <%= index %>;
         <%- end -%>
 
         <%- group.values.each do |value| -%>
-        public static boolean is<%= value.camelcase %>(int flags) {
+        public static boolean is<%= value.camelcase %>(short flags) {
             return (flags & <%= value.name %>) != 0;
         }
 
         <%- end -%>
-        private final int flags;
+        private final short flags;
 
-        public <%= group.name %>(int flags) {
+        public <%= group.name %>(short flags) {
             this.flags = flags;
         }
 

--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -207,7 +207,18 @@ public abstract class Nodes {
             this.<%= param.name %> = <%= param.name %>;
         <%- end -%>
         }
+        <%# methods for flags -%>
+        <%- node.params.each do |param| -%>
+        <%- if param.is_a?(FlagsParam) -%>
+        <%- flags.find { |flag| flag.name == param.kind }.tap { raise "Expected to find #{param.kind}" unless _1 }.values.each do |value| -%>
 
+        public boolean is<%= value.camelcase %>() {
+            return <%= param.kind %>.is<%= value.camelcase %>(this.<%= param.name %>);
+        }
+        <%- end -%>
+        <%- end -%>
+        <%- end -%>
+        <%# potential override of setNewLineFlag() -%>
         <%- if node.newline == false -%>
         @Override
         public void setNewLineFlag(Source source, boolean[] newlineMarked) {

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -71,6 +71,14 @@ module YARP
     def <%= param.name.delete_suffix("_loc") %>
       <%= param.name %>&.slice
     end
+    <%- when FlagsParam -%>
+    <%- flags.find { |flag| flag.name == param.kind }.tap { raise "Expected to find #{param.kind}" unless _1 }.values.each do |value| -%>
+
+    # def <%= value.name.downcase %>?: () -> bool
+    def <%= value.name.downcase %>?
+      <%= param.name %>.anybits?(<%= param.kind %>::<%= value.name %>)
+    end
+    <%- end -%>
     <%- end -%>
     <%- end -%>
   end

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -18,7 +18,7 @@ module YARP
     def accept(visitor)
       visitor.visit_<%= node.human %>(self)
     end
-
+    <%# potential override of set_newline_flag -%>
     <%- if node.newline == false -%>
     def set_newline_flag(newline_marked)
       # Never mark <%= node.name %> with a newline flag, mark children instead

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -136,7 +136,7 @@ module YARP
             when ConstantListParam then "Array.new(load_varint) { load_constant }"
             when LocationParam then "load_location"
             when OptionalLocationParam then "load_optional_location"
-            when UInt32Param then "load_varint"
+            when UInt32Param, FlagsParam then "load_varint"
             else raise
             end
           } + ["location"]).join(", ") -%>)

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -81,7 +81,7 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
         case <%= node.type %>:
             <%- node.params.each do |param| -%>
             <%- case param -%>
-            <%- when LocationParam, OptionalLocationParam, UInt32Param, ConstantParam -%>
+            <%- when LocationParam, OptionalLocationParam, UInt32Param, FlagsParam, ConstantParam -%>
             <%- when NodeParam -%>
             yp_node_destroy(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             <%- when OptionalNodeParam -%>
@@ -121,7 +121,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
             memsize->memsize += sizeof(yp_<%= node.human %>_t);
             <%- node.params.each do |param| -%>
             <%- case param -%>
-            <%- when ConstantParam, UInt32Param, LocationParam, OptionalLocationParam -%>
+            <%- when ConstantParam, UInt32Param, FlagsParam, LocationParam, OptionalLocationParam -%>
             <%- when NodeParam -%>
             yp_node_memsize_node((yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, memsize);
             <%- when OptionalNodeParam -%>

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -73,6 +73,10 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
             char <%= param.name %>_buffer[12];
             snprintf(<%= param.name %>_buffer, sizeof(<%= param.name %>_buffer), "+%d", ((yp_<%= node.human %>_t *)node)-><%= param.name %>);
             yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
+            <%- when FlagsParam -%>
+            char <%= param.name %>_buffer[12];
+            snprintf(<%= param.name %>_buffer, sizeof(<%= param.name %>_buffer), "+%d", node->flags >> <%= COMMON_FLAGS %>);
+            yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
             <%- else -%>
             <%- raise -%>
             <%- end -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -38,11 +38,11 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
     switch (YP_NODE_TYPE(node)) {
         <%- nodes.each do |node| -%>
         case <%= node.type %>: {
-        <%- if node.needs_serialized_length? -%>
-                // serialize length
-                // encoding of location u32s make us need to save this offset.
-                size_t length_offset = buffer->length;
-                yp_buffer_append_str(buffer, "\0\0\0\0", 4); /* consume 4 bytes, updated below */
+            <%- if node.needs_serialized_length? -%>
+            // serialize length
+            // encoding of location u32s make us need to save this offset.
+            size_t length_offset = buffer->length;
+            yp_buffer_append_str(buffer, "\0\0\0\0", 4); /* consume 4 bytes, updated below */
             <%- end -%>
             <%- node.params.each do |param| -%>
             <%- case param -%>
@@ -89,14 +89,16 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
             }
             <%- when UInt32Param -%>
             yp_buffer_append_u32(buffer, ((yp_<%= node.human %>_t *)node)-><%= param.name %>);
+            <%- when FlagsParam -%>
+            yp_buffer_append_u32(buffer, node->flags >> <%= COMMON_FLAGS %>);
             <%- else -%>
             <%- raise -%>
             <%- end -%>
             <%- end -%>
             <%- if node.needs_serialized_length? -%>
-                // serialize length
-                uint32_t length = yp_sizet_to_u32(buffer->length - offset - sizeof(uint32_t));
-                memcpy(buffer->value + length_offset, &length, sizeof(uint32_t));
+            // serialize length
+            uint32_t length = yp_sizet_to_u32(buffer->length - offset - sizeof(uint32_t));
+            memcpy(buffer->value + length_offset, &length, sizeof(uint32_t));
             <%- end -%>
             break;
         }

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -4,6 +4,8 @@ require "erb"
 require "fileutils"
 require "yaml"
 
+COMMON_FLAGS = 1
+
 class Param
   attr_reader :name, :options
 
@@ -101,6 +103,15 @@ class UInt32Param < Param
   def java_type = "int"
 end
 
+# This represents a set of flags. It is very similar to the UInt32Param, but can
+# be directly embedded into the flags field on the struct and provides
+# convenient methods for checking if a flag is set.
+class FlagsParam < Param
+  def rbs_class = "Integer"
+  def java_type = "int"
+  def kind = options.fetch(:kind)
+end
+
 PARAM_TYPES = {
   "node" => NodeParam,
   "node?" => OptionalNodeParam,
@@ -112,6 +123,7 @@ PARAM_TYPES = {
   "location" => LocationParam,
   "location?" => OptionalLocationParam,
   "uint32" => UInt32Param,
+  "flags" => FlagsParam
 }
 
 # This class represents a node in the tree, configured by the config.yml file in

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -108,7 +108,7 @@ end
 # convenient methods for checking if a flag is set.
 class FlagsParam < Param
   def rbs_class = "Integer"
-  def java_type = "int"
+  def java_type = "short"
   def kind = options.fetch(:kind)
 end
 


### PR DESCRIPTION
A couple of things are happening in this commit. We now have a special param type for flags (previously these were all uint32 params). The param type accepts a "kind" field that should link up 1:1 with one of the flag types.

This commit changes all of the previous params known as flags to be of the flags type.

The flags type is special in that it doesn't have its own field in the struct. Instead we embed the value within the flags field (previously the top half of the type enum) shifted by the number of common flags (currently 1). This ends up saving us 4 bytes per call node, range node, until node, while node, regular expression node, and interpolated regular expression node.

When serializing or converting to Ruby, we unshift the value and return it as normal. As such only the C API has changed slightly.

On the Ruby API side, now that we have more information about the kind of flags, we can provide more convenience methods on the nodes based on the names of the flags. This means we now have:

CallNode#safe_navigation?
CallNode#variable_call?

InterpolatedRegularExpressionNode#ignore_case?
InterpolatedRegularExpressionNode#multi_line?
InterpolatedRegularExpressionNode#extended?
InterpolatedRegularExpressionNode#euc_jp?
InterpolatedRegularExpressionNode#ascii_8bit?
InterpolatedRegularExpressionNode#windows_31j?
InterpolatedRegularExpressionNode#utf_8?
InterpolatedRegularExpressionNode#once?

RangeNode#exclude_end?
RangeNode#flip_flop?

RegularExpressionNode#ignore_case?
RegularExpressionNode#multi_line?
RegularExpressionNode#extended?
RegularExpressionNode#euc_jp?
RegularExpressionNode#ascii_8bit?
RegularExpressionNode#windows_31j?
RegularExpressionNode#utf_8?
RegularExpressionNode#once?

UntilNode#begin_modifier?

WhileNode#begin_modifier?