### PR TITLE
improve fuzzing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ fuzz-docker-build: fuzz/docker/Dockerfile
 	$(Q) docker build -t yarp/fuzz fuzz/docker/
 
 fuzz-run-%: FORCE fuzz-docker-build
+	$(ECHO) "generating templates"
+	$(Q) bundle exec rake templates
 	$(ECHO) "running $* fuzzer"
 	$(Q) docker run --rm -v $(shell pwd):/yarp yarp/fuzz /bin/bash -c "FUZZ_FLAGS=\"$(FUZZ_FLAGS)\" make build/fuzz.$*"
 	$(ECHO) "starting AFL++ run"

--- a/fuzz/tools/minimize.sh
+++ b/fuzz/tools/minimize.sh
@@ -12,7 +12,5 @@ executable=/yarp/build/fuzz."$(basename $(dirname $(dirname $DIR)))"
 for file in $(find "$DIR" -type f ! -name "*.*")
 do
   echo "Minimizing $file: this may take a long time"
-  AFL_TMIN_EXACT=1 afl-tmin "$flags" -i "$file" -o "$file".min -- "$executable"
+  AFL_TMIN_EXACT=1 afl-tmin $flags -i "$file" -o "${file}.min" -- "$executable"
 done
-
-


### PR DESCRIPTION
- ensure header files are generated for compilation in the container
- don't quote the flags passed to afl-tmin (empty flags end up being an empty string which confuses afl-tmin) in the minimization step