### PR TITLE
Keep the line endings for *.txt as they are committed in the repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,9 @@ test/fixtures/unparser/**/*.txt linguist-vendored
 test/fixtures/whitequark/**/*.txt linguist-vendored
 test/snapshots/**/*.txt linguist-generated
 
-# Preserve \n on git clone on Windows, regardless of the git config core.autocrlf value
+# All .rb files should have LF line ending, even on Windows, regardless of the git config core.autocrlf value.
+# All .txt should have their line endings as committed in the repository (there are some intentional CR in there),
+# regardless of the git config core.autocrlf value.
 # See https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
 **/*.rb text eol=lf
-**/*.txt text eol=lf
+**/*.txt -text


### PR DESCRIPTION
Fixes the issue reported in https://github.com/ruby/yarp/pull/1270