### PR TITLE
Add a size tracker to yp_list_t

### DIFF
--- a/fuzz/unescape.c
+++ b/fuzz/unescape.c
@@ -1,27 +1,22 @@
 #include <yarp.h>
 
 static void
-unescape (const char *input, size_t size, yp_unescape_type_t type) {
-    yp_string_t *str = malloc (sizeof (yp_string_t));
-    assert (str);
-    yp_list_t *error_list = malloc (sizeof (yp_list_t));
-    assert (error_list);
-    yp_parser_t *parser = malloc(sizeof (yp_parser_t));
-    assert (parser);
-    yp_parser_init(parser, input, size, "unescape.c");
-    yp_list_init (error_list);
-    yp_unescape_manipulate_string (parser, input, size, str, type, error_list);
-    yp_parser_free(parser);
-    free(parser);
-    yp_list_free (error_list);
-    free (error_list);
-    yp_string_free (str);
-    free (str);
+unescape(const char *input, size_t size, yp_unescape_type_t type) {
+    yp_parser_t parser;
+    yp_parser_init(&parser, input, size, "unescape.c");
+
+    yp_string_t string = YP_EMPTY_STRING;
+    yp_list_t error_list = YP_LIST_EMPTY;
+    yp_unescape_manipulate_string(&parser, input, size, &string, type, &error_list);
+
+    yp_parser_free(&parser);
+    yp_string_free(&string);
+    yp_list_free(&error_list);
 }
 
 void
-harness (const char *input, size_t size) {
-    unescape (input, size, YP_UNESCAPE_ALL);
-    unescape (input, size, YP_UNESCAPE_MINIMAL);
-    unescape (input, size, YP_UNESCAPE_NONE);
+harness(const char *input, size_t size) {
+    unescape(input, size, YP_UNESCAPE_ALL);
+    unescape(input, size, YP_UNESCAPE_MINIMAL);
+    unescape(input, size, YP_UNESCAPE_NONE);
 }

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -51,6 +51,9 @@ typedef struct {
     size_t capacity;
 } yp_constant_pool_t;
 
+// Define an empty constant pool.
+#define YP_CONSTANT_POOL_EMPTY ((yp_constant_pool_t) { .constants = NULL, .size = 0, .capacity = 0 })
+
 // Initialize a new constant pool with a given capacity.
 bool yp_constant_pool_init(yp_constant_pool_t *pool, size_t capacity);
 

--- a/include/yarp/util/yp_list.h
+++ b/include/yarp/util/yp_list.h
@@ -15,9 +15,7 @@
 //       int value;
 //     } yp_int_node_t;
 //
-//     yp_list_t list;
-//     yp_list_init(&list);
-//
+//     yp_list_t list = YP_LIST_EMPTY;
 //     yp_int_node_t *node = malloc(sizeof(yp_int_node_t));
 //     node->value = 5;
 //
@@ -45,18 +43,20 @@ typedef struct yp_list_node {
 // This represents the overall linked list. It keeps a pointer to the head and
 // tail so that iteration is easy and pushing new nodes is easy.
 typedef struct {
+    size_t size;
     yp_list_node_t *head;
     yp_list_node_t *tail;
 } yp_list_t;
 
-// Initializes a new list.
-YP_EXPORTED_FUNCTION void yp_list_init(yp_list_t *list);
+// This represents an empty list. It's used to initialize a stack-allocated list
+// as opposed to a method call.
+#define YP_LIST_EMPTY ((yp_list_t) { .size = 0, .head = NULL, .tail = NULL })
 
 // Returns true if the given list is empty.
 YP_EXPORTED_FUNCTION bool yp_list_empty_p(yp_list_t *list);
 
-// Returns the size of the list in O(n) time.
-YP_EXPORTED_FUNCTION uint32_t yp_list_size(yp_list_t *list);
+// Returns the size of the list.
+YP_EXPORTED_FUNCTION size_t yp_list_size(yp_list_t *list);
 
 // Append a node to the given list.
 void yp_list_append(yp_list_t *list, yp_list_node_t *node);

--- a/include/yarp/util/yp_newline_list.h
+++ b/include/yarp/util/yp_newline_list.h
@@ -35,6 +35,10 @@ typedef struct {
     size_t column;
 } yp_line_column_t;
 
+#define YP_NEWLINE_LIST_EMPTY ((yp_newline_list_t) { \
+    .start = NULL, .offsets = NULL, .size = 0, .capacity = 0, .last_offset = 0, .last_index = 0 \
+})
+
 // Initialize a new newline list with the given capacity. Returns true if the
 // allocation of the offsets succeeds, otherwise returns false.
 bool yp_newline_list_init(yp_newline_list_t *list, const char *start, size_t capacity);

--- a/include/yarp/util/yp_state_stack.h
+++ b/include/yarp/util/yp_state_stack.h
@@ -10,7 +10,7 @@
 typedef uint32_t yp_state_stack_t;
 
 // Initializes the state stack to an empty stack.
-void yp_state_stack_init(yp_state_stack_t *stack);
+#define YP_STATE_STACK_EMPTY ((yp_state_stack_t) 0)
 
 // Pushes a value onto the stack.
 void yp_state_stack_push(yp_state_stack_t *stack, bool value);

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -530,12 +530,10 @@ YP_EXPORTED_FUNCTION bool
 yp_unescape_string(const char *start, size_t length, yp_unescape_type_t unescape_type, yp_string_t *result) {
     bool success;
 
-    yp_list_t error_list;
-    yp_list_init(&error_list);
-
     yp_parser_t parser;
     yp_parser_init(&parser, start, length, "");
 
+    yp_list_t error_list = YP_LIST_EMPTY;
     yp_unescape_manipulate_string(&parser, start, length, result, unescape_type, &error_list);
     success = yp_list_empty_p(&error_list);
 

--- a/src/util/yp_list.c
+++ b/src/util/yp_list.c
@@ -1,28 +1,15 @@
 #include "yarp/util/yp_list.h"
 
-// Initializes a new list.
-YP_EXPORTED_FUNCTION void
-yp_list_init(yp_list_t *list) {
-    *list = (yp_list_t) { .head = NULL, .tail = NULL };
-}
-
 // Returns true if the given list is empty.
 YP_EXPORTED_FUNCTION bool
 yp_list_empty_p(yp_list_t *list) {
     return list->head == NULL;
 }
 
-YP_EXPORTED_FUNCTION uint32_t
+// Returns the size of the list.
+YP_EXPORTED_FUNCTION size_t
 yp_list_size(yp_list_t *list) {
-    yp_list_node_t *node = list->head;
-    uint32_t length = 0;
-
-    while (node != NULL) {
-        length++;
-        node = node->next;
-    }
-
-    return length;
+    return list->size;
 }
 
 // Append a node to the given list.
@@ -33,7 +20,9 @@ yp_list_append(yp_list_t *list, yp_list_node_t *node) {
     } else {
         list->tail->next = node;
     }
+
     list->tail = node;
+    list->size++;
 }
 
 // Deallocate the internal state of the given list.
@@ -47,4 +36,6 @@ yp_list_free(yp_list_t *list) {
         free(node);
         node = next;
     }
+
+    list->size = 0;
 }

--- a/src/util/yp_state_stack.c
+++ b/src/util/yp_state_stack.c
@@ -1,11 +1,5 @@
 #include "yarp/util/yp_state_stack.h"
 
-// Initializes the state stack to an empty stack.
-void
-yp_state_stack_init(yp_state_stack_t *stack) {
-    *stack = 0;
-}
-
 // Pushes a value onto the stack.
 void
 yp_state_stack_push(yp_state_stack_t *stack, bool value) {

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -13190,6 +13190,8 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
         .enclosure_nesting = 0,
         .lambda_enclosure_nesting = -1,
         .brace_nesting = 0,
+        .do_loop_stack = YP_STATE_STACK_EMPTY,
+        .accepts_block_stack = YP_STATE_STACK_EMPTY,
         .lex_modes = {
             .index = 0,
             .stack = {{ .mode = YP_LEX_DEFAULT }},
@@ -13201,6 +13203,9 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
         .current = { .type = YP_TOKEN_EOF, .start = source, .end = source },
         .next_start = NULL,
         .heredoc_end = NULL,
+        .comment_list = YP_LIST_EMPTY,
+        .warning_list = YP_LIST_EMPTY,
+        .error_list = YP_LIST_EMPTY,
         .current_scope = NULL,
         .current_context = NULL,
         .recovering = false,
@@ -13213,15 +13218,11 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
         .pattern_matching_newlines = false,
         .in_keyword_arg = false,
         .filepath_string = filepath_string,
+        .constant_pool = YP_CONSTANT_POOL_EMPTY,
+        .newline_list = YP_NEWLINE_LIST_EMPTY
     };
 
-    yp_state_stack_init(&parser->do_loop_stack);
-    yp_state_stack_init(&parser->accepts_block_stack);
     yp_accepts_block_stack_push(parser, true);
-
-    yp_list_init(&parser->warning_list);
-    yp_list_init(&parser->error_list);
-    yp_list_init(&parser->comment_list);
 
     // Initialize the constant pool. We're going to completely guess as to the
     // number of constants that we'll need based on the size of the input. The

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -113,7 +113,7 @@ void yp_serialize_comment(yp_parser_t *parser, yp_comment_t *comment, yp_buffer_
 }
 
 void yp_serialize_comment_list(yp_parser_t *parser, yp_list_t list, yp_buffer_t *buffer) {
-    yp_buffer_append_u32(buffer, yp_list_size(&list));
+    yp_buffer_append_u32(buffer, yp_sizet_to_u32(yp_list_size(&list)));
 
     yp_comment_t *comment;
     for (comment = (yp_comment_t *) list.head; comment != NULL; comment = (yp_comment_t *) comment->node.next) {
@@ -133,7 +133,7 @@ void yp_serialize_diagnostic(yp_parser_t *parser, yp_diagnostic_t *diagnostic, y
 }
 
 void yp_serialize_diagnostic_list(yp_parser_t *parser, yp_list_t list, yp_buffer_t *buffer) {
-    yp_buffer_append_u32(buffer, yp_list_size(&list));
+    yp_buffer_append_u32(buffer, yp_sizet_to_u32(yp_list_size(&list)));
 
     yp_diagnostic_t *diagnostic;
     for (diagnostic = (yp_diagnostic_t *) list.head; diagnostic != NULL; diagnostic = (yp_diagnostic_t *) diagnostic->node.next) {


### PR DESCRIPTION
We're serializing the size a couple of times for errors, warnings, and comments. This can get costly if there are a lot, so instead we'll track the size.

The compiler also started figuring out that we hadn't initialized every variable, so this also sets everything in `yp_parser_init`.