### PR TITLE
Treat yp_buffer_t as an opaque pointer

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -66,7 +66,7 @@ dump_input(yp_string_t *input, const char *filepath) {
     yp_node_t *node = yp_parse(&parser);
     yp_serialize(&parser, node, &buffer);
 
-    VALUE result = rb_str_new(buffer.value, buffer.length);
+    VALUE result = rb_str_new(yp_buffer_value(&buffer), yp_buffer_length(&buffer));
     yp_node_destroy(&parser, node);
     yp_buffer_free(&buffer);
     yp_parser_free(&parser);
@@ -483,7 +483,7 @@ parse_serialize_file_metadata(VALUE self, VALUE filepath, VALUE metadata) {
     if (!yp_string_mapped_init(&input, checked)) return Qnil;
 
     yp_parse_serialize(yp_string_source(&input), yp_string_length(&input), &buffer, check_string(metadata));
-    VALUE result = rb_str_new(buffer.value, buffer.length);
+    VALUE result = rb_str_new(yp_buffer_value(&buffer), yp_buffer_length(&buffer));
 
     yp_buffer_free(&buffer);
     return result;

--- a/include/yarp/util/yp_buffer.h
+++ b/include/yarp/util/yp_buffer.h
@@ -12,15 +12,23 @@
 // A yp_buffer_t is a simple memory buffer that stores data in a contiguous
 // block of memory. It is used to store the serialized representation of a
 // YARP tree.
-// NOTE: keep in sync with YARP::LibRubyParser::Buffer in lib/yarp.rb
 typedef struct {
     char *value;
     size_t length;
     size_t capacity;
 } yp_buffer_t;
 
+// Return the size of the yp_buffer_t struct.
+YP_EXPORTED_FUNCTION size_t yp_buffer_sizeof(void);
+
 // Initialize a yp_buffer_t with its default values.
 YP_EXPORTED_FUNCTION bool yp_buffer_init(yp_buffer_t *buffer);
+
+// Return the value of the buffer.
+YP_EXPORTED_FUNCTION char * yp_buffer_value(yp_buffer_t *buffer);
+
+// Return the length of the buffer.
+YP_EXPORTED_FUNCTION size_t yp_buffer_length(yp_buffer_t *buffer);
 
 // Append the given amount of space as zeroes to the buffer.
 void yp_buffer_append_zeroes(yp_buffer_t *buffer, size_t length);

--- a/src/util/yp_buffer.c
+++ b/src/util/yp_buffer.c
@@ -2,6 +2,12 @@
 
 #define YP_BUFFER_INITIAL_SIZE 1024
 
+// Return the size of the yp_buffer_t struct.
+size_t
+yp_buffer_sizeof(void) {
+    return sizeof(yp_buffer_t);
+}
+
 // Initialize a yp_buffer_t with its default values.
 bool
 yp_buffer_init(yp_buffer_t *buffer) {
@@ -10,6 +16,18 @@ yp_buffer_init(yp_buffer_t *buffer) {
 
     buffer->value = (char *) malloc(YP_BUFFER_INITIAL_SIZE);
     return buffer->value != NULL;
+}
+
+// Return the value of the buffer.
+char *
+yp_buffer_value(yp_buffer_t *buffer) {
+    return buffer->value;
+}
+
+// Return the length of the buffer.
+size_t
+yp_buffer_length(yp_buffer_t *buffer) {
+    return buffer->length;
 }
 
 // Append the given amount of space to the buffer.


### PR DESCRIPTION
Right now, we have to keep the buffer FFI object in sync with the definition of yp_buffer_t because we access its fields directly. If we add more fields or change the order, things will get out of sync.

Instead, let's treat yp_buffer_t as an opaque pointer and access its fields through accessor functions directly. This is more consistent with how we handle strings anyway.