### PR TITLE
fix: unterminated % in arguments

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6494,13 +6494,11 @@ parser_lex(yp_parser_t *parser) {
 
                 // % %= %i %I %q %Q %w %W
                 case '%': {
-                    // In a BEG state, if you encounter a % then you must be
-                    // starting something. In this case if there is no
-                    // subsequent character then we have an invalid token. We're
-                    // going to say it's the percent operator because we don't
-                    // want to move into the string lex mode unnecessarily.
-                    if (lex_state_beg_p(parser) && (parser->current.end >= parser->end)) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "unexpected end of input");
+                    // If there is no subsequent character then we have an invalid token. We're
+                    // going to say it's the percent operator because we don't want to move into the
+                    // string lex mode unnecessarily.
+                    if ((lex_state_beg_p(parser) || lex_state_arg_p(parser)) && (parser->current.end >= parser->end)) {
+                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected end of input");
                         LEX(YP_TOKEN_PERCENT);
                     }
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -155,6 +155,13 @@ class ErrorsTest < Test::Unit::TestCase
     ]
   end
 
+  def test_unterminated_argument_expression
+    assert_errors expression('a %'), 'a %', [
+      ["Unexpected end of input", 2..3],
+      ["Expected a value after the operator.", 3..3],
+    ]
+  end
+
   def test_1_2_3
     assert_errors expression("(1, 2, 3)"), "(1, 2, 3)", [
       ["Expected to be able to parse an expression.", 2..2],


### PR DESCRIPTION
The problem being addressed here:

```
>> YARP.parse('a %')
irb: src/yarp.c:5594: parser_lex: Assertion `parser->current.end <= parser->end' failed.
Aborted (core dumped)
```

Bug found via the fuzzer.