### PR TITLE
fix: endless ranges in conditional expressions

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -459,8 +459,12 @@ yp_flip_flop(yp_node_t *node) {
         }
         case YP_NODE_RANGE_NODE: {
             yp_range_node_t *cast = (yp_range_node_t *) node;
-            yp_flip_flop(cast->left);
-            yp_flip_flop(cast->right);
+            if (cast->left) {
+                yp_flip_flop(cast->left);
+            }
+            if (cast->right) {
+                yp_flip_flop(cast->right);
+            }
 
             // Here we change the range node into a flip flop node. We can do
             // this since the nodes are exactly the same except for the type.

--- a/test/fixtures/endless_range_in_conditional.txt
+++ b/test/fixtures/endless_range_in_conditional.txt
@@ -1,0 +1,3 @@
+if 1..2 ; end
+if ..1 ; end
+if 1.. ; end

--- a/test/snapshots/endless_range_in_conditional.txt
+++ b/test/snapshots/endless_range_in_conditional.txt
@@ -1,0 +1,31 @@
+ProgramNode(0...39)(
+  [],
+  StatementsNode(0...39)(
+    [IfNode(0...13)(
+       (0...2),
+       FlipFlopNode(3...7)(
+         IntegerNode(3...4)(),
+         IntegerNode(6...7)(),
+         (4...6),
+         0
+       ),
+       nil,
+       nil,
+       (10...13)
+     ),
+     IfNode(14...26)(
+       (14...16),
+       FlipFlopNode(17...20)(nil, IntegerNode(19...20)(), (17...19), 0),
+       nil,
+       nil,
+       (23...26)
+     ),
+     IfNode(27...39)(
+       (27...29),
+       FlipFlopNode(30...33)(IntegerNode(30...31)(), nil, (31...33), 0),
+       nil,
+       nil,
+       (36...39)
+     )]
+  )
+)


### PR DESCRIPTION
yp_flip_flop should only recurse on range endpoints if they exist.

Previously, parsing code like `if ..2` would segfault. This bug was found with the fuzzer.