### PR TITLE
Change heredoc locations to just their declaration

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2706,6 +2706,10 @@ yp_interpolated_string_node_create(yp_parser_t *parser, const yp_token_t *openin
 // Append a part to an InterpolatedStringNode node.
 static inline void
 yp_interpolated_string_node_append(yp_interpolated_string_node_t *node, yp_node_t *part) {
+    if (node->parts.size == 0 && node->opening_loc.start == NULL) {
+        node->base.location.start = part->location.start;
+    }
+
     yp_node_list_append(&node->parts, part);
     node->base.location.end = part->location.end;
 }
@@ -10711,12 +10715,15 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             lex_state_set(parser, YP_LEX_STATE_END);
             expect(parser, YP_TOKEN_HEREDOC_END, "Expected a closing delimiter for heredoc.");
+
             if (quote == YP_HEREDOC_QUOTE_BACKTICK) {
                 assert(YP_NODE_TYPE_P(node, YP_NODE_INTERPOLATED_X_STRING_NODE));
                 yp_interpolated_xstring_node_closing_set(((yp_interpolated_x_string_node_t *) node), &parser->previous);
+                node->location = ((yp_interpolated_x_string_node_t *) node)->opening_loc;
             } else {
                 assert(YP_NODE_TYPE_P(node, YP_NODE_INTERPOLATED_STRING_NODE));
                 yp_interpolated_string_node_closing_set((yp_interpolated_string_node_t *) node, &parser->previous);
+                node->location = ((yp_interpolated_string_node_t *) node)->opening_loc;
             }
 
             // If this is a heredoc that is indented with a ~, then we need to dedent

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -411,7 +411,8 @@ module YARP
     end
 
     def test_InterpolatedStringNode
-      assert_location(InterpolatedStringNode, "<<~A\nhello world\nA")
+      assert_location(InterpolatedStringNode, "\"foo \#@bar baz\"")
+      assert_location(InterpolatedStringNode, "<<~A\nhello world\nA", 0...4)
     end
 
     def test_InterpolatedSymbolNode

--- a/test/snapshots/dash_heredocs.txt
+++ b/test/snapshots/dash_heredocs.txt
@@ -1,13 +1,13 @@
-ProgramNode(0...231)(
+ProgramNode(0...217)(
   [],
-  StatementsNode(0...231)(
-    [InterpolatedStringNode(0...15)(
+  StatementsNode(0...217)(
+    [InterpolatedStringNode(0...6)(
        (0...6),
        [StringNode(7...11)(nil, (7...11), nil, "  a\n")],
        (11...15)
      ),
-     CallNode(16...58)(
-       InterpolatedStringNode(16...47)(
+     CallNode(16...36)(
+       InterpolatedStringNode(16...24)(
          (16...24),
          [StringNode(37...41)(nil, (37...41), nil, "  a\n")],
          (41...47)
@@ -15,8 +15,8 @@ ProgramNode(0...231)(
        nil,
        (25...26),
        nil,
-       ArgumentsNode(27...58)(
-         [InterpolatedStringNode(27...58)(
+       ArgumentsNode(27...36)(
+         [InterpolatedStringNode(27...36)(
             (27...36),
             [StringNode(47...51)(nil, (47...51), nil, "  b\n")],
             (51...58)
@@ -27,7 +27,7 @@ ProgramNode(0...231)(
        0,
        "+"
      ),
-     InterpolatedXStringNode(59...81)(
+     InterpolatedXStringNode(59...67)(
        (59...67),
        [StringNode(68...72)(nil, (68...72), nil, "  a\n"),
         EmbeddedStatementsNode(72...76)(
@@ -50,17 +50,17 @@ ProgramNode(0...231)(
         StringNode(76...77)(nil, (76...77), nil, "\n")],
        (77...81)
      ),
-     InterpolatedStringNode(82...106)(
+     InterpolatedStringNode(82...88)(
        (82...88),
        [StringNode(98...102)(nil, (98...102), nil, "  a\n")],
        (102...106)
      ),
-     InterpolatedStringNode(107...128)(
+     InterpolatedStringNode(107...113)(
        (107...113),
        [StringNode(114...122)(nil, (114...122), nil, "  a\n" + "  b\n")],
        (122...128)
      ),
-     InterpolatedStringNode(129...151)(
+     InterpolatedStringNode(129...137)(
        (129...137),
        [StringNode(138...142)(nil, (138...142), nil, "  a\n"),
         EmbeddedStatementsNode(142...146)(
@@ -83,7 +83,7 @@ ProgramNode(0...231)(
         StringNode(146...147)(nil, (146...147), nil, "\n")],
        (147...151)
      ),
-     InterpolatedStringNode(152...172)(
+     InterpolatedStringNode(152...158)(
        (152...158),
        [StringNode(159...163)(nil, (159...163), nil, "  a\n"),
         EmbeddedStatementsNode(163...167)(
@@ -107,13 +107,13 @@ ProgramNode(0...231)(
        (168...172)
      ),
      StringNode(173...179)((173...175), (175...178), (178...179), "abc"),
-     InterpolatedStringNode(181...200)(
+     InterpolatedStringNode(181...187)(
        (181...187),
        [StringNode(188...196)(nil, (188...196), nil, "  a\n" + "  b\n")],
        (196...200)
      ),
-     InterpolatedStringNode(201...208)((201...206), [], (207...208)),
-     InterpolatedStringNode(209...231)(
+     InterpolatedStringNode(201...206)((201...206), [], (207...208)),
+     InterpolatedStringNode(209...217)(
        (209...217),
        [StringNode(218...227)(nil, (218...227), nil, "  a \#{1}\n")],
        (227...231)

--- a/test/snapshots/dos_endings.txt
+++ b/test/snapshots/dos_endings.txt
@@ -22,7 +22,7 @@ ProgramNode(0...108)(
        (28...31),
        (36...37)
      ),
-     InterpolatedStringNode(41...73)(
+     InterpolatedStringNode(41...45)(
        (41...45),
        [StringNode(47...70)(
           nil,
@@ -49,7 +49,7 @@ ProgramNode(0...108)(
          (95...96),
          ArgumentsNode(96...107)(
            [CallNode(96...107)(
-              InterpolatedStringNode(96...128)(
+              InterpolatedStringNode(96...102)(
                 (96...102),
                 [StringNode(110...121)(
                    nil,

--- a/test/snapshots/heredoc_with_trailing_newline.txt
+++ b/test/snapshots/heredoc_with_trailing_newline.txt
@@ -1,6 +1,4 @@
-ProgramNode(0...10)(
+ProgramNode(0...6)(
   [],
-  StatementsNode(0...10)(
-    [InterpolatedStringNode(0...10)((0...6), [], (7...10))]
-  )
+  StatementsNode(0...6)([InterpolatedStringNode(0...6)((0...6), [], (7...10))])
 )

--- a/test/snapshots/heredocs_nested.txt
+++ b/test/snapshots/heredocs_nested.txt
@@ -1,13 +1,13 @@
-ProgramNode(0...47)(
+ProgramNode(0...7)(
   [],
-  StatementsNode(0...47)(
-    [InterpolatedStringNode(0...47)(
+  StatementsNode(0...7)(
+    [InterpolatedStringNode(0...7)(
        (0...7),
        [StringNode(8...12)(nil, (8...12), nil, "pre\n"),
         EmbeddedStatementsNode(12...36)(
           (12...14),
-          StatementsNode(15...35)(
-            [InterpolatedStringNode(15...35)(
+          StatementsNode(15...21)(
+            [InterpolatedStringNode(15...21)(
                (15...21),
                [StringNode(22...30)(nil, (22...30), nil, "  hello\n")],
                (30...35)

--- a/test/snapshots/heredocs_with_ignored_newlines.txt
+++ b/test/snapshots/heredocs_with_ignored_newlines.txt
@@ -1,8 +1,8 @@
-ProgramNode(0...106)(
+ProgramNode(0...23)(
   [],
-  StatementsNode(0...106)(
-    [InterpolatedStringNode(0...14)((0...7), [], (9...14)),
-     InterpolatedStringNode(15...106)(
+  StatementsNode(0...23)(
+    [InterpolatedStringNode(0...7)((0...7), [], (9...14)),
+     InterpolatedStringNode(15...23)(
        (15...23),
        [StringNode(25...100)(
           nil,

--- a/test/snapshots/heredocs_with_ignored_newlines_and_non_empty.txt
+++ b/test/snapshots/heredocs_with_ignored_newlines_and_non_empty.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...26)(
+ProgramNode(0...6)(
   [],
-  StatementsNode(0...26)(
-    [InterpolatedStringNode(0...26)(
+  StatementsNode(0...6)(
+    [InterpolatedStringNode(0...6)(
        (0...6),
        [StringNode(7...23)(nil, (7...23), nil, " some\n" + " heredocs\n")],
        (23...26)

--- a/test/snapshots/seattlerb/heredoc__backslash_dos_format.txt
+++ b/test/snapshots/seattlerb/heredoc__backslash_dos_format.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...35)(
+ProgramNode(0...12)(
   [:str],
-  StatementsNode(0...35)(
-    [LocalVariableWriteNode(0...35)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        :str,
        0,
-       InterpolatedStringNode(6...35)(
+       InterpolatedStringNode(6...12)(
          (6...12),
          [StringNode(14...30)(nil, (14...30), nil, "beforeafter\r\n")],
          (30...35)

--- a/test/snapshots/seattlerb/heredoc_backslash_nl.txt
+++ b/test/snapshots/seattlerb/heredoc_backslash_nl.txt
@@ -1,13 +1,13 @@
-ProgramNode(0...93)(
+ProgramNode(0...49)(
   [],
-  StatementsNode(0...93)(
+  StatementsNode(0...49)(
     [StringNode(0...40)(
        (0...1),
        (1...39),
        (39...40),
        "  why would someone do this?   blah\n"
      ),
-     InterpolatedStringNode(42...93)(
+     InterpolatedStringNode(42...49)(
        (42...49),
        [StringNode(50...88)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_bad_hex_escape.txt
+++ b/test/snapshots/seattlerb/heredoc_bad_hex_escape.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...21)(
+ProgramNode(0...9)(
   [:s],
-  StatementsNode(0...21)(
-    [LocalVariableWriteNode(0...21)(
+  StatementsNode(0...9)(
+    [LocalVariableWriteNode(0...9)(
        :s,
        0,
-       InterpolatedStringNode(4...21)(
+       InterpolatedStringNode(4...9)(
          (4...9),
          [StringNode(10...17)(nil, (10...17), nil, "a\xE9b\n")],
          (17...21)

--- a/test/snapshots/seattlerb/heredoc_bad_oct_escape.txt
+++ b/test/snapshots/seattlerb/heredoc_bad_oct_escape.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...27)(
+ProgramNode(0...10)(
   [:s],
-  StatementsNode(0...27)(
-    [LocalVariableWriteNode(0...27)(
+  StatementsNode(0...10)(
+    [LocalVariableWriteNode(0...10)(
        :s,
        0,
-       InterpolatedStringNode(4...27)(
+       InterpolatedStringNode(4...10)(
          (4...10),
          [StringNode(11...23)(nil, (11...23), nil, "a\xA7b\n" + "cöd\n")],
          (23...27)

--- a/test/snapshots/seattlerb/heredoc_comma_arg.txt
+++ b/test/snapshots/seattlerb/heredoc_comma_arg.txt
@@ -7,7 +7,7 @@ ProgramNode(0...47)(
        (16...17)
      ),
      ArrayNode(19...47)(
-       [InterpolatedStringNode(20...46)(
+       [InterpolatedStringNode(20...27)(
           (20...27),
           [StringNode(29...41)(nil, (29...41), nil, "  some text\n")],
           (41...46)

--- a/test/snapshots/seattlerb/heredoc_lineno.txt
+++ b/test/snapshots/seattlerb/heredoc_lineno.txt
@@ -1,10 +1,10 @@
 ProgramNode(0...41)(
   [:c, :d],
   StatementsNode(0...41)(
-    [LocalVariableWriteNode(0...34)(
+    [LocalVariableWriteNode(0...11)(
        :c,
        0,
-       InterpolatedStringNode(4...34)(
+       InterpolatedStringNode(4...11)(
          (4...11),
          [StringNode(12...30)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_nested.txt
+++ b/test/snapshots/seattlerb/heredoc_nested.txt
@@ -2,12 +2,12 @@ ProgramNode(0...23)(
   [],
   StatementsNode(0...23)(
     [ArrayNode(0...23)(
-       [InterpolatedStringNode(1...21)(
+       [InterpolatedStringNode(1...4)(
           (1...4),
           [EmbeddedStatementsNode(6...12)(
              (6...8),
-             StatementsNode(8...17)(
-               [InterpolatedStringNode(8...17)(
+             StatementsNode(8...11)(
+               [InterpolatedStringNode(8...11)(
                   (8...11),
                   [StringNode(13...15)(nil, (13...15), nil, "b\n")],
                   (15...17)

--- a/test/snapshots/seattlerb/heredoc_squiggly.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...31)(
+ProgramNode(0...12)(
   [:a],
-  StatementsNode(0...31)(
-    [LocalVariableWriteNode(0...31)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        :a,
        0,
-       InterpolatedStringNode(4...31)(
+       InterpolatedStringNode(4...12)(
          (4...12),
          [StringNode(13...25)(nil, (13...25), nil, "x\n" + "y\n" + "z\n")],
          (25...31)

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
@@ -11,7 +11,7 @@ ProgramNode(0...20)(
          (7...8),
          ArgumentsNode(8...19)(
            [CallNode(8...19)(
-              InterpolatedStringNode(8...42)(
+              InterpolatedStringNode(8...14)(
                 (8...14),
                 [StringNode(21...26)(nil, (21...26), nil, "\n"),
                  EmbeddedStatementsNode(26...32)(

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...24)(
+ProgramNode(0...10)(
   [:a],
-  StatementsNode(0...24)(
-    [LocalVariableWriteNode(0...24)(
+  StatementsNode(0...10)(
+    [LocalVariableWriteNode(0...10)(
        :a,
        0,
-       InterpolatedStringNode(4...24)(
+       InterpolatedStringNode(4...10)(
          (4...10),
          [StringNode(11...20)(nil, (11...20), nil, "x\n" + "\n" + "z\n")],
          (20...24)

--- a/test/snapshots/seattlerb/heredoc_squiggly_empty.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_empty.txt
@@ -1,4 +1,4 @@
-ProgramNode(0...7)(
+ProgramNode(0...4)(
   [],
-  StatementsNode(0...7)([InterpolatedStringNode(0...7)((0...4), [], (5...7))])
+  StatementsNode(0...4)([InterpolatedStringNode(0...4)((0...4), [], (5...7))])
 )

--- a/test/snapshots/seattlerb/heredoc_squiggly_interp.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_interp.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...42)(
+ProgramNode(0...10)(
   [:a],
-  StatementsNode(0...42)(
-    [LocalVariableWriteNode(0...42)(
+  StatementsNode(0...10)(
+    [LocalVariableWriteNode(0...10)(
        :a,
        0,
-       InterpolatedStringNode(4...42)(
+       InterpolatedStringNode(4...10)(
          (4...10),
          [StringNode(11...22)(nil, (11...22), nil, "    w\n" + "x"),
           EmbeddedStatementsNode(22...27)(

--- a/test/snapshots/seattlerb/heredoc_squiggly_no_indent.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_no_indent.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...9)(
+ProgramNode(0...4)(
   [],
-  StatementsNode(0...9)(
-    [InterpolatedStringNode(0...9)(
+  StatementsNode(0...4)(
+    [InterpolatedStringNode(0...4)(
        (0...4),
        [StringNode(5...7)(nil, (5...7), nil, "a\n")],
        (7...9)

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...49)(
+ProgramNode(0...12)(
   [:a],
-  StatementsNode(0...49)(
-    [LocalVariableWriteNode(0...49)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        :a,
        0,
-       InterpolatedStringNode(4...49)(
+       InterpolatedStringNode(4...12)(
          (4...12),
          [StringNode(13...43)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...43)(
+ProgramNode(0...12)(
   [:a],
-  StatementsNode(0...43)(
-    [LocalVariableWriteNode(0...43)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        :a,
        0,
-       InterpolatedStringNode(4...43)(
+       InterpolatedStringNode(4...12)(
          (4...12),
          [StringNode(13...37)(
             nil,

--- a/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
+++ b/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
@@ -1,10 +1,10 @@
-ProgramNode(0...24)(
+ProgramNode(0...10)(
   [:a],
-  StatementsNode(0...24)(
-    [LocalVariableWriteNode(0...24)(
+  StatementsNode(0...10)(
+    [LocalVariableWriteNode(0...10)(
        :a,
        0,
-       InterpolatedStringNode(4...24)(
+       InterpolatedStringNode(4...10)(
          (4...10),
          [StringNode(11...20)(nil, (11...20), nil, "x\n" + "\n" + "z\n")],
          (20...24)

--- a/test/snapshots/seattlerb/heredoc_trailing_slash_continued_call.txt
+++ b/test/snapshots/seattlerb/heredoc_trailing_slash_continued_call.txt
@@ -2,7 +2,7 @@ ProgramNode(0...22)(
   [],
   StatementsNode(0...22)(
     [CallNode(0...22)(
-       InterpolatedStringNode(0...16)(
+       InterpolatedStringNode(0...5)(
          (0...5),
          [StringNode(7...12)(nil, (7...12), nil, "blah\n")],
          (12...16)

--- a/test/snapshots/seattlerb/heredoc_unicode.txt
+++ b/test/snapshots/seattlerb/heredoc_unicode.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...20)(
+ProgramNode(0...9)(
   [],
-  StatementsNode(0...20)(
-    [InterpolatedStringNode(0...20)(
+  StatementsNode(0...9)(
+    [InterpolatedStringNode(0...9)(
        (0...9),
        [StringNode(10...12)(nil, (10...12), nil, ".\n")],
        (12...20)

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.txt
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...25)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...25)(
-    [InterpolatedStringNode(0...25)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(6...21)(nil, (6...21), nil, "foo\rbar\n" + "baz\r\n")],
        (21...25)

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.txt
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...29)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...29)(
-    [InterpolatedStringNode(0...29)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(7...24)(nil, (7...24), nil, "foo\rbar\r\n" + "baz\r\r\n")],
        (24...29)

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix.txt
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...19)(
+ProgramNode(0...7)(
   [],
-  StatementsNode(0...19)(
-    [InterpolatedStringNode(0...19)(
+  StatementsNode(0...7)(
+    [InterpolatedStringNode(0...7)(
        (0...7),
        [StringNode(9...15)(nil, (9...15), nil, "body\r\n")],
        (15...19)

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.txt
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...23)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...23)(
-    [InterpolatedStringNode(0...23)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(6...19)(nil, (6...19), nil, "foo\rbar\r\n" + "baz\n")],
        (19...23)

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.txt
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...27)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...27)(
-    [InterpolatedStringNode(0...27)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(7...22)(nil, (7...22), nil, "foo\rbar\r\r\n" + "baz\r\n")],
        (22...27)

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.txt
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...21)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...21)(
-    [InterpolatedStringNode(0...21)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(6...11)(nil, (6...11), nil, "foo\r"),
         EmbeddedVariableNode(11...16)(

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.txt
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...24)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...24)(
-    [InterpolatedStringNode(0...24)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(7...12)(nil, (7...12), nil, "foo\r"),
         EmbeddedVariableNode(12...17)(

--- a/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.txt
+++ b/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...23)(
+ProgramNode(0...10)(
   [],
-  StatementsNode(0...23)(
-    [InterpolatedStringNode(0...23)(
+  StatementsNode(0...10)(
+    [InterpolatedStringNode(0...10)(
        (0...10),
        [StringNode(11...15)(nil, (11...15), nil, "\#${\n")],
        (15...23)

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.txt
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...18)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...18)(
-    [InterpolatedStringNode(0...18)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(6...14)(nil, (6...14), nil, "\r\n" + "\r\r\n" + "\r\n")],
        (14...18)

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.txt
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...23)(
+ProgramNode(0...5)(
   [],
-  StatementsNode(0...23)(
-    [InterpolatedStringNode(0...23)(
+  StatementsNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        (0...5),
        [StringNode(7...18)(
           nil,

--- a/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.txt
+++ b/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.txt
@@ -9,7 +9,7 @@ ProgramNode(0...30)(
        ArgumentsNode(2...30)(
          [CallNode(2...30)(
             CallNode(2...26)(
-              InterpolatedStringNode(2...22)(
+              InterpolatedStringNode(2...8)(
                 (2...8),
                 [StringNode(12...16)(nil, (12...16), nil, "  a\n")],
                 (16...22)

--- a/test/snapshots/seattlerb/parse_line_heredoc.txt
+++ b/test/snapshots/seattlerb/parse_line_heredoc.txt
@@ -5,7 +5,7 @@ ProgramNode(6...88)(
        :string,
        0,
        CallNode(15...31)(
-         InterpolatedStringNode(15...71)(
+         InterpolatedStringNode(15...25)(
            (15...25),
            [StringNode(32...57)(
               nil,

--- a/test/snapshots/seattlerb/parse_line_heredoc_evstr.txt
+++ b/test/snapshots/seattlerb/parse_line_heredoc_evstr.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...14)(
+ProgramNode(0...4)(
   [],
-  StatementsNode(0...14)(
-    [InterpolatedStringNode(0...14)(
+  StatementsNode(0...4)(
+    [InterpolatedStringNode(0...4)(
        (0...4),
        [StringNode(5...7)(nil, (5...7), nil, "a\n"),
         EmbeddedStatementsNode(7...11)(

--- a/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
+++ b/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
@@ -1,7 +1,7 @@
 ProgramNode(0...48)(
   [],
   StatementsNode(0...48)(
-    [InterpolatedStringNode(0...34)(
+    [InterpolatedStringNode(0...8)(
        (0...8),
        [StringNode(9...28)(
           nil,

--- a/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
+++ b/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
@@ -1,10 +1,10 @@
 ProgramNode(6...74)(
   [:string],
   StatementsNode(6...74)(
-    [LocalVariableWriteNode(6...57)(
+    [LocalVariableWriteNode(6...22)(
        :string,
        0,
-       InterpolatedStringNode(15...57)(
+       InterpolatedStringNode(15...22)(
          (15...22),
          [StringNode(23...48)(
             nil,

--- a/test/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
+++ b/test/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
@@ -3,12 +3,12 @@ ProgramNode(0...30)(
   StatementsNode(0...30)(
     [ArrayNode(0...30)(
        [StringNode(4...5)(nil, (4...5), nil, "1"),
-        InterpolatedStringNode(0...12)(
+        InterpolatedStringNode(6...12)(
           nil,
           [EmbeddedStatementsNode(6...12)(
              (6...8),
-             StatementsNode(8...19)(
-               [InterpolatedStringNode(8...19)(
+             StatementsNode(8...11)(
+               [InterpolatedStringNode(8...11)(
                   (8...11),
                   [StringNode(15...17)(nil, (15...17), nil, "2\n")],
                   (17...19)

--- a/test/snapshots/seattlerb/str_heredoc_interp.txt
+++ b/test/snapshots/seattlerb/str_heredoc_interp.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...17)(
+ProgramNode(0...4)(
   [],
-  StatementsNode(0...17)(
-    [InterpolatedStringNode(0...17)(
+  StatementsNode(0...4)(
+    [InterpolatedStringNode(0...4)(
        (0...4),
        [EmbeddedStatementsNode(5...9)(
           (5...7),

--- a/test/snapshots/seattlerb/words_interp.txt
+++ b/test/snapshots/seattlerb/words_interp.txt
@@ -2,7 +2,7 @@ ProgramNode(0...9)(
   [],
   StatementsNode(0...9)(
     [ArrayNode(0...9)(
-       [InterpolatedStringNode(0...8)(
+       [InterpolatedStringNode(3...8)(
           nil,
           [EmbeddedStatementsNode(3...7)(
              (3...5),

--- a/test/snapshots/single_quote_heredocs.txt
+++ b/test/snapshots/single_quote_heredocs.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...48)(
+ProgramNode(0...8)(
   [],
-  StatementsNode(0...48)(
-    [InterpolatedStringNode(0...48)(
+  StatementsNode(0...8)(
+    [InterpolatedStringNode(0...8)(
        (0...8),
        [StringNode(9...44)(
           nil,

--- a/test/snapshots/strings.txt
+++ b/test/snapshots/strings.txt
@@ -120,7 +120,7 @@ ProgramNode(0...498)(
      ),
      ArrayNode(325...339)(
        [StringNode(328...329)(nil, (328...329), nil, "a"),
-        InterpolatedStringNode(0...336)(
+        InterpolatedStringNode(330...336)(
           nil,
           [StringNode(330...331)(nil, (330...331), nil, "b"),
            EmbeddedStatementsNode(331...335)(

--- a/test/snapshots/tilde_heredocs.txt
+++ b/test/snapshots/tilde_heredocs.txt
@@ -1,17 +1,17 @@
-ProgramNode(0...387)(
+ProgramNode(0...372)(
   [],
-  StatementsNode(0...387)(
-    [InterpolatedStringNode(0...15)(
+  StatementsNode(0...372)(
+    [InterpolatedStringNode(0...6)(
        (0...6),
        [StringNode(7...11)(nil, (7...11), nil, "a\n")],
        (11...15)
      ),
-     InterpolatedStringNode(16...38)(
+     InterpolatedStringNode(16...22)(
        (16...22),
        [StringNode(23...34)(nil, (23...34), nil, "\ta\n" + "b\n" + "\t\tc\n")],
        (34...38)
      ),
-     InterpolatedStringNode(39...59)(
+     InterpolatedStringNode(39...45)(
        (39...45),
        [EmbeddedStatementsNode(48...52)(
           (48...50),
@@ -21,7 +21,7 @@ ProgramNode(0...387)(
         StringNode(52...55)(nil, (52...55), nil, " a\n")],
        (55...59)
      ),
-     InterpolatedStringNode(60...80)(
+     InterpolatedStringNode(60...66)(
        (60...66),
        [StringNode(67...71)(nil, (67...71), nil, "a "),
         EmbeddedStatementsNode(71...75)(
@@ -32,7 +32,7 @@ ProgramNode(0...387)(
         StringNode(75...76)(nil, (75...76), nil, "\n")],
        (76...80)
      ),
-     InterpolatedStringNode(81...102)(
+     InterpolatedStringNode(81...87)(
        (81...87),
        [StringNode(88...93)(nil, (88...93), nil, " a\n"),
         EmbeddedStatementsNode(93...97)(
@@ -43,7 +43,7 @@ ProgramNode(0...387)(
         StringNode(97...98)(nil, (97...98), nil, "\n")],
        (98...102)
      ),
-     InterpolatedStringNode(103...125)(
+     InterpolatedStringNode(103...109)(
        (103...109),
        [StringNode(110...116)(nil, (110...116), nil, "a\n"),
         EmbeddedStatementsNode(116...120)(
@@ -54,52 +54,52 @@ ProgramNode(0...387)(
         StringNode(120...121)(nil, (120...121), nil, "\n")],
        (121...125)
      ),
-     InterpolatedStringNode(126...145)(
+     InterpolatedStringNode(126...132)(
        (126...132),
        [StringNode(133...141)(nil, (133...141), nil, "a\n" + "b\n")],
        (141...145)
      ),
-     InterpolatedStringNode(146...166)(
+     InterpolatedStringNode(146...152)(
        (146...152),
        [StringNode(153...162)(nil, (153...162), nil, "a\n" + " b\n")],
        (162...166)
      ),
-     InterpolatedStringNode(167...187)(
+     InterpolatedStringNode(167...173)(
        (167...173),
        [StringNode(174...183)(nil, (174...183), nil, "\ta\n" + "b\n")],
        (183...187)
      ),
-     InterpolatedStringNode(188...210)(
+     InterpolatedStringNode(188...196)(
        (188...196),
        [StringNode(197...206)(nil, (197...206), nil, "a \#{1}\n")],
        (206...210)
      ),
-     InterpolatedStringNode(211...229)(
+     InterpolatedStringNode(211...217)(
        (211...217),
        [StringNode(218...225)(nil, (218...225), nil, "a\n" + " b\n")],
        (225...229)
      ),
-     InterpolatedStringNode(230...248)(
+     InterpolatedStringNode(230...236)(
        (230...236),
        [StringNode(237...244)(nil, (237...244), nil, " a\n" + "b\n")],
        (244...248)
      ),
-     InterpolatedStringNode(249...275)(
+     InterpolatedStringNode(249...255)(
        (249...255),
        [StringNode(256...271)(nil, (256...271), nil, "a\n" + "b\n")],
        (271...275)
      ),
-     InterpolatedStringNode(276...296)(
+     InterpolatedStringNode(276...282)(
        (276...282),
        [StringNode(283...292)(nil, (283...292), nil, "a\n" + "\n" + "b\n")],
        (292...296)
      ),
-     InterpolatedStringNode(297...317)(
+     InterpolatedStringNode(297...303)(
        (297...303),
        [StringNode(304...313)(nil, (304...313), nil, "a\n" + "\n" + "b\n")],
        (313...317)
      ),
-     InterpolatedStringNode(318...340)(
+     InterpolatedStringNode(318...324)(
        (318...324),
        [StringNode(325...336)(
           nil,
@@ -109,7 +109,7 @@ ProgramNode(0...387)(
         )],
        (336...340)
      ),
-     InterpolatedStringNode(341...365)(
+     InterpolatedStringNode(341...347)(
        (341...347),
        [StringNode(348...351)(nil, (348...351), nil, "\n"),
         EmbeddedStatementsNode(351...355)(
@@ -120,7 +120,7 @@ ProgramNode(0...387)(
         StringNode(355...357)(nil, (355...357), nil, "a\n")],
        (357...365)
      ),
-     InterpolatedStringNode(366...387)(
+     InterpolatedStringNode(366...372)(
        (366...372),
        [EmbeddedStatementsNode(375...379)(
           (375...377),

--- a/test/snapshots/unescaping.txt
+++ b/test/snapshots/unescaping.txt
@@ -1,6 +1,6 @@
-ProgramNode(0...55)(
+ProgramNode(0...39)(
   [],
-  StatementsNode(0...55)(
+  StatementsNode(0...39)(
     [ArrayNode(0...10)(
        [StringNode(1...9)((1...2), (2...8), (8...9), "\u0003{1}")],
        (0...1),
@@ -14,7 +14,7 @@ ProgramNode(0...55)(
        0
      ),
      StringNode(22...30)((22...23), (23...29), (29...30), "\u0003{1}"),
-     InterpolatedStringNode(32...55)(
+     InterpolatedStringNode(32...39)(
        (32...39),
        [StringNode(40...50)(nil, (40...50), nil, "\u0003{1}\n")],
        (50...55)

--- a/test/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/snapshots/unparser/corpus/literal/assignment.txt
@@ -1,6 +1,6 @@
-ProgramNode(0...719)(
+ProgramNode(0...704)(
   [:a, :b, :foo, :c, :x],
-  StatementsNode(0...719)(
+  StatementsNode(0...704)(
     [GlobalVariableWriteNode(0...6)((0...2), (3...4), IntegerNode(5...6)()),
      MultiWriteNode(8...24)(
        [GlobalVariableWriteNode(8...10)((8...10), nil, nil),
@@ -615,10 +615,10 @@ ProgramNode(0...719)(
        (554...557),
        StringNode(558...561)((558...560), (560...560), (560...561), "")
      ),
-     LocalVariableWriteNode(562...591)(
+     LocalVariableWriteNode(562...576)(
        :x,
        0,
-       InterpolatedStringNode(566...591)(
+       InterpolatedStringNode(566...576)(
          (566...576),
          [StringNode(577...579)(nil, (577...579), nil, "  "),
           EmbeddedStatementsNode(579...582)((579...581), nil, (581...582)),
@@ -628,13 +628,13 @@ ProgramNode(0...719)(
        (562...563),
        (564...565)
      ),
-     CallNode(591...620)(
+     CallNode(591...605)(
        LocalVariableReadNode(591...592)(:x, 0),
        (592...593),
        (593...594),
        nil,
-       ArgumentsNode(595...620)(
-         [InterpolatedStringNode(595...620)(
+       ArgumentsNode(595...605)(
+         [InterpolatedStringNode(595...605)(
             (595...605),
             [StringNode(606...608)(nil, (606...608), nil, "  "),
              EmbeddedStatementsNode(608...611)((608...610), nil, (610...611)),
@@ -647,13 +647,13 @@ ProgramNode(0...719)(
        0,
        "x="
      ),
-     CallNode(620...651)(
+     CallNode(620...636)(
        LocalVariableReadNode(620...621)(:x, 0),
        nil,
        (621...623),
        (621...622),
-       ArgumentsNode(626...651)(
-         [InterpolatedStringNode(626...651)(
+       ArgumentsNode(626...636)(
+         [InterpolatedStringNode(626...636)(
             (626...636),
             [StringNode(637...639)(nil, (637...639), nil, "  "),
              EmbeddedStatementsNode(639...642)((639...641), nil, (641...642)),
@@ -672,8 +672,8 @@ ProgramNode(0...719)(
          nil,
          (652...664),
          (652...653),
-         ArgumentsNode(653...687)(
-           [InterpolatedStringNode(653...687)(
+         ArgumentsNode(653...663)(
+           [InterpolatedStringNode(653...663)(
               (653...663),
               [StringNode(673...675)(nil, (673...675), nil, "  "),
                EmbeddedStatementsNode(675...678)(
@@ -703,10 +703,10 @@ ProgramNode(0...719)(
        ),
        (665...668)
      ),
-     InstanceVariableOperatorOrWriteNode(687...719)(
+     InstanceVariableOperatorOrWriteNode(687...704)(
        (687...689),
        (690...693),
-       InterpolatedStringNode(694...719)(
+       InterpolatedStringNode(694...704)(
          (694...704),
          [StringNode(705...707)(nil, (705...707), nil, "  "),
           EmbeddedStatementsNode(707...710)((707...709), nil, (709...710)),

--- a/test/snapshots/unparser/corpus/literal/def.txt
+++ b/test/snapshots/unparser/corpus/literal/def.txt
@@ -983,8 +983,8 @@ ProgramNode(0...913)(
        (860...861),
        nil,
        nil,
-       StatementsNode(864...893)(
-         [InterpolatedStringNode(864...893)(
+       StatementsNode(864...874)(
+         [InterpolatedStringNode(864...874)(
             (864...874),
             [StringNode(875...879)(nil, (875...879), nil, "    "),
              EmbeddedStatementsNode(879...882)((879...881), nil, (881...882)),

--- a/test/snapshots/unparser/corpus/literal/dstr.txt
+++ b/test/snapshots/unparser/corpus/literal/dstr.txt
@@ -19,7 +19,7 @@ ProgramNode(0...299)(
        (21...23),
        TrueNode(24...28)(),
        StatementsNode(31...64)(
-         [InterpolatedStringNode(31...61)(
+         [InterpolatedStringNode(31...41)(
             (31...41),
             [StringNode(42...44)(nil, (42...44), nil, "a\n"),
              EmbeddedStatementsNode(44...47)((44...46), nil, (46...47)),
@@ -31,7 +31,7 @@ ProgramNode(0...299)(
        nil,
        (65...68)
      ),
-     InterpolatedStringNode(69...109)(
+     InterpolatedStringNode(69...79)(
        (69...79),
        [StringNode(80...89)(nil, (80...89), nil, "\#{}\#{}\n"),
         EmbeddedStatementsNode(89...92)((89...91), nil, (91...92)),
@@ -43,7 +43,7 @@ ProgramNode(0...299)(
        (101...109)
      ),
      RescueModifierNode(109...130)(
-       InterpolatedStringNode(109...145)(
+       InterpolatedStringNode(109...119)(
          (109...119),
          [EmbeddedStatementsNode(131...134)((131...133), nil, (133...134)),
           StringNode(134...137)(nil, (134...137), nil, "\n" + "a\n")],
@@ -91,11 +91,11 @@ ProgramNode(0...299)(
      IfNode(174...225)(
        (174...176),
        TrueNode(177...181)(),
-       StatementsNode(184...222)(
-         [ReturnNode(184...222)(
+       StatementsNode(184...201)(
+         [ReturnNode(184...201)(
             (184...190),
-            ArgumentsNode(191...222)(
-              [InterpolatedStringNode(191...222)(
+            ArgumentsNode(191...201)(
+              [InterpolatedStringNode(191...201)(
                  (191...201),
                  [StringNode(202...206)(nil, (202...206), nil, "    "),
                   EmbeddedStatementsNode(206...211)(
@@ -117,8 +117,8 @@ ProgramNode(0...299)(
        nil,
        (226...229),
        (229...230),
-       ArgumentsNode(230...259)(
-         [InterpolatedStringNode(230...259)(
+       ArgumentsNode(230...240)(
+         [InterpolatedStringNode(230...240)(
             (230...240),
             [StringNode(242...244)(nil, (242...244), nil, "  "),
              EmbeddedStatementsNode(244...250)(
@@ -152,8 +152,8 @@ ProgramNode(0...299)(
        nil,
        (259...262),
        (262...263),
-       ArgumentsNode(263...298)(
-         [InterpolatedStringNode(263...298)(
+       ArgumentsNode(263...273)(
+         [InterpolatedStringNode(263...273)(
             (263...273),
             [StringNode(281...283)(nil, (281...283), nil, "  "),
              EmbeddedStatementsNode(283...289)(

--- a/test/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/snapshots/unparser/corpus/literal/literal.txt
@@ -3,9 +3,9 @@ ProgramNode(0...916)(
   StatementsNode(0...916)(
     [HashNode(0...38)(
        (0...1),
-       [AssocNode(2...53)(
+       [AssocNode(2...21)(
           StringNode(2...7)((2...3), (3...6), (6...7), "foo"),
-          InterpolatedStringNode(11...53)(
+          InterpolatedStringNode(11...21)(
             (11...21),
             [StringNode(39...41)(nil, (39...41), nil, "  "),
              EmbeddedStatementsNode(41...44)((41...43), nil, (43...44)),
@@ -47,8 +47,8 @@ ProgramNode(0...916)(
          nil,
          (98...99),
          (99...100),
-         ArgumentsNode(100...128)(
-           [InterpolatedStringNode(100...128)(
+         ArgumentsNode(100...110)(
+           [InterpolatedStringNode(100...110)(
               (100...110),
               [StringNode(114...116)(nil, (114...116), nil, "  "),
                EmbeddedStatementsNode(116...119)(
@@ -99,9 +99,9 @@ ProgramNode(0...916)(
      ),
      HashNode(137...167)(
        (137...138),
-       [AssocNode(139...182)(
+       [AssocNode(139...158)(
           StringNode(139...144)((139...140), (140...143), (143...144), "foo"),
-          InterpolatedStringNode(148...182)(
+          InterpolatedStringNode(148...158)(
             (148...158),
             [StringNode(168...170)(nil, (168...170), nil, "  "),
              EmbeddedStatementsNode(170...173)((170...172), nil, (172...173)),

--- a/test/snapshots/unparser/corpus/semantic/block.txt
+++ b/test/snapshots/unparser/corpus/semantic/block.txt
@@ -95,8 +95,8 @@ ProgramNode(0...148)(
        nil,
        (82...85),
        (85...86),
-       ArgumentsNode(86...109)(
-         [InterpolatedStringNode(86...109)(
+       ArgumentsNode(86...92)(
+         [InterpolatedStringNode(86...92)(
             (86...92),
             [StringNode(101...105)(nil, (101...105), nil, "  b\n")],
             (105...109)
@@ -131,8 +131,8 @@ ProgramNode(0...148)(
        nil,
        (118...121),
        (121...122),
-       ArgumentsNode(122...141)(
-         [InterpolatedStringNode(122...141)(
+       ArgumentsNode(122...128)(
+         [InterpolatedStringNode(122...128)(
             (122...128),
             [StringNode(133...137)(nil, (133...137), nil, "  b\n")],
             (137...141)

--- a/test/snapshots/unparser/corpus/semantic/dstr.txt
+++ b/test/snapshots/unparser/corpus/semantic/dstr.txt
@@ -1,62 +1,62 @@
 ProgramNode(0...608)(
   [],
   StatementsNode(0...608)(
-    [InterpolatedStringNode(0...10)((0...5), [], (6...10)),
-     InterpolatedStringNode(11...23)((11...18), [], (19...23)),
-     InterpolatedStringNode(24...35)((24...30), [], (31...35)),
-     InterpolatedStringNode(36...49)((36...44), [], (45...49)),
-     InterpolatedStringNode(50...64)(
+    [InterpolatedStringNode(0...5)((0...5), [], (6...10)),
+     InterpolatedStringNode(11...18)((11...18), [], (19...23)),
+     InterpolatedStringNode(24...30)((24...30), [], (31...35)),
+     InterpolatedStringNode(36...44)((36...44), [], (45...49)),
+     InterpolatedStringNode(50...55)(
        (50...55),
        [StringNode(56...60)(nil, (56...60), nil, "  a\n")],
        (60...64)
      ),
-     InterpolatedStringNode(65...81)(
+     InterpolatedStringNode(65...72)(
        (65...72),
        [StringNode(73...77)(nil, (73...77), nil, "  a\n")],
        (77...81)
      ),
-     InterpolatedStringNode(82...102)(
+     InterpolatedStringNode(82...87)(
        (82...87),
        [StringNode(88...94)(nil, (88...94), nil, "  a\n" + "  "),
         EmbeddedStatementsNode(94...97)((94...96), nil, (96...97)),
         StringNode(97...98)(nil, (97...98), nil, "\n")],
        (98...102)
      ),
-     InterpolatedStringNode(103...124)(
+     InterpolatedStringNode(103...109)(
        (103...109),
        [StringNode(110...116)(nil, (110...116), nil, "a\n"),
         EmbeddedStatementsNode(116...119)((116...118), nil, (118...119)),
         StringNode(119...120)(nil, (119...120), nil, "\n")],
        (120...124)
      ),
-     InterpolatedStringNode(125...150)(
+     InterpolatedStringNode(125...131)(
        (125...131),
        [StringNode(132...138)(nil, (132...138), nil, "a\n"),
         EmbeddedStatementsNode(138...141)((138...140), nil, (140...141)),
         StringNode(141...146)(nil, (141...146), nil, "\n" + "b\n")],
        (146...150)
      ),
-     InterpolatedStringNode(151...172)(
+     InterpolatedStringNode(151...157)(
        (151...157),
        [StringNode(158...168)(nil, (158...168), nil, "a\n" + "  b\n")],
        (168...172)
      ),
-     InterpolatedStringNode(173...190)(
+     InterpolatedStringNode(173...180)(
        (173...180),
        [StringNode(181...186)(nil, (181...186), nil, "a\n" + "\n" + "b\n")],
        (186...190)
      ),
-     InterpolatedStringNode(191...210)(
+     InterpolatedStringNode(191...198)(
        (191...198),
        [StringNode(199...206)(nil, (199...206), nil, " a\n" + "\n" + " b\n")],
        (206...210)
      ),
-     InterpolatedStringNode(211...229)(
+     InterpolatedStringNode(211...218)(
        (211...218),
        [StringNode(219...225)(nil, (219...225), nil, " a\\nb\n")],
        (225...229)
      ),
-     InterpolatedStringNode(230...251)(
+     InterpolatedStringNode(230...235)(
        (230...235),
        [EmbeddedStatementsNode(236...239)((236...238), nil, (238...239)),
         StringNode(239...242)(nil, (239...242), nil, "a\n" + " "),
@@ -64,21 +64,21 @@ ProgramNode(0...608)(
         StringNode(245...247)(nil, (245...247), nil, "a\n")],
        (247...251)
      ),
-     InterpolatedStringNode(252...275)(
+     InterpolatedStringNode(252...257)(
        (252...257),
        [StringNode(258...260)(nil, (258...260), nil, "  "),
         EmbeddedStatementsNode(260...263)((260...262), nil, (262...263)),
         StringNode(263...271)(nil, (263...271), nil, "\n" + "  \#{}\n")],
        (271...275)
      ),
-     InterpolatedStringNode(276...296)(
+     InterpolatedStringNode(276...281)(
        (276...281),
        [StringNode(282...284)(nil, (282...284), nil, " a"),
         EmbeddedStatementsNode(284...287)((284...286), nil, (286...287)),
         StringNode(287...292)(nil, (287...292), nil, "b\n" + " c\n")],
        (292...296)
      ),
-     InterpolatedStringNode(297...314)(
+     InterpolatedStringNode(297...303)(
        (297...303),
        [EmbeddedStatementsNode(306...309)((306...308), nil, (308...309)),
         StringNode(309...310)(nil, (309...310), nil, "\n")],
@@ -87,8 +87,8 @@ ProgramNode(0...608)(
      IfNode(315...349)(
        (315...317),
        TrueNode(318...322)(),
-       StatementsNode(325...346)(
-         [InterpolatedStringNode(325...346)(
+       StatementsNode(325...331)(
+         [InterpolatedStringNode(325...331)(
             (325...331),
             [EmbeddedStatementsNode(336...339)((336...338), nil, (338...339)),
              StringNode(339...340)(nil, (339...340), nil, "\n")],
@@ -101,8 +101,8 @@ ProgramNode(0...608)(
      IfNode(351...386)(
        (351...353),
        TrueNode(354...358)(),
-       StatementsNode(361...383)(
-         [InterpolatedStringNode(361...383)(
+       StatementsNode(361...367)(
+         [InterpolatedStringNode(361...367)(
             (361...367),
             [StringNode(368...373)(nil, (368...373), nil, "b"),
              EmbeddedStatementsNode(373...376)((373...375), nil, (375...376)),
@@ -116,8 +116,8 @@ ProgramNode(0...608)(
      IfNode(388...423)(
        (388...390),
        TrueNode(391...395)(),
-       StatementsNode(398...420)(
-         [InterpolatedStringNode(398...420)(
+       StatementsNode(398...404)(
+         [InterpolatedStringNode(398...404)(
             (398...404),
             [EmbeddedStatementsNode(409...412)((409...411), nil, (411...412)),
              StringNode(412...414)(nil, (412...414), nil, "a\n")],
@@ -130,8 +130,8 @@ ProgramNode(0...608)(
      IfNode(425...464)(
        (425...427),
        TrueNode(428...432)(),
-       StatementsNode(435...461)(
-         [InterpolatedStringNode(435...461)(
+       StatementsNode(435...443)(
+         [InterpolatedStringNode(435...443)(
             (435...443),
             [StringNode(444...455)(
                nil,

--- a/test/snapshots/unparser/corpus/semantic/while.txt
+++ b/test/snapshots/unparser/corpus/semantic/while.txt
@@ -102,8 +102,8 @@ ProgramNode(0...188)(
          nil,
          (106...107),
          (107...108),
-         ArgumentsNode(108...123)(
-           [InterpolatedStringNode(108...123)((108...114), [], (119...123))]
+         ArgumentsNode(108...114)(
+           [InterpolatedStringNode(108...114)((108...114), [], (119...123))]
          ),
          (114...115),
          BlockNode(116...130)(

--- a/test/snapshots/whitequark/array_words_interp.txt
+++ b/test/snapshots/whitequark/array_words_interp.txt
@@ -3,7 +3,7 @@ ProgramNode(0...38)(
   StatementsNode(0...38)(
     [ArrayNode(0...14)(
        [StringNode(3...6)(nil, (3...6), nil, "foo"),
-        InterpolatedStringNode(0...13)(
+        InterpolatedStringNode(7...13)(
           nil,
           [EmbeddedStatementsNode(7...13)(
              (7...9),
@@ -29,7 +29,7 @@ ProgramNode(0...38)(
      ),
      ArrayNode(16...38)(
        [StringNode(19...22)(nil, (19...22), nil, "foo"),
-        InterpolatedStringNode(0...37)(
+        InterpolatedStringNode(23...37)(
           nil,
           [EmbeddedStatementsNode(23...29)(
              (23...25),

--- a/test/snapshots/whitequark/bug_heredoc_do.txt
+++ b/test/snapshots/whitequark/bug_heredoc_do.txt
@@ -6,8 +6,8 @@ ProgramNode(0...23)(
        nil,
        (0...1),
        nil,
-       ArgumentsNode(2...20)(
-         [InterpolatedStringNode(2...20)((2...10), [], (14...20))]
+       ArgumentsNode(2...10)(
+         [InterpolatedStringNode(2...10)((2...10), [], (14...20))]
        ),
        nil,
        BlockNode(11...23)([], nil, nil, (11...13), (20...23)),

--- a/test/snapshots/whitequark/bug_interp_single.txt
+++ b/test/snapshots/whitequark/bug_interp_single.txt
@@ -11,7 +11,7 @@ ProgramNode(0...16)(
        (5...6)
      ),
      ArrayNode(8...16)(
-       [InterpolatedStringNode(0...15)(
+       [InterpolatedStringNode(11...15)(
           nil,
           [EmbeddedStatementsNode(11...15)(
              (11...13),

--- a/test/snapshots/whitequark/dedenting_heredoc.txt
+++ b/test/snapshots/whitequark/dedenting_heredoc.txt
@@ -1,13 +1,13 @@
-ProgramNode(0...327)(
+ProgramNode(0...309)(
   [],
-  StatementsNode(0...327)(
-    [CallNode(0...28)(
+  StatementsNode(0...309)(
+    [CallNode(0...8)(
        nil,
        nil,
        (0...1),
        nil,
-       ArgumentsNode(2...28)(
-         [InterpolatedStringNode(2...28)(
+       ArgumentsNode(2...8)(
+         [InterpolatedStringNode(2...8)(
             (2...8),
             [StringNode(9...17)(nil, (9...17), nil, "  x\n"),
              EmbeddedStatementsNode(17...25)(
@@ -26,13 +26,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(29...55)(
+     CallNode(29...37)(
        nil,
        nil,
        (29...30),
        nil,
-       ArgumentsNode(31...55)(
-         [InterpolatedStringNode(31...55)(
+       ArgumentsNode(31...37)(
+         [InterpolatedStringNode(31...37)(
             (31...37),
             [StringNode(38...46)(nil, (38...46), nil, "  x\n"),
              EmbeddedStatementsNode(46...52)(
@@ -61,13 +61,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(56...78)(
+     CallNode(56...62)(
        nil,
        nil,
        (56...57),
        nil,
-       ArgumentsNode(58...78)(
-         [InterpolatedStringNode(58...78)(
+       ArgumentsNode(58...62)(
+         [InterpolatedStringNode(58...62)(
             (58...62),
             [StringNode(63...76)(nil, (63...76), nil, "x\n" + "y\n")],
             (76...78)
@@ -78,13 +78,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(79...97)(
+     CallNode(79...85)(
        nil,
        nil,
        (79...80),
        nil,
-       ArgumentsNode(81...97)(
-         [InterpolatedStringNode(81...97)(
+       ArgumentsNode(81...85)(
+         [InterpolatedStringNode(81...85)(
             (81...85),
             [StringNode(86...95)(nil, (86...95), nil, "\tx\n" + "y\n")],
             (95...97)
@@ -95,13 +95,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(98...124)(
+     CallNode(98...104)(
        nil,
        nil,
        (98...99),
        nil,
-       ArgumentsNode(100...124)(
-         [InterpolatedStringNode(100...124)(
+       ArgumentsNode(100...104)(
+         [InterpolatedStringNode(100...104)(
             (100...104),
             [StringNode(105...122)(nil, (105...122), nil, "x\n" + "y\n")],
             (122...124)
@@ -112,13 +112,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(125...148)(
+     CallNode(125...131)(
        nil,
        nil,
        (125...126),
        nil,
-       ArgumentsNode(127...148)(
-         [InterpolatedStringNode(127...148)(
+       ArgumentsNode(127...131)(
+         [InterpolatedStringNode(127...131)(
             (127...131),
             [StringNode(132...146)(nil, (132...146), nil, "\tx\n" + "y\n")],
             (146...148)
@@ -129,13 +129,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(149...170)(
+     CallNode(149...155)(
        nil,
        nil,
        (149...150),
        nil,
-       ArgumentsNode(151...170)(
-         [InterpolatedStringNode(151...170)(
+       ArgumentsNode(151...155)(
+         [InterpolatedStringNode(151...155)(
             (151...155),
             [StringNode(156...168)(nil, (156...168), nil, "  x\n" + "\ty\n")],
             (168...170)
@@ -146,13 +146,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(171...193)(
+     CallNode(171...177)(
        nil,
        nil,
        (171...172),
        nil,
-       ArgumentsNode(173...193)(
-         [InterpolatedStringNode(173...193)(
+       ArgumentsNode(173...177)(
+         [InterpolatedStringNode(173...177)(
             (173...177),
             [StringNode(178...191)(nil, (178...191), nil, "  x\n" + "  y\n")],
             (191...193)
@@ -163,26 +163,26 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(194...205)(
+     CallNode(194...200)(
        nil,
        nil,
        (194...195),
        nil,
-       ArgumentsNode(196...205)(
-         [InterpolatedStringNode(196...205)((196...200), [], (201...205))]
+       ArgumentsNode(196...200)(
+         [InterpolatedStringNode(196...200)((196...200), [], (201...205))]
        ),
        nil,
        nil,
        0,
        "p"
      ),
-     CallNode(206...222)(
+     CallNode(206...212)(
        nil,
        nil,
        (206...207),
        nil,
-       ArgumentsNode(208...222)(
-         [InterpolatedStringNode(208...222)(
+       ArgumentsNode(208...212)(
+         [InterpolatedStringNode(208...212)(
             (208...212),
             [StringNode(213...220)(
                nil,
@@ -198,13 +198,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(223...241)(
+     CallNode(223...229)(
        nil,
        nil,
        (223...224),
        nil,
-       ArgumentsNode(225...241)(
-         [InterpolatedStringNode(225...241)(
+       ArgumentsNode(225...229)(
+         [InterpolatedStringNode(225...229)(
             (225...229),
             [StringNode(230...239)(
                nil,
@@ -220,13 +220,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(242...261)(
+     CallNode(242...248)(
        nil,
        nil,
        (242...243),
        nil,
-       ArgumentsNode(244...261)(
-         [InterpolatedStringNode(244...261)(
+       ArgumentsNode(244...248)(
+         [InterpolatedStringNode(244...248)(
             (244...248),
             [StringNode(249...259)(nil, (249...259), nil, "x\n" + "  y\n")],
             (259...261)
@@ -237,13 +237,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(262...275)(
+     CallNode(262...268)(
        nil,
        nil,
        (262...263),
        nil,
-       ArgumentsNode(264...275)(
-         [InterpolatedStringNode(264...275)(
+       ArgumentsNode(264...268)(
+         [InterpolatedStringNode(264...268)(
             (264...268),
             [StringNode(269...273)(nil, (269...273), nil, "x\n")],
             (273...275)
@@ -254,13 +254,13 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(276...290)(
+     CallNode(276...282)(
        nil,
        nil,
        (276...277),
        nil,
-       ArgumentsNode(278...290)(
-         [InterpolatedStringNode(278...290)(
+       ArgumentsNode(278...282)(
+         [InterpolatedStringNode(278...282)(
             (278...282),
             [StringNode(283...288)(nil, (283...288), nil, "ð\n")],
             (288...290)
@@ -271,26 +271,26 @@ ProgramNode(0...327)(
        0,
        "p"
      ),
-     CallNode(291...300)(
+     CallNode(291...297)(
        nil,
        nil,
        (291...292),
        nil,
-       ArgumentsNode(293...300)(
-         [InterpolatedStringNode(293...300)((293...297), [], (298...300))]
+       ArgumentsNode(293...297)(
+         [InterpolatedStringNode(293...297)((293...297), [], (298...300))]
        ),
        nil,
        nil,
        0,
        "p"
      ),
-     CallNode(301...327)(
+     CallNode(301...309)(
        nil,
        nil,
        (301...302),
        nil,
-       ArgumentsNode(303...327)(
-         [InterpolatedXStringNode(303...327)(
+       ArgumentsNode(303...309)(
+         [InterpolatedXStringNode(303...309)(
             (303...309),
             [StringNode(310...318)(nil, (310...318), nil, "  x\n"),
              EmbeddedStatementsNode(318...324)(

--- a/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
+++ b/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...27)(
+ProgramNode(0...8)(
   [],
-  StatementsNode(0...27)(
-    [InterpolatedStringNode(0...27)(
+  StatementsNode(0...8)(
+    [InterpolatedStringNode(0...8)(
        (0...8),
        [StringNode(9...23)(nil, (9...23), nil, "baz\\\n" + "qux\n")],
        (23...27)

--- a/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
+++ b/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...26)(
+ProgramNode(0...8)(
   [],
-  StatementsNode(0...26)(
-    [InterpolatedStringNode(0...26)(
+  StatementsNode(0...8)(
+    [InterpolatedStringNode(0...8)(
        (0...8),
        [StringNode(9...22)(nil, (9...22), nil, "baz\\\n" + "qux\n")],
        (22...26)

--- a/test/snapshots/whitequark/heredoc.txt
+++ b/test/snapshots/whitequark/heredoc.txt
@@ -1,17 +1,17 @@
-ProgramNode(0...66)(
+ProgramNode(0...52)(
   [],
-  StatementsNode(0...66)(
-    [InterpolatedStringNode(0...22)(
+  StatementsNode(0...52)(
+    [InterpolatedStringNode(0...8)(
        (0...8),
        [StringNode(9...17)(nil, (9...17), nil, "foo\n" + "bar\n")],
        (17...22)
      ),
-     InterpolatedStringNode(23...43)(
+     InterpolatedStringNode(23...29)(
        (23...29),
        [StringNode(30...38)(nil, (30...38), nil, "foo\n" + "bar\n")],
        (38...43)
      ),
-     InterpolatedXStringNode(44...66)(
+     InterpolatedXStringNode(44...52)(
        (44...52),
        [StringNode(53...61)(nil, (53...61), nil, "foo\n" + "bar\n")],
        (61...66)

--- a/test/snapshots/whitequark/interp_digit_var.txt
+++ b/test/snapshots/whitequark/interp_digit_var.txt
@@ -1,6 +1,6 @@
-ProgramNode(1...444)(
+ProgramNode(1...433)(
   [],
-  StatementsNode(1...444)(
+  StatementsNode(1...433)(
     [StringNode(1...6)((1...2), (2...5), (5...6), "\#@1"),
      StringNode(9...15)((9...10), (10...14), (14...15), "\#@@1"),
      ArrayNode(18...25)(
@@ -89,32 +89,32 @@ ProgramNode(1...444)(
      SymbolNode(296...303)((296...298), (298...302), (302...303), "\#@@1"),
      XStringNode(306...311)((306...307), (307...310), (310...311), "\#@1"),
      XStringNode(314...320)((314...315), (315...319), (319...320), "\#@@1"),
-     InterpolatedStringNode(322...341)(
+     InterpolatedStringNode(322...331)(
        (322...331),
        [StringNode(332...336)(nil, (332...336), nil, "\#@1\n")],
        (336...341)
      ),
-     InterpolatedStringNode(342...362)(
+     InterpolatedStringNode(342...351)(
        (342...351),
        [StringNode(352...357)(nil, (352...357), nil, "\#@@1\n")],
        (357...362)
      ),
-     InterpolatedStringNode(363...382)(
+     InterpolatedStringNode(363...372)(
        (363...372),
        [StringNode(373...377)(nil, (373...377), nil, "\#@1\n")],
        (377...382)
      ),
-     InterpolatedStringNode(383...403)(
+     InterpolatedStringNode(383...392)(
        (383...392),
        [StringNode(393...398)(nil, (393...398), nil, "\#@@1\n")],
        (398...403)
      ),
-     InterpolatedXStringNode(404...423)(
+     InterpolatedXStringNode(404...413)(
        (404...413),
        [StringNode(414...418)(nil, (414...418), nil, "\#@1\n")],
        (418...423)
      ),
-     InterpolatedXStringNode(424...444)(
+     InterpolatedXStringNode(424...433)(
        (424...433),
        [StringNode(434...439)(nil, (434...439), nil, "\#@@1\n")],
        (439...444)

--- a/test/snapshots/whitequark/parser_bug_640.txt
+++ b/test/snapshots/whitequark/parser_bug_640.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...24)(
+ProgramNode(0...6)(
   [],
-  StatementsNode(0...24)(
-    [InterpolatedStringNode(0...24)(
+  StatementsNode(0...6)(
+    [InterpolatedStringNode(0...6)(
        (0...6),
        [StringNode(7...20)(nil, (7...20), nil, "bazqux\n")],
        (20...24)

--- a/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.txt
+++ b/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.txt
@@ -1,7 +1,7 @@
-ProgramNode(0...19)(
+ProgramNode(0...7)(
   [],
-  StatementsNode(0...19)(
-    [InterpolatedStringNode(0...19)(
+  StatementsNode(0...7)(
+    [InterpolatedStringNode(0...7)(
        (0...7),
        [EmbeddedStatementsNode(10...13)((10...12), nil, (12...13)),
         StringNode(13...14)(nil, (13...14), nil, "\n")],

--- a/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
+++ b/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
@@ -43,17 +43,17 @@ ProgramNode(0...210)(
      ),
      SymbolNode(123...130)(nil, (125...129), nil, "ab"),
      SymbolNode(132...139)((132...134), (134...138), (138...139), "ab"),
-     InterpolatedStringNode(141...161)(
+     InterpolatedStringNode(141...150)(
        (141...150),
        [StringNode(151...156)(nil, (151...156), nil, "ab\n")],
        (156...161)
      ),
-     InterpolatedStringNode(162...182)(
+     InterpolatedStringNode(162...171)(
        (162...171),
        [StringNode(172...177)(nil, (172...177), nil, "a\\\n" + "b\n")],
        (177...182)
      ),
-     InterpolatedXStringNode(183...203)(
+     InterpolatedXStringNode(183...192)(
        (183...192),
        [StringNode(193...198)(nil, (193...198), nil, "ab\n")],
        (198...203)

--- a/test/snapshots/whitequark/ruby_bug_11989.txt
+++ b/test/snapshots/whitequark/ruby_bug_11989.txt
@@ -1,13 +1,13 @@
-ProgramNode(0...21)(
+ProgramNode(0...8)(
   [],
-  StatementsNode(0...21)(
-    [CallNode(0...21)(
+  StatementsNode(0...8)(
+    [CallNode(0...8)(
        nil,
        nil,
        (0...1),
        nil,
-       ArgumentsNode(2...21)(
-         [InterpolatedStringNode(2...21)(
+       ArgumentsNode(2...8)(
+         [InterpolatedStringNode(2...8)(
             (2...8),
             [StringNode(9...19)(nil, (9...19), nil, "x\n" + "   y\n")],
             (19...21)

--- a/test/snapshots/whitequark/ruby_bug_11990.txt
+++ b/test/snapshots/whitequark/ruby_bug_11990.txt
@@ -8,7 +8,7 @@ ProgramNode(0...12)(
        nil,
        ArgumentsNode(2...12)(
          [StringConcatNode(2...12)(
-            InterpolatedStringNode(2...19)(
+            InterpolatedStringNode(2...6)(
               (2...6),
               [StringNode(13...17)(nil, (13...17), nil, "x\n")],
               (17...19)

--- a/test/snapshots/whitequark/slash_newline_in_heredocs.txt
+++ b/test/snapshots/whitequark/slash_newline_in_heredocs.txt
@@ -1,12 +1,12 @@
-ProgramNode(0...56)(
+ProgramNode(0...33)(
   [],
-  StatementsNode(0...56)(
-    [InterpolatedStringNode(0...27)(
+  StatementsNode(0...33)(
+    [InterpolatedStringNode(0...4)(
        (0...4),
        [StringNode(5...25)(nil, (5...25), nil, "    1     2\n" + "    3\n")],
        (25...27)
      ),
-     InterpolatedStringNode(29...56)(
+     InterpolatedStringNode(29...33)(
        (29...33),
        [StringNode(34...54)(nil, (34...54), nil, "1 2\n" + "3\n")],
        (54...56)


### PR DESCRIPTION
Currently, heredocs throw off the location information of all of their parent nodes all of the way up the tree. This can be very confusing for consumers, as it doesn't make sense why their call node is however many lines long when it's just `foo.bar(<<~HERE)`.

This changes the location information of heredocs to reflect only their declarations. As such, all of the parent nodes have more accurate location information.

To ensure we have accurate location information and that we never overlap parent/child locations, I've added Jemma's parse-test branch location tests.

This also fixes a bug where interpolated string nodes could have incorrect start locations if they had missing openings.

Fixes #892.