### PR TITLE
Run parse_test.rb on JRuby, TruffleRuby and older CRuby versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@ test/fixtures/unparser/**/*.txt linguist-vendored
 test/fixtures/whitequark/**/*.txt linguist-vendored
 test/snapshots/**/*.txt linguist-generated
 
-test/fixtures/**/*.txt -text
-
+# Preserve \n on git clone on Windows, regardless of the git config core.autocrlf value
+# See https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
 **/*.rb text eol=lf
+**/*.txt text eol=lf

--- a/test/newline_test.rb
+++ b/test/newline_test.rb
@@ -4,6 +4,13 @@ require "yarp_test_helper"
 
 return unless defined?(RubyVM::InstructionSequence)
 
+# It is useful to have a diff even if the strings to compare are big
+# However, ruby/ruby does not have a version of Test::Unit with access to
+# max_diff_target_string_size
+if defined?(Test::Unit::Assertions::AssertionMessage)
+  Test::Unit::Assertions::AssertionMessage.max_diff_target_string_size = 5000
+end
+
 class NewlineTest < Test::Unit::TestCase
   class NewlineVisitor < YARP::Visitor
     attr_reader :source, :newlines

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -6,13 +6,6 @@ require "yarp_test_helper"
 # running on Ruby 3.2+.
 return if RUBY_VERSION < "3.2.0"
 
-# It is useful to have a diff even if the strings to compare are big
-# However, ruby/ruby does not have a version of Test::Unit with access to
-# max_diff_target_string_size
-if defined?(Test::Unit::Assertions::AssertionMessage)
-  Test::Unit::Assertions::AssertionMessage.max_diff_target_string_size = 5000
-end
-
 class ParseTest < Test::Unit::TestCase
   # When we pretty-print the trees to compare against the snapshots, we want to
   # be certain that we print with the same external encoding. This is because


### PR DESCRIPTION
* Only skip the Ripper part, since that one depends on the RUBY_VERSION.

I noticed in https://github.com/ruby/yarp/actions/runs/5859209143/job/15884736966
On CRuby:
`1246 tests, 334838 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications`

On TruffleRuby:
`256 tests, 7106 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications`

With this PR on TruffleRuby:
https://github.com/ruby/yarp/actions/runs/5859462998/job/15885515840?pr=1249
`1222 tests, 309691 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications`

Which is much closer (not exactly the same since some tests rely on `RubyVM` and `YARP::Debug`)