### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -73,7 +73,7 @@ The header is structured like the following table:
 | varint | content pool size |
 
 After the header comes the body of the serialized string.
-The body consistents of a sequence of nodes that is built using a prefix traversal order of the syntax tree.
+The body consists of a sequence of nodes that is built using a prefix traversal order of the syntax tree.
 Each node is structured like the following table:
 
 | # bytes | field |

--- a/rust/yarp-sys/README.md
+++ b/rust/yarp-sys/README.md
@@ -17,7 +17,7 @@ doing `cargo doc --open`!)
 
 ### Dependencies
 
-In addition to the Ruby YARP depedencies, you shouldn't need anything else besides Rust.
+In addition to the Ruby YARP dependencies, you shouldn't need anything else besides Rust.
 
 ### Updating bindings
 


### PR DESCRIPTION
I found two typos while reading through the docs and thought I'd open a pull request to fix them 🙌🏼 