### PR TITLE
Incorporate unary minus on numbers into node

### DIFF
--- a/test/snapshots/method_calls.txt
+++ b/test/snapshots/method_calls.txt
@@ -997,17 +997,7 @@ ProgramNode(0...1200)(
                  (791...793),
                  "a"
                ),
-               CallNode(794...796)(
-                 IntegerNode(795...796)(),
-                 nil,
-                 (794...795),
-                 nil,
-                 nil,
-                 nil,
-                 nil,
-                 0,
-                 "-@"
-               ),
+               IntegerNode(794...796)(),
                nil
              )]
           )]

--- a/test/snapshots/numbers.txt
+++ b/test/snapshots/numbers.txt
@@ -22,45 +22,13 @@ ProgramNode(0...161)(
      IntegerNode(82...85)(),
      ImaginaryNode(87...89)(IntegerNode(87...88)()),
      RationalNode(91...93)(IntegerNode(91...92)()),
-     CallNode(95...97)(
-       IntegerNode(96...97)(),
-       nil,
-       (95...96),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     IntegerNode(95...97)(),
      ImaginaryNode(99...102)(RationalNode(99...101)(IntegerNode(99...100)())),
      ImaginaryNode(104...109)(RationalNode(104...108)(FloatNode(104...107)())),
-     CallNode(111...115)(
-       ImaginaryNode(112...115)(
-         RationalNode(112...114)(IntegerNode(112...113)())
-       ),
-       nil,
-       (111...112),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
+     ImaginaryNode(111...115)(
+       RationalNode(111...114)(IntegerNode(111...113)())
      ),
-     CallNode(117...123)(
-       ImaginaryNode(118...123)(
-         RationalNode(118...122)(FloatNode(118...121)())
-       ),
-       nil,
-       (117...118),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     ImaginaryNode(117...123)(RationalNode(117...122)(FloatNode(117...121)())),
      RationalNode(125...129)(IntegerNode(125...128)()),
      ImaginaryNode(131...135)(IntegerNode(131...134)()),
      ImaginaryNode(137...142)(

--- a/test/snapshots/seattlerb/cond_unary_minus.txt
+++ b/test/snapshots/seattlerb/cond_unary_minus.txt
@@ -1,22 +1,6 @@
 ProgramNode(0...10)(
   [],
   StatementsNode(0...10)(
-    [IfNode(0...10)(
-       (0...2),
-       CallNode(3...5)(
-         IntegerNode(4...5)(),
-         nil,
-         (3...4),
-         nil,
-         nil,
-         nil,
-         nil,
-         0,
-         "-@"
-       ),
-       nil,
-       nil,
-       (7...10)
-     )]
+    [IfNode(0...10)((0...2), IntegerNode(3...5)(), nil, nil, (7...10))]
   )
 )

--- a/test/snapshots/seattlerb/parse_pattern_019.txt
+++ b/test/snapshots/seattlerb/parse_pattern_019.txt
@@ -5,17 +5,7 @@ ProgramNode(0...26)(
        IntegerNode(5...6)(),
        [InNode(7...22)(
           RangeNode(10...15)(
-            CallNode(10...12)(
-              IntegerNode(11...12)(),
-              nil,
-              (10...11),
-              nil,
-              nil,
-              nil,
-              nil,
-              0,
-              "-@"
-            ),
+            IntegerNode(10...12)(),
             IntegerNode(14...15)(),
             (12...14),
             0

--- a/test/snapshots/seattlerb/uminus_float.txt
+++ b/test/snapshots/seattlerb/uminus_float.txt
@@ -1,16 +1,1 @@
-ProgramNode(0...4)(
-  [],
-  StatementsNode(0...4)(
-    [CallNode(0...4)(
-       FloatNode(1...4)(),
-       nil,
-       (0...1),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     )]
-  )
-)
+ProgramNode(0...4)([], StatementsNode(0...4)([FloatNode(0...4)()]))

--- a/test/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/snapshots/unparser/corpus/literal/literal.txt
@@ -185,29 +185,9 @@ ProgramNode(0...916)(
      RationalNode(234...238)(FloatNode(234...237)()),
      RationalNode(239...243)(FloatNode(239...242)()),
      ImaginaryNode(244...246)(IntegerNode(244...245)()),
-     CallNode(247...250)(
-       ImaginaryNode(248...250)(IntegerNode(248...249)()),
-       nil,
-       (247...248),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     ImaginaryNode(247...250)(IntegerNode(247...249)()),
      ImaginaryNode(251...255)(FloatNode(251...254)()),
-     CallNode(256...261)(
-       ImaginaryNode(257...261)(FloatNode(257...260)()),
-       nil,
-       (256...257),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     ImaginaryNode(256...261)(FloatNode(256...260)()),
      ImaginaryNode(262...294)(IntegerNode(262...293)()),
      ImaginaryNode(295...298)(
        RationalNode(295...297)(IntegerNode(295...296)())
@@ -487,17 +467,7 @@ ProgramNode(0...916)(
        (651...653),
        0
      ),
-     CallNode(657...661)(
-       FloatNode(658...661)(),
-       nil,
-       (657...658),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     FloatNode(657...661)(),
      FloatNode(662...665)(),
      ArrayNode(666...672)(
        [IntegerNode(667...668)(), IntegerNode(670...671)()],

--- a/test/snapshots/unparser/corpus/semantic/literal.txt
+++ b/test/snapshots/unparser/corpus/semantic/literal.txt
@@ -2,32 +2,12 @@ ProgramNode(0...131)(
   [],
   StatementsNode(0...131)(
     [RationalNode(0...4)(FloatNode(0...3)()),
-     CallNode(5...8)(
-       RationalNode(6...8)(IntegerNode(6...7)()),
-       nil,
-       (5...6),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     RationalNode(5...8)(IntegerNode(5...7)()),
      IntegerNode(9...12)(),
      IntegerNode(13...18)(),
      FloatNode(19...23)(),
      FloatNode(24...38)(),
-     CallNode(39...54)(
-       FloatNode(40...54)(),
-       nil,
-       (39...40),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     FloatNode(39...54)(),
      StringNode(55...57)((55...56), (56...57), nil, "c"),
      RegularExpressionNode(58...63)((58...61), (61...62), (62...63), "/", 0),
      RegularExpressionNode(64...70)((64...67), (67...69), (69...70), ")", 0),
@@ -43,17 +23,7 @@ ProgramNode(0...131)(
        0
      ),
      FloatNode(86...102)(),
-     CallNode(103...120)(
-       FloatNode(104...120)(),
-       nil,
-       (103...104),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
+     FloatNode(103...120)(),
      CallNode(121...131)(
        nil,
        nil,

--- a/test/snapshots/whitequark/args.txt
+++ b/test/snapshots/whitequark/args.txt
@@ -644,17 +644,7 @@ ProgramNode(0...690)(
          nil,
          [KeywordParameterNode(583...590)(
             (583...587),
-            CallNode(588...590)(
-              IntegerNode(589...590)(),
-              nil,
-              (588...589),
-              nil,
-              nil,
-              nil,
-              nil,
-              0,
-              "-@"
-            )
+            IntegerNode(588...590)()
           )],
          nil,
          nil

--- a/test/snapshots/whitequark/float.txt
+++ b/test/snapshots/whitequark/float.txt
@@ -1,17 +1,4 @@
 ProgramNode(0...11)(
   [],
-  StatementsNode(0...11)(
-    [CallNode(0...5)(
-       FloatNode(1...5)(),
-       nil,
-       (0...1),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
-     FloatNode(7...11)()]
-  )
+  StatementsNode(0...11)([FloatNode(0...5)(), FloatNode(7...11)()])
 )

--- a/test/snapshots/whitequark/int.txt
+++ b/test/snapshots/whitequark/int.txt
@@ -1,18 +1,6 @@
 ProgramNode(0...12)(
   [],
   StatementsNode(0...12)(
-    [IntegerNode(0...3)(),
-     CallNode(5...8)(
-       IntegerNode(6...8)(),
-       nil,
-       (5...6),
-       nil,
-       nil,
-       nil,
-       nil,
-       0,
-       "-@"
-     ),
-     IntegerNode(10...12)()]
+    [IntegerNode(0...3)(), IntegerNode(5...8)(), IntegerNode(10...12)()]
   )
 )

--- a/test/snapshots/whitequark/lparenarg_after_lvar__since_25.txt
+++ b/test/snapshots/whitequark/lparenarg_after_lvar__since_25.txt
@@ -9,19 +9,7 @@ ProgramNode(0...31)(
        ArgumentsNode(4...14)(
          [CallNode(4...14)(
             ParenthesesNode(4...10)(
-              StatementsNode(5...9)(
-                [CallNode(5...9)(
-                   FloatNode(6...9)(),
-                   nil,
-                   (5...6),
-                   nil,
-                   nil,
-                   nil,
-                   nil,
-                   0,
-                   "-@"
-                 )]
-              ),
+              StatementsNode(5...9)([FloatNode(5...9)()]),
               (4...5),
               (9...10)
             ),
@@ -48,19 +36,7 @@ ProgramNode(0...31)(
        ArgumentsNode(21...31)(
          [CallNode(21...31)(
             ParenthesesNode(21...27)(
-              StatementsNode(22...26)(
-                [CallNode(22...26)(
-                   FloatNode(23...26)(),
-                   nil,
-                   (22...23),
-                   nil,
-                   nil,
-                   nil,
-                   nil,
-                   0,
-                   "-@"
-                 )]
-              ),
+              StatementsNode(22...26)([FloatNode(22...26)()]),
               (21...22),
               (26...27)
             ),


### PR DESCRIPTION
Some unary minuses get incorporated into number literals, and some do not. So a straight compilation of -@ calls is not correct. For example:

-5 # will not call Integer#-@
-5**1 # will call Integer#-@

So if you monkey-patch Integer#-@, those values will be different. As such, it makes more sense to incorporate the minus sign into the range of the integer itself.

We also do this for floats, rationals, and imaginaries.

Fixes #1148