### PR TITLE
Check locals

### DIFF
--- a/bin/locals
+++ b/bin/locals
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$:.unshift(File.expand_path("../lib", __dir__))
+require "yarp"
+
+source = ARGV[0] == "-e" ? ARGV[1] : File.read(ARGV[0])
+
+puts "CRuby:"
+p YARP.const_get(:Debug).cruby_locals(source)
+
+puts "YARP:"
+p YARP.const_get(:Debug).yarp_locals(source)

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -311,6 +311,138 @@ module YARP
   # This module is used for testing and debugging and is not meant to be used by
   # consumers of this library.
   module Debug
+    class ISeq
+      attr_reader :parts
+
+      def initialize(parts)
+        @parts = parts
+      end
+
+      def type = parts[0]
+      def local_table = parts[10]
+      def instructions = parts[13]
+
+      def each_child
+        instructions.each do |instruction|
+          # Only look at arrays. Other instructions are line numbers or
+          # tracepoint events.
+          next unless instruction.is_a?(Array)
+
+          instruction.each do |opnd|
+            # Only look at arrays. Other operands are literals.
+            next unless opnd.is_a?(Array)
+
+            # Only look at instruction sequences. Other operands are literals.
+            next unless opnd[0] == "YARVInstructionSequence/SimpleDataFormat"
+
+            yield ISeq.new(opnd)
+          end
+        end
+      end
+    end
+
+    # For the given source, compiles with CRuby and returns a list of all of the
+    # sets of local variables that were encountered.
+    def self.cruby_locals(source)
+      verbose = $VERBOSE
+      $VERBOSE = nil
+
+      begin
+        locals = []
+        stack = [ISeq.new(RubyVM::InstructionSequence.compile(source).to_a)]
+
+        while (iseq = stack.pop)
+          if iseq.type != :once
+            names = iseq.local_table
+
+            # CRuby will push on a special local variable when there are keyword
+            # arguments. We get rid of that here.
+            names = names.grep_v(Integer)
+
+            # TODO: We don't support numbered local variables yet, so we get rid
+            # of those here.
+            names = names.grep_v(/^_\d$/)
+
+            # Now push them onto the list of locals.
+            locals << names
+          end
+
+          iseq.each_child { |child| stack << child }
+        end
+
+        locals
+      ensure
+        $VERBOSE = verbose
+      end
+    end
+
+    # For the given source, parses with YARP and returns a list of all of the
+    # sets of local variables that were encountered.
+    def self.yarp_locals(source)
+      locals = []
+      stack = [YARP.parse(source).value]
+
+      while (node = stack.pop)
+        case node
+        when BlockNode, DefNode, LambdaNode
+          names = node.locals
+
+          params = node.parameters
+          params = params&.parameters unless node.is_a?(DefNode)
+
+          # YARP places parameters in the same order that they appear in the
+          # source. CRuby places them in the order that they need to appear
+          # according to their own internal calling convention. We mimic that
+          # order here so that we can compare properly.
+          if params
+            sorted = [
+              *params.requireds.grep(RequiredParameterNode).map(&:constant_id),
+              *params.optionals.map(&:constant_id),
+              *((params.rest.name ? params.rest.name.to_sym : :*) if params.rest && params.rest.operator != ","),
+              *params.posts.grep(RequiredParameterNode).map(&:constant_id),
+              *params.keywords.reject(&:value).map { |param| param.name.chomp(":").to_sym },
+              *params.keywords.select(&:value).map { |param| param.name.chomp(":").to_sym }
+            ]
+
+            # TODO: When we get a ... parameter, we should be pushing * and &
+            # onto the local list. We don't do that yet, so we need to add them
+            # in here.
+            if params.keyword_rest.is_a?(ForwardingParameterNode)
+              sorted.push(:*, :&, :"...")
+            end
+
+            # Recurse down the parameter tree to find any destructured
+            # parameters and add them after the other parameters.
+            param_stack = params.requireds.concat(params.posts).grep(RequiredDestructuredParameterNode).reverse
+            while (param = param_stack.pop)
+              case param
+              when RequiredDestructuredParameterNode
+                param_stack.concat(param.parameters.reverse)
+              when RequiredParameterNode
+                sorted << param.constant_id
+              when SplatNode
+                sorted << param.expression.constant_id if param.expression
+              end
+            end
+
+            names = sorted.concat(names - sorted)
+          end
+
+          locals << names
+        when ClassNode, ModuleNode, ProgramNode, SingletonClassNode
+          locals << node.locals
+        when ForNode
+          locals << []
+        when PostExecutionNode
+          locals.push([], [])
+        end
+
+        stack.concat(node.child_nodes.compact)
+      end
+
+      locals
+    end
+
     def self.newlines(source)
       YARP.parse(source).source.offsets
     end

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -734,8 +734,7 @@ module YARP
       when :on_sp
         # skip
       when :on_tstring_content
-        if previous[1] == :on_tstring_content &&
-            (token[2].start_with?("\#$") || token[2].start_with?("\#@"))
+        if previous[1] == :on_tstring_content && (token[2].start_with?("\#$") || token[2].start_with?("\#@"))
           previous[2] << token[2]
         else
           results << token

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -29,8 +29,9 @@ task :lint do
 
   # Check for trailing spaces
   trailing_spaces_found = false
-  Dir.glob("**/*.{c,h,erb,rb,yml}").reject { _1.start_with? "vendor/" }.
-    each do |path|
+  Dir.glob("**/*.{c,h,erb,rb,yml}")
+    .reject { _1.start_with?("tmp") || _1.start_with?("vendor/") }
+    .each do |path|
       File.readlines(path).each_with_index do |line, index|
         if line.match(/[ \t]+$/)
           warn("Trailing spaces found in #{path} on line #{index + 1}")

--- a/test/locals_test.rb
+++ b/test/locals_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# This test is going to use the RubyVM::InstructionSequence class to compile
+# local tables and compare against them to ensure we have the same locals in the
+# same order. This is important to guarantee that we compile indices correctly
+# on CRuby (in terms of compatibility).
+#
+# There have also been changes made in other versions of Ruby, so we only want
+# to test on the most recent versions.
+return if !defined?(RubyVM::InstructionSequence) || RUBY_VERSION < "3.2"
+
+require "yarp_test_helper"
+
+class LocalsTest < Test::Unit::TestCase
+  invalid = []
+  todos = []
+
+  # Invalid break
+  invalid << "break.txt"
+  invalid << "if.txt"
+  invalid << "rescue.txt"
+  invalid << "seattlerb/block_break.txt"
+  invalid << "unless.txt"
+  invalid << "whitequark/break.txt"
+  invalid << "whitequark/break_block.txt"
+
+  # Invalid next
+  invalid << "next.txt"
+  invalid << "seattlerb/block_next.txt"
+  invalid << "unparser/corpus/literal/control.txt"
+  invalid << "whitequark/next.txt"
+  invalid << "whitequark/next_block.txt"
+
+  # Invalid redo
+  invalid << "keywords.txt"
+  invalid << "whitequark/redo.txt"
+
+  # Invalid retry
+  invalid << "whitequark/retry.txt"
+
+  # Invalid yield
+  invalid << "seattlerb/dasgn_icky2.txt"
+  invalid << "seattlerb/yield_arg.txt"
+  invalid << "seattlerb/yield_call_assocs.txt"
+  invalid << "seattlerb/yield_empty_parens.txt"
+  invalid << "unparser/corpus/literal/yield.txt"
+  invalid << "whitequark/args_assocs.txt"
+  invalid << "whitequark/args_assocs_legacy.txt"
+  invalid << "whitequark/yield.txt"
+  invalid << "yield.txt"
+
+  # Dead code eliminated
+  invalid << "whitequark/ruby_bug_10653.txt"
+
+  # case :a
+  # in Symbol(*lhs, x, *rhs)
+  # end
+  todos << "seattlerb/case_in.txt"
+
+  # <<~HERE
+  #   #{<<~THERE}
+  #   THERE
+  # HERE
+  todos << "seattlerb/heredoc_nested.txt"
+
+  base = File.join(__dir__, "fixtures")
+  skips = invalid | todos
+
+  Dir["**/*.txt", base: base].each do |relative|
+    next if skips.include?(relative)
+
+    filepath = File.join(base, relative)
+    define_method("test_#{relative}") { assert_locals(filepath) }
+  end
+
+  private
+
+  def assert_locals(filepath)
+    source = File.read(filepath)
+
+    expected = YARP.const_get(:Debug).cruby_locals(source)
+    actual = YARP.const_get(:Debug).yarp_locals(source)
+
+    assert_equal(expected, actual)
+  end
+end

--- a/test/newline_test.rb
+++ b/test/newline_test.rb
@@ -17,62 +17,55 @@ class NewlineTest < Test::Unit::TestCase
     end
   end
 
-  root = File.dirname(__dir__)
-
-  Dir["{lib,test}/**/*.rb", base: root].each do |relative|
-    # Our newlines are not exact, so for now skip a couple of files that are
-    # marked as incorrect.
-    next if relative == "test/parse_serialize_test.rb"
-
-    filepath = File.join(root, relative)
-
-    define_method "test_newline_flags_#{relative}" do
-      source = File.read(filepath, binmode: true, external_encoding: Encoding::UTF_8)
-      expected = rubyvm_lines(source)
-
-      result = YARP.parse_file(filepath)
-      assert_empty result.errors
-
-      result.mark_newlines
-      visitor = NewlineVisitor.new(result.source)
-      result.value.accept(visitor)
-      actual = visitor.newlines
-
-      if relative == "lib/yarp/serialize.rb"
-        # while (b = io.getbyte) >= 128 has 2 newline flags
-        line_number = source.lines.index { |line| line.include?('while (b = io.getbyte) >= 128') } + 1
-        expected.delete_at(expected.index(line_number))
-      elsif relative == "lib/yarp/lex_compat.rb"
-        # extra flag for: dedent_next =\n  ((token.event: due to bytecode order
-        # different line for: token =\n  case event: due to bytecode order
-        # extra flag for: lex_state =\n  if RIPPER: due to bytecode order
-        source.lines.each.with_index(1) do |line, line_number|
-          if line =~ /^\s+\w+ =$/
-            actual.delete(line_number)
-
-            # different line for: token =\n  case event: due to bytecode order
-            if line =~ /token =$/
-              expected.delete(line_number + 1)
-            end
-          end
-        end
-
-        # extra flag for: (token[2].start_with?("\#$") || token[2].start_with?("\#@"))
-        # unclear when ParenthesesNode should allow a second flag on the same line or not
-        index = source.lines.index do |line|
-          line.include?('(token[2].start_with?("\#$") || token[2].start_with?("\#@"))')
-        end
-        actual.delete(index + 1)
-      elsif relative == "test/parse_test.rb"
-        line_number = source.lines.index { |line| line.include?("while (node = queue.shift)") } + 1
-        expected.delete_at(expected.index(line_number))
-      end
-
-      assert_equal expected, actual
+  base = File.dirname(__dir__)
+  Dir["{lib,test}/**/*.rb", base: base].each do |relative|
+    define_method("test_newline_flags_#{relative}") do
+      assert_newlines(base, relative)
     end
   end
 
   private
+
+  def assert_newlines(base, relative)
+    filepath = File.join(base, relative)
+    source = File.read(filepath, binmode: true, external_encoding: Encoding::UTF_8)
+    expected = rubyvm_lines(source)
+
+    result = YARP.parse_file(filepath)
+    assert_empty result.errors
+
+    result.mark_newlines
+    visitor = NewlineVisitor.new(result.source)
+
+    result.value.accept(visitor)
+    actual = visitor.newlines
+
+    source.each_line.with_index(1) do |line, line_number|
+      # Lines like `while (foo = bar)` result in two line flags in the bytecode
+      # but only one newline flag in the AST. We need to remove the extra line
+      # flag from the bytecode to make the test pass.
+      if line.match?(/while \(/)
+        index = expected.index(line_number)
+        expected.delete_at(index) if index
+      end
+
+      # Lines like `foo =` where the value is on the next line result in another
+      # line flag in the bytecode but only one newline flag in the AST.
+      if line.match?(/^\s+\w+ =$/)
+        if source.lines[line_number].match?(/^\s+case/)
+          actual[actual.index(line_number)] += 1
+        else
+          actual.delete_at(actual.index(line_number))
+        end
+      end
+
+      if line.match?(/^\s+\w+ = \[$/)
+        actual[actual.index(line_number)] += 1
+      end
+    end
+
+    assert_equal expected, actual
+  end
 
   def ignore_warnings
     previous_verbosity = $VERBOSE

--- a/test/parse_serialize_test.rb
+++ b/test/parse_serialize_test.rb
@@ -20,7 +20,5 @@ class ParseSerializeTest < Test::Unit::TestCase
       return node if node.is_a?(YARP::SourceFileNode)
       queue.concat(node.child_nodes.compact)
     end
-
-    nil
   end
 end


### PR DESCRIPTION
We want to ensure that we have the same set of locals for any given scope as CRuby does so that we can compile them correctly.

Currently we need to skip "special" locals like the keyword arguments hash and numbered parameters, but this gets us to a place we can iterate.

I had to add a bit of stuff to make the newline test work again. That's what the extra noise is for.