### PR TITLE
Nested heredocs

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -647,19 +647,34 @@ module YARP
         # can shuffle around the token to match Ripper's output.
         case state
         when :default
+          # The default state is when there are no heredocs at all. In this
+          # state we can append the token to the list of tokens and move on.
           tokens << token
 
+          # If we get the declaration of a heredoc, then we open a new heredoc
+          # and move into the heredoc_opened state.
           if event == :on_heredoc_beg
             state = :heredoc_opened
             heredoc_stack.last << Heredoc.build(token)
           end
         when :heredoc_opened
+          # The heredoc_opened state is when we've seen the declaration of a
+          # heredoc and are now lexing the body of the heredoc. In this state we
+          # push tokens onto the most recently created heredoc.
           heredoc_stack.last.last << token
 
           case event
           when :on_heredoc_beg
+            # If we receive a heredoc declaration while lexing the body of a
+            # heredoc, this means we have nested heredocs. In this case we'll
+            # push a new heredoc onto the stack and stay in the heredoc_opened
+            # state since we're now lexing the body of the new heredoc.
             heredoc_stack << [Heredoc.build(token)]
           when :on_heredoc_end
+            # If we receive the end of a heredoc, then we're done lexing the
+            # body of the heredoc. In this case we now have a completed heredoc
+            # but need to wait for the next newline to push it into the token
+            # stream.
             state = :heredoc_closed
           end
         when :heredoc_closed

--- a/rakelib/serialization.rake
+++ b/rakelib/serialization.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-known_failures = %w[seattlerb/heredoc_nested.txt]
 fixtures = File.expand_path("../test/fixtures", __dir__)
 serialized_dir = File.expand_path("../serialized", fixtures)
 
@@ -11,7 +10,6 @@ task "test:serialize_fixtures" do
   require "fileutils"
 
   Dir["**/*.txt", base: fixtures].each do |relative|
-    next if known_failures.include?(relative)
     path = "#{fixtures}/#{relative}"
     serialized_path = "#{serialized_dir}/#{relative}"
 
@@ -27,7 +25,6 @@ task "test:java_loader" do
   java_import 'org.yarp.Nodes$Source'
 
   Dir["**/*.txt", base: fixtures].each do |relative|
-    next if known_failures.include?(relative)
     path = "#{fixtures}/#{relative}"
     serialized_path = "#{serialized_dir}/#{relative}"
     serialized = File.binread(serialized_path).unpack('c*')

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7150,13 +7150,13 @@ parser_lex(yp_parser_t *parser) {
                         breakpoint = yp_strpbrk(parser, breakpoint + 1, breakpoints, parser->end - (breakpoint + 1));
                         break;
                     case '\n': {
-                        yp_newline_list_append(&parser->newline_list, breakpoint);
-
                         if (parser->heredoc_end != NULL && (parser->heredoc_end > breakpoint)) {
                             parser_flush_heredoc_end(parser);
                             parser->current.end = breakpoint + 1;
                             LEX(YP_TOKEN_STRING_CONTENT);
                         }
+
+                        yp_newline_list_append(&parser->newline_list, breakpoint);
 
                         const char *start = breakpoint + 1;
                         if (parser->lex_modes.current->as.heredoc.indent != YP_HEREDOC_INDENT_NONE) {

--- a/test/snapshots/seattlerb/heredoc_nested.txt
+++ b/test/snapshots/seattlerb/heredoc_nested.txt
@@ -1,0 +1,27 @@
+ProgramNode(0...23)(
+  [],
+  StatementsNode(0...23)(
+    [ArrayNode(0...23)(
+       [InterpolatedStringNode(1...21)(
+          (1...4),
+          [EmbeddedStatementsNode(6...12)(
+             (6...8),
+             StatementsNode(8...17)(
+               [InterpolatedStringNode(8...17)(
+                  (8...11),
+                  [StringNode(13...15)(nil, (13...15), nil, "b\n")],
+                  (15...17)
+                )]
+             ),
+             (11...12)
+           ),
+           StringNode(12...13)(nil, (12...13), nil, "\n"),
+           StringNode(17...19)(nil, (17...19), nil, "a\n")],
+          (19...21)
+        ),
+        IntegerNode(21...22)()],
+       (0...1),
+       (22...23)
+     )]
+  )
+)


### PR DESCRIPTION
Looks like we're pretty much working as expected already, we just needed to not double-count a newline. Also skipping some tests here for comparing to ripper because there may be a bug or at least unanticipated behavior in ripper for nested heredocs. See Ruby bug here: https://bugs.ruby-lang.org/issues/19838.

Fixes #1176.