### PR TITLE
Add a convenience value method for numeric literals

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -313,6 +313,30 @@ module YARP
     end
   end
 
+  class FloatNode < Node
+    def value
+      Float(slice)
+    end
+  end
+
+  class ImaginaryNode < Node
+    def value
+      Complex(0, numeric.slice)
+    end
+  end
+
+  class IntegerNode < Node
+    def value
+      Integer(slice)
+    end
+  end
+
+  class RationalNode < Node
+    def value
+      Rational(numeric.slice)
+    end
+  end
+
   # Load the serialized AST using the source as a reference into a tree.
   def self.load(source, serialized)
     Serialize.load(source, serialized)


### PR DESCRIPTION
From https://github.com/ruby/yarp/issues/1098#issuecomment-1613821135

For instance this is necessary for https://github.com/ruby/yarp/issues/1237#issuecomment-1684896663