### PR TITLE
Prepare for rendering templates in ruby/ruby

### DIFF
--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -40,12 +40,12 @@ module YARP
 
     # def child_nodes: () -> Array[nil | Node]
     def child_nodes
-      [<%= node.params.filter_map { |param|
+      [<%= node.params.map { |param|
         case param
         when SingleNodeParam then param.name
         when NodeListParam then "*#{param.name}"
         end
-      }.join(", ") %>]
+      }.compact.join(", ") %>]
     end
 
     # def deconstruct: () -> Array[nil | Node]
@@ -74,7 +74,7 @@ module YARP
       <%= param.name %>&.slice
     end
     <%- when FlagsParam -%>
-    <%- flags.find { |flag| flag.name == param.kind }.tap { raise "Expected to find #{param.kind}" unless _1 }.values.each do |value| -%>
+    <%- flags.find { |flag| flag.name == param.kind }.tap { |flag| raise "Expected to find #{param.kind}" unless flag }.values.each do |value| -%>
 
     # def <%= value.name.downcase %>?: () -> bool
     def <%= value.name.downcase %>?

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -257,7 +257,11 @@ def template(name, locals)
   template = File.expand_path("../#{filepath}", __dir__)
   write_to = File.expand_path("../#{name}", __dir__)
 
-  erb = ERB.new(File.read(template), trim_mode: "-")
+  if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+    erb = ERB.new(File.read(template), trim_mode: "-")
+  else
+    erb = ERB.new(File.read(template), nil, "-")
+  end
   erb.filename = template
 
   non_ruby_heading = <<~HEADING
@@ -316,5 +320,6 @@ TEMPLATES = [
 ]
 
 if __FILE__ == $0
-  TEMPLATES.each { |f| template f, locals }
+  templates = ARGV.empty? ? TEMPLATES : ARGV
+  templates.each { |f| template f, locals }
 end

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -320,6 +320,10 @@ TEMPLATES = [
 ]
 
 if __FILE__ == $0
-  templates = ARGV.empty? ? TEMPLATES : ARGV
-  templates.each { |f| template f, locals }
+  if ARGV.empty?
+    TEMPLATES.each { |f| template(f, locals) }
+  else
+    name, write_to = ARGV
+    template(name, locals, write_to: write_to)
+  end
 end


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/8228 will render templates in the ruby/ruby's build process. For that, this PR adds a couple of changes:

* Let `templates/template.rb` take an optional `ARGV` to specify rendering targets individually
* Support Ruby 2.5 ([baseruby](https://github.com/ruby/ruby/blob/4e881ee6b6a55c9fc154d535b268a431e26f1b7c/configure.ac#L78-L79)) to run `templates/template.rb`
    * We should have CI for baseruby compatibility in this repository as well, but I'd like to fix the sync script asap and deal with it in a later PR. At least we could notice it when we sync changes.