### PR TITLE
All bin/ scripts which take filepaths default to "test.rb"

### DIFF
--- a/bin/lex
+++ b/bin/lex
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 # Usage:
+#   bin/lex # defaults to test.rb
 #   bin/lex <filename>
 #   bin/lex -e "<source-code>"
 
@@ -12,7 +13,7 @@ require "yarp"
 if ARGV[0] == "-e"
   source = ARGV[1]
 else
-  filepath = ARGV.first
+  filepath = ARGV.first || "test.rb"
   source = File.read(filepath)
 end
 

--- a/bin/locals
+++ b/bin/locals
@@ -4,7 +4,7 @@
 $:.unshift(File.expand_path("../lib", __dir__))
 require "yarp"
 
-source = ARGV[0] == "-e" ? ARGV[1] : File.read(ARGV[0])
+source = ARGV[0] == "-e" ? ARGV[1] : File.read(ARGV[0] || "test.rb")
 
 puts "CRuby:"
 p YARP.const_get(:Debug).cruby_locals(source)

--- a/bin/parse
+++ b/bin/parse
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 # Usage:
+#   bin/parse # defaults to test.rb
 #   bin/parse <filename>
 #   bin/parse -e "<source-code>"
 
@@ -11,7 +12,7 @@ require "yarp"
 if ARGV[0] == "-e"
   result = YARP.parse(ARGV[1])
 else
-  result = YARP.parse_file(ARGV[0])
+  result = YARP.parse_file(ARGV[0] || "test.rb")
 end
 
 result.mark_newlines if ENV['MARK_NEWLINES']


### PR DESCRIPTION
For instance, if you don't pass any args to bin/parse, it will now default to "bin/parse test.rb" This commit applies this change to bin/lex, bin/locals and bin/parse