### PR TITLE
preallocate arrays when building the Ruby AST

### DIFF
--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -146,14 +146,14 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     <%- when NodeParam, OptionalNodeParam -%>
                     argv[<%= index %>] = rb_ary_pop(value_stack);
                     <%- when NodeListParam -%>
-                    argv[<%= index %>] = rb_ary_new();
+                    argv[<%= index %>] = rb_ary_new_capa(cast-><%= param.name %>.size);
                     for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
                         rb_ary_push(argv[<%= index %>], rb_ary_pop(value_stack));
                     }
                     <%- when StringParam -%>
                     argv[<%= index %>] = yp_string_new(&cast-><%= param.name %>, encoding);
                     <%- when LocationListParam -%>
-                    argv[<%= index %>] = rb_ary_new();
+                    argv[<%= index %>] = rb_ary_new_capa(cast-><%= param.name %>.size);
                     for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
                         yp_location_t location = cast-><%= param.name %>.locations[index];
                         rb_ary_push(argv[<%= index %>], yp_location_new(parser, location.start, location.end, source));
@@ -161,7 +161,7 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     <%- when ConstantParam -%>
                     argv[<%= index %>] = rb_id2sym(constants[cast-><%= param.name %> - 1]);
                     <%- when ConstantListParam -%>
-                    argv[<%= index %>] = rb_ary_new();
+                    argv[<%= index %>] = rb_ary_new_capa(cast-><%= param.name %>.size);
                     for (size_t index = 0; index < cast-><%= param.name %>.size; index++) {
                         rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= param.name %>.ids[index] - 1]));
                     }


### PR DESCRIPTION
This change is good for a ~10% performance improvement in the unscientific benchmark of:

```ruby
files.each do |f|
  YARP.parse_file(f)
end
```

where `files` is all the Ruby files in a large codebase.