### PR TITLE
Use _snprintf when using Windows versions prior to 2015 (< 1900)

### DIFF
--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -34,6 +34,11 @@
 #   define inline __inline
 #endif
 
+// Windows versions before 2015 use _snprintf
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#   define snprintf _snprintf
+#endif
+
 int yp_strncasecmp(const char *string1, const char *string2, size_t length);
 
 #endif


### PR DESCRIPTION
Ruby CI has informed us that snprintf is not available on Windows versions, but _sprintf is supported. This commit allows us to use _sprintf where applicable.