### PR TITLE
update `memsize` with new types

### DIFF
--- a/bin/memsize
+++ b/bin/memsize
@@ -10,14 +10,16 @@ results =
       node["name"],
       node.fetch("child_nodes", []).sum do |child_node|
         case child_node["type"]
-        when "integer"
+        when "uint32", "constant"
           4
         when "node", "node?"
           8
         when "location", "location?"
           16
-        when "node[]", "string", "token", "token?", "location[]"
+        when "node[]", "string", "token", "token?", "location[]", "constant[]"
           24
+        when "flags"
+          0
         else
           raise "Unknown type: #{child_node["type"]}"
         end


### PR DESCRIPTION
When trying to run `bin/memsize` on a newly-built tree from `HEAD`, I encountered the error:

```
Traceback (most recent call last):
	4: from bin/memsize:8:in `<main>'
	3: from bin/memsize:8:in `map'
	2: from bin/memsize:11:in `block in <main>'
	1: from bin/memsize:11:in `sum'
bin/memsize:22:in `block (2 levels) in <main>': Unknown type: constant[] (RuntimeError)
```

This PR fixes things up so that `bin/memsize` runs properly.  IIUC, `flags` shouldn't be counted, since I think it's accounted for in other ways, but let me know if that's not the case.