### PR TITLE
[rust] add an `as_byte_slice` method to `Location`

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -410,15 +410,23 @@ impl<'pr> Location<'pr> {{
     pub fn end(&self) -> *const c_char {{
         unsafe {{ self.pointer.as_ref().end }}
     }}
+
+    /// Returns a byte slice for the range.
+    #[must_use]
+    pub fn as_byte_slice(&self) -> &'pr [u8] {{
+        let start: *mut u8 = self.start() as *mut u8;
+        let end: *mut u8 = self.end() as *mut u8;
+
+        unsafe {{
+          let len = usize::try_from(end.offset_from(start)).expect("end should point to memory after start");
+          std::slice::from_raw_parts(start, len)
+        }}
+    }}
 }}
 
 impl std::fmt::Debug for Location<'_> {{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
-        let start: *mut u8 = unsafe {{ self.pointer.as_ref().start as *mut u8 }};
-        let end: *mut u8 = unsafe {{ self.pointer.as_ref().end as *mut u8 }};
-
-        let len = end as usize - start as usize;
-        let slice: &[u8] = unsafe {{ std::slice::from_raw_parts(start, len) }};
+        let slice: &[u8] = self.as_byte_slice();
 
         let mut visible = String::new();
         visible.push('"');

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -251,6 +251,10 @@ mod tests {
         let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();
 
         assert_eq!(slice, "222");
+
+        let slice = std::str::from_utf8(location.as_byte_slice()).unwrap();
+
+        assert_eq!(slice, "222");
     }
 
     #[test]


### PR DESCRIPTION
This new function is slightly redundant with `ParseResult::as_slice`, but the new function is consistent with `Comment::text`.  And like `Comment::text`, `Location::as_byte_slice` is more useful when you are writing visitors and what to examine some of the source text of a node (my motivating example was examining the opening delimiter of `InterpolatedStringNode` for determining heredocs).

Open to changing the name for consistency with `ParseResult::as_slice` or `str::as_bytes`.