### PR TITLE
Omit locals test if running on a 32 bit machine

### DIFF
--- a/test/locals_test.rb
+++ b/test/locals_test.rb
@@ -9,6 +9,10 @@
 # to test on the most recent versions.
 return if !defined?(RubyVM::InstructionSequence) || RUBY_VERSION < "3.2"
 
+# Omit tests if running on a 32-bit machine because there is a bug with how
+# Ruby is handling large ISeqs on 32-bit machines
+return if RUBY_PLATFORM =~ /i686/
+
 require "yarp_test_helper"
 
 class LocalsTest < Test::Unit::TestCase


### PR DESCRIPTION
See the crash https://github.com/ruby/ruby/actions/runs/5871605132/job/15921373210?pr=8226. We can further investigate why reading these iseqs is causing crashes on 32 bit machines. But since it looks like a Ruby bug, and not a YARP bug, we'd rather proceed with the sync now. We can then make the fix on the Ruby side (while the syncing resumes as normal).