### PR TITLE
add a diagnostic for `*rest` in order after optional state

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8340,6 +8340,10 @@ update_parameter_state(yp_parser_t *parser, yp_token_t *token, yp_parameters_ord
         return;
     }
 
+    if (token->type == YP_TOKEN_USTAR && *current == YP_PARAMETERS_ORDER_AFTER_OPTIONAL) {
+        yp_diagnostic_list_append(&parser->error_list, token->start, token->end, "Unexpected parameter *");
+    }
+
     if (*current == YP_PARAMETERS_ORDER_NOTHING_AFTER || state > *current) {
         // We know what transition we failed on, so we can provide a better error here.
         yp_diagnostic_list_append(&parser->error_list, token->start, token->end, "Unexpected parameter order");

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1059,6 +1059,22 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expected, "def foo(a,b,&a);end", [
       ["Duplicated parameter name.", 13..14]
     ]
+
+    expected = DefNode(
+      Location(),
+      nil,
+      ParametersNode([], [OptionalParameterNode(:a, Location(), Location(), IntegerNode())], [RequiredParameterNode(:b)], RestParameterNode(Location(), Location()), [], nil, nil),
+      nil,
+      [:a, :b, :c],
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "def foo(a = 1,b,*c);end", [["Unexpected parameter *", 16..17]]
   end
 
   private


### PR DESCRIPTION
Fixes: https://github.com/ruby/yarp/issues/1230