### PR TITLE
ClassNodes and ModuleNodes now always have ConstantPathNode children

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -723,6 +723,7 @@ nodes:
         type: location
       - name: constant_path
         type: node
+        kind: ConstantPathNode
       - name: inheritance_operator_loc
         type: location?
       - name: superclass
@@ -760,7 +761,7 @@ nodes:
       - name: parent
         type: node?
       - name: child
-        type: node
+        type: node?
       - name: delimiter_loc
         type: location
     comment: |
@@ -1314,6 +1315,7 @@ nodes:
         type: location
       - name: constant_path
         type: node
+        kind: ConstantPathNode
       - name: body
         type: node?
       - name: end_keyword_loc

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1493,7 +1493,7 @@ yp_constant_path_node_create(yp_parser_t *parser, yp_node_t *parent, const yp_to
             .type = YP_NODE_CONSTANT_PATH_NODE,
             .location = {
                 .start = parent == NULL ? delimiter->start : parent->location.start,
-                .end = child == NULL ? parent->location.end : child->location.end
+                .end = child == NULL ? (parent == NULL ? delimiter->end : parent->location.end) : child->location.end
             },
         },
         .parent = parent,
@@ -1510,7 +1510,10 @@ yp_constant_path_node_from_path_or_read_node(yp_parser_t *parser, yp_node_t *nod
         return (yp_constant_path_node_t *)node;
     }
 
-    assert(node->type == YP_NODE_CONSTANT_READ_NODE || node->type == YP_NODE_MISSING_NODE);
+    if (node->type != YP_NODE_CONSTANT_READ_NODE && node->type != YP_NODE_MISSING_NODE) {
+        yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Not a valid class or module name");
+        return yp_constant_path_node_create(parser, NULL, &parser->current, NULL);
+    }
 
     return yp_constant_path_node_create(parser, node, &parser->current, NULL);
 }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -16,9 +16,9 @@ class ErrorsTest < Test::Unit::TestCase
     expected = ModuleNode(
       [],
       Location(),
-      ConstantReadNode(),
+      ConstantPathNode(ConstantReadNode(), nil, Location()),
       StatementsNode(
-        [ModuleNode([], Location(), MissingNode(), nil, Location())]
+        [ModuleNode([], Location(), ConstantPathNode(MissingNode(), nil, Location()), nil, Location())]
       ),
       Location()
     )
@@ -383,7 +383,12 @@ class ErrorsTest < Test::Unit::TestCase
       Location(),
       nil,
       nil,
-      StatementsNode([ModuleNode([], Location(), ConstantReadNode(), nil, Location())]),
+      StatementsNode([ModuleNode(
+        [],
+        Location(),
+        ConstantPathNode(ConstantReadNode(), nil, Location()),
+        nil,
+        Location())]),
       [],
       Location(),
       nil,
@@ -414,7 +419,11 @@ class ErrorsTest < Test::Unit::TestCase
            BlockNode(
              [],
              nil,
-             StatementsNode([ModuleNode([], Location(), ConstantReadNode(), nil, Location())]),
+             StatementsNode([ModuleNode([], Location(), ConstantPathNode(
+               ConstantReadNode(),
+               nil,
+               Location()
+             ), nil, Location())]),
              Location(),
              Location()
            ),
@@ -451,7 +460,7 @@ class ErrorsTest < Test::Unit::TestCase
         [ClassNode(
            [],
            Location(),
-           ConstantReadNode(),
+           ConstantPathNode(ConstantReadNode(), nil, Location()),
            nil,
            nil,
            nil,
@@ -951,7 +960,7 @@ class ErrorsTest < Test::Unit::TestCase
     expected = ClassNode(
       [],
       Location(),
-      ConstantReadNode(),
+      ConstantPathNode(ConstantReadNode(), nil, Location()),
       nil,
       nil,
       StatementsNode([ReturnNode(Location(), nil)]),
@@ -967,7 +976,7 @@ class ErrorsTest < Test::Unit::TestCase
     expected = ModuleNode(
       [],
       Location(),
-      ConstantReadNode(),
+      ConstantPathNode(ConstantReadNode(), nil, Location()),
       StatementsNode([ReturnNode(Location(), nil)]),
       Location()
     )

--- a/test/snapshots/classes.txt
+++ b/test/snapshots/classes.txt
@@ -4,7 +4,7 @@ ProgramNode(0...370)(
     [ClassNode(0...17)(
        [:a],
        (0...5),
-       ConstantReadNode(6...7)(),
+       ConstantPathNode(6...7)(ConstantReadNode(6...7)(), nil, (17...18)),
        nil,
        nil,
        StatementsNode(8...13)(
@@ -21,7 +21,7 @@ ProgramNode(0...370)(
      ClassNode(19...39)(
        [],
        (19...24),
-       ConstantReadNode(25...26)(),
+       ConstantPathNode(25...26)(ConstantReadNode(25...26)(), nil, (39...40)),
        nil,
        nil,
        BeginNode(28...39)(
@@ -37,7 +37,7 @@ ProgramNode(0...370)(
      ClassNode(41...75)(
        [],
        (41...46),
-       ConstantReadNode(47...48)(),
+       ConstantPathNode(47...48)(ConstantReadNode(47...48)(), nil, (75...76)),
        nil,
        nil,
        BeginNode(50...75)(
@@ -53,7 +53,7 @@ ProgramNode(0...370)(
      ClassNode(77...98)(
        [:a],
        (77...82),
-       ConstantReadNode(83...84)(),
+       ConstantPathNode(83...84)(ConstantReadNode(83...84)(), nil, (98...99)),
        (85...86),
        ConstantReadNode(87...88)(),
        StatementsNode(89...94)(
@@ -98,7 +98,11 @@ ProgramNode(0...370)(
      ClassNode(122...162)(
        [],
        (122...127),
-       ConstantReadNode(128...129)(),
+       ConstantPathNode(128...129)(
+         ConstantReadNode(128...129)(),
+         nil,
+         (162...163)
+       ),
        nil,
        nil,
        StatementsNode(131...157)(
@@ -123,7 +127,11 @@ ProgramNode(0...370)(
      ClassNode(164...218)(
        [],
        (164...169),
-       ConstantReadNode(170...171)(),
+       ConstantPathNode(170...171)(
+         ConstantReadNode(170...171)(),
+         nil,
+         (218...219)
+       ),
        nil,
        nil,
        StatementsNode(173...213)(
@@ -260,7 +268,11 @@ ProgramNode(0...370)(
      ClassNode(352...370)(
        [],
        (352...357),
-       ConstantReadNode(358...359)(),
+       ConstantPathNode(358...359)(
+         ConstantReadNode(358...359)(),
+         nil,
+         (370...371)
+       ),
        (360...361),
        CallNode(362...366)(
          ConstantReadNode(362...363)(),

--- a/test/snapshots/method_calls.txt
+++ b/test/snapshots/method_calls.txt
@@ -1175,7 +1175,11 @@ ProgramNode(0...1237)(
          [ClassNode(905...929)(
             [],
             (905...910),
-            ConstantReadNode(911...914)(),
+            ConstantPathNode(911...914)(
+              ConstantReadNode(911...914)(),
+              nil,
+              (929...930)
+            ),
             nil,
             nil,
             StatementsNode(915...925)(
@@ -1208,7 +1212,11 @@ ProgramNode(0...1237)(
          [ModuleNode(935...960)(
             [],
             (935...941),
-            ConstantReadNode(942...945)(),
+            ConstantPathNode(942...945)(
+              ConstantReadNode(942...945)(),
+              nil,
+              (960...961)
+            ),
             StatementsNode(946...956)(
               [CallNode(946...956)(
                  nil,

--- a/test/snapshots/modules.txt
+++ b/test/snapshots/modules.txt
@@ -4,7 +4,7 @@ ProgramNode(0...140)(
     [ModuleNode(0...18)(
        [:a],
        (0...6),
-       ConstantReadNode(7...8)(),
+       ConstantPathNode(7...8)(ConstantReadNode(7...8)(), nil, (18...19)),
        StatementsNode(9...14)(
          [LocalVariableWriteNode(9...14)(
             :a,
@@ -53,7 +53,7 @@ ProgramNode(0...140)(
      ModuleNode(57...85)(
        [:x],
        (57...63),
-       ConstantReadNode(64...65)(),
+       ConstantPathNode(64...65)(ConstantReadNode(64...65)(), nil, (85...86)),
        BeginNode(67...85)(
          nil,
          StatementsNode(67...72)(

--- a/test/snapshots/seattlerb/TestRubyParserShared.txt
+++ b/test/snapshots/seattlerb/TestRubyParserShared.txt
@@ -45,7 +45,11 @@ ProgramNode(0...689)(
      ClassNode(141...269)(
        [],
        (141...146),
-       ConstantReadNode(147...148)(),
+       ConstantPathNode(147...148)(
+         ConstantReadNode(147...148)(),
+         nil,
+         (282...291)
+       ),
        nil,
        nil,
        StatementsNode(168...246)(
@@ -91,14 +95,22 @@ ProgramNode(0...689)(
      ClassNode(293...376)(
        [],
        (293...298),
-       ConstantReadNode(299...300)(),
+       ConstantPathNode(299...300)(
+         ConstantReadNode(299...300)(),
+         nil,
+         (384...393)
+       ),
        nil,
        nil,
        StatementsNode(315...358)(
          [ClassNode(315...358)(
             [],
             (315...320),
-            ConstantReadNode(321...322)(),
+            ConstantPathNode(321...322)(
+              ConstantReadNode(321...322)(),
+              nil,
+              (364...373)
+            ),
             nil,
             nil,
             StatementsNode(337...343)(
@@ -116,7 +128,11 @@ ProgramNode(0...689)(
      ClassNode(395...498)(
        [],
        (395...400),
-       ConstantReadNode(401...402)(),
+       ConstantPathNode(401...402)(
+         ConstantReadNode(401...402)(),
+         nil,
+         (506...515)
+       ),
        nil,
        nil,
        StatementsNode(417...480)(
@@ -162,7 +178,11 @@ ProgramNode(0...689)(
      ModuleNode(517...565)(
        [],
        (517...523),
-       ConstantReadNode(524...525)(),
+       ConstantPathNode(524...525)(
+         ConstantReadNode(524...525)(),
+         nil,
+         (565...566)
+       ),
        StatementsNode(528...561)(
          [ConstantWriteNode(528...561)(
             (528...529),
@@ -180,12 +200,20 @@ ProgramNode(0...689)(
      ModuleNode(568...651)(
        [],
        (568...574),
-       ConstantReadNode(575...576)(),
+       ConstantPathNode(575...576)(
+         ConstantReadNode(575...576)(),
+         nil,
+         (659...668)
+       ),
        StatementsNode(590...633)(
          [ModuleNode(590...633)(
             [],
             (590...596),
-            ConstantReadNode(597...598)(),
+            ConstantPathNode(597...598)(
+              ConstantReadNode(597...598)(),
+              nil,
+              (639...648)
+            ),
             StatementsNode(612...618)(
               [ConstantWriteNode(612...618)(
                  (612...613),

--- a/test/snapshots/seattlerb/class_comments.txt
+++ b/test/snapshots/seattlerb/class_comments.txt
@@ -4,7 +4,7 @@ ProgramNode(19...71)(
     [ClassNode(19...71)(
        [],
        (19...24),
-       ConstantReadNode(25...26)(),
+       ConstantPathNode(25...26)(ConstantReadNode(25...26)(), nil, (71...72)),
        nil,
        nil,
        StatementsNode(40...67)(

--- a/test/snapshots/seattlerb/defn_oneliner_eq2.txt
+++ b/test/snapshots/seattlerb/defn_oneliner_eq2.txt
@@ -4,7 +4,7 @@ ProgramNode(0...28)(
     [ClassNode(0...28)(
        [],
        (0...5),
-       ConstantReadNode(6...7)(),
+       ConstantPathNode(6...7)(ConstantReadNode(6...7)(), nil, (28...29)),
        nil,
        nil,
        StatementsNode(10...24)(

--- a/test/snapshots/seattlerb/defs_oneliner_eq2.txt
+++ b/test/snapshots/seattlerb/defs_oneliner_eq2.txt
@@ -4,7 +4,7 @@ ProgramNode(0...33)(
     [ClassNode(0...33)(
        [],
        (0...5),
-       ConstantReadNode(6...7)(),
+       ConstantPathNode(6...7)(ConstantReadNode(6...7)(), nil, (33...34)),
        nil,
        nil,
        StatementsNode(10...29)(

--- a/test/snapshots/seattlerb/magic_encoding_comment.txt
+++ b/test/snapshots/seattlerb/magic_encoding_comment.txt
@@ -4,7 +4,7 @@ ProgramNode(18...90)(
     [ClassNode(18...90)(
        [],
        (18...23),
-       ConstantReadNode(24...52)(),
+       ConstantPathNode(24...52)(ConstantReadNode(24...52)(), nil, (90...91)),
        nil,
        nil,
        StatementsNode(54...86)(

--- a/test/snapshots/seattlerb/module_comments.txt
+++ b/test/snapshots/seattlerb/module_comments.txt
@@ -4,7 +4,7 @@ ProgramNode(24...77)(
     [ModuleNode(24...77)(
        [],
        (24...30),
-       ConstantReadNode(31...32)(),
+       ConstantPathNode(31...32)(ConstantReadNode(31...32)(), nil, (77...78)),
        StatementsNode(46...73)(
          [DefNode(46...73)(
             (50...54),

--- a/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
+++ b/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
@@ -14,7 +14,7 @@ ProgramNode(0...48)(
      ClassNode(35...48)(
        [],
        (35...40),
-       ConstantReadNode(41...44)(),
+       ConstantPathNode(41...44)(ConstantReadNode(41...44)(), nil, (48...49)),
        nil,
        nil,
        nil,

--- a/test/snapshots/unparser/corpus/literal/class.txt
+++ b/test/snapshots/unparser/corpus/literal/class.txt
@@ -4,7 +4,7 @@ ProgramNode(0...213)(
     [ClassNode(0...11)(
        [],
        (0...5),
-       ConstantReadNode(6...7)(),
+       ConstantPathNode(6...7)(ConstantReadNode(6...7)(), nil, (11...12)),
        nil,
        nil,
        nil,
@@ -61,7 +61,7 @@ ProgramNode(0...213)(
      ClassNode(84...99)(
        [],
        (84...89),
-       ConstantReadNode(90...91)(),
+       ConstantPathNode(90...91)(ConstantReadNode(90...91)(), nil, (99...100)),
        (92...93),
        ConstantReadNode(94...95)(),
        nil,
@@ -70,7 +70,11 @@ ProgramNode(0...213)(
      ClassNode(101...119)(
        [],
        (101...106),
-       ConstantReadNode(107...108)(),
+       ConstantPathNode(107...108)(
+         ConstantReadNode(107...108)(),
+         nil,
+         (119...120)
+       ),
        (109...110),
        ConstantPathNode(111...115)(
          ConstantReadNode(111...112)(),
@@ -100,7 +104,11 @@ ProgramNode(0...213)(
      ClassNode(144...198)(
        [],
        (144...149),
-       ConstantReadNode(150...151)(),
+       ConstantPathNode(150...151)(
+         ConstantReadNode(150...151)(),
+         nil,
+         (198...199)
+       ),
        nil,
        nil,
        StatementsNode(154...194)(

--- a/test/snapshots/unparser/corpus/literal/if.txt
+++ b/test/snapshots/unparser/corpus/literal/if.txt
@@ -52,7 +52,11 @@ ProgramNode(0...246)(
      ModuleNode(102...133)(
        [:foo],
        (102...108),
-       ConstantReadNode(109...110)(),
+       ConstantPathNode(109...110)(
+         ConstantReadNode(109...110)(),
+         nil,
+         (133...134)
+       ),
        StatementsNode(113...129)(
          [IfNode(113...129)(
             (123...125),
@@ -85,7 +89,11 @@ ProgramNode(0...246)(
      ModuleNode(135...170)(
        [:foo],
        (135...141),
-       ConstantReadNode(142...143)(),
+       ConstantPathNode(142...143)(
+         ConstantReadNode(142...143)(),
+         nil,
+         (170...171)
+       ),
        StatementsNode(146...166)(
          [UnlessNode(146...166)(
             (156...162),

--- a/test/snapshots/unparser/corpus/literal/module.txt
+++ b/test/snapshots/unparser/corpus/literal/module.txt
@@ -1,7 +1,13 @@
 ProgramNode(0...106)(
   [],
   StatementsNode(0...106)(
-    [ModuleNode(0...12)([], (0...6), ConstantReadNode(7...8)(), nil, (9...12)),
+    [ModuleNode(0...12)(
+       [],
+       (0...6),
+       ConstantPathNode(7...8)(ConstantReadNode(7...8)(), nil, (12...13)),
+       nil,
+       (9...12)
+     ),
      ModuleNode(14...29)(
        [],
        (14...20),
@@ -31,7 +37,11 @@ ProgramNode(0...106)(
      ModuleNode(51...106)(
        [],
        (51...57),
-       ConstantReadNode(58...59)(),
+       ConstantPathNode(58...59)(
+         ConstantReadNode(58...59)(),
+         nil,
+         (106...107)
+       ),
        StatementsNode(62...102)(
          [CallNode(62...76)(
             nil,

--- a/test/snapshots/unparser/corpus/literal/send.txt
+++ b/test/snapshots/unparser/corpus/literal/send.txt
@@ -4,7 +4,7 @@ ProgramNode(0...999)(
     [ModuleNode(0...35)(
        [:foo, :a, :_],
        (0...6),
-       ConstantReadNode(7...8)(),
+       ConstantPathNode(7...8)(ConstantReadNode(7...8)(), nil, (35...36)),
        StatementsNode(11...31)(
          [OrWriteNode(11...31)(
             LocalVariableWriteNode(11...14)(:foo, 0, nil, (11...14), nil),
@@ -52,7 +52,7 @@ ProgramNode(0...999)(
      ModuleNode(37...73)(
        [:local],
        (37...43),
-       ConstantReadNode(44...45)(),
+       ConstantPathNode(44...45)(ConstantReadNode(44...45)(), nil, (73...74)),
        StatementsNode(48...69)(
          [LocalVariableWriteNode(48...57)(
             :local,
@@ -79,7 +79,11 @@ ProgramNode(0...999)(
        ClassNode(74...85)(
          [],
          (74...79),
-         ConstantReadNode(80...81)(),
+         ConstantPathNode(80...81)(
+           ConstantReadNode(80...81)(),
+           nil,
+           (85...86)
+         ),
          nil,
          nil,
          nil,
@@ -98,7 +102,11 @@ ProgramNode(0...999)(
        ModuleNode(90...102)(
          [],
          (90...96),
-         ConstantReadNode(97...98)(),
+         ConstantPathNode(97...98)(
+           ConstantReadNode(97...98)(),
+           nil,
+           (102...103)
+         ),
          nil,
          (99...102)
        ),

--- a/test/snapshots/unparser/corpus/literal/while.txt
+++ b/test/snapshots/unparser/corpus/literal/while.txt
@@ -4,7 +4,7 @@ ProgramNode(0...620)(
     [ModuleNode(0...68)(
        [],
        (0...6),
-       ConstantReadNode(7...8)(),
+       ConstantPathNode(7...8)(ConstantReadNode(7...8)(), nil, (68...69)),
        StatementsNode(11...64)(
          [CallNode(11...64)(
             nil,
@@ -127,7 +127,11 @@ ProgramNode(0...620)(
      ModuleNode(112...146)(
        [:foo],
        (112...118),
-       ConstantReadNode(119...120)(),
+       ConstantPathNode(119...120)(
+         ConstantReadNode(119...120)(),
+         nil,
+         (146...147)
+       ),
        StatementsNode(123...142)(
          [WhileNode(123...142)(
             (133...138),
@@ -159,7 +163,11 @@ ProgramNode(0...620)(
      ModuleNode(148...182)(
        [:foo],
        (148...154),
-       ConstantReadNode(155...156)(),
+       ConstantPathNode(155...156)(
+         ConstantReadNode(155...156)(),
+         nil,
+         (182...183)
+       ),
        StatementsNode(159...178)(
          [UntilNode(159...178)(
             (169...174),
@@ -191,7 +199,11 @@ ProgramNode(0...620)(
      ModuleNode(184...228)(
        [:foo],
        (184...190),
-       ConstantReadNode(191...192)(),
+       ConstantPathNode(191...192)(
+         ConstantReadNode(191...192)(),
+         nil,
+         (228...229)
+       ),
        StatementsNode(195...224)(
          [WhileNode(195...224)(
             (195...200),
@@ -233,7 +245,11 @@ ProgramNode(0...620)(
      ModuleNode(230...299)(
        [],
        (230...236),
-       ConstantReadNode(237...238)(),
+       ConstantPathNode(237...238)(
+         ConstantReadNode(237...238)(),
+         nil,
+         (299...300)
+       ),
        StatementsNode(241...295)(
          [CallNode(241...295)(
             nil,
@@ -306,7 +322,11 @@ ProgramNode(0...620)(
      ModuleNode(301...370)(
        [],
        (301...307),
-       ConstantReadNode(308...309)(),
+       ConstantPathNode(308...309)(
+         ConstantReadNode(308...309)(),
+         nil,
+         (370...371)
+       ),
        StatementsNode(312...366)(
          [CallNode(312...366)(
             nil,

--- a/test/snapshots/unparser/corpus/semantic/while.txt
+++ b/test/snapshots/unparser/corpus/semantic/while.txt
@@ -134,7 +134,11 @@ ProgramNode(0...188)(
      ModuleNode(132...188)(
        [:foo],
        (132...138),
-       ConstantReadNode(139...140)(),
+       ConstantPathNode(139...140)(
+         ConstantReadNode(139...140)(),
+         nil,
+         (188...189)
+       ),
        StatementsNode(143...184)(
          [LocalVariableWriteNode(143...152)(
             :foo,

--- a/test/snapshots/while.txt
+++ b/test/snapshots/while.txt
@@ -108,7 +108,11 @@ ProgramNode(0...314)(
        ClassNode(169...198)(
          [:a],
          (169...174),
-         ConstantReadNode(175...178)(),
+         ConstantPathNode(175...178)(
+           ConstantReadNode(175...178)(),
+           nil,
+           (198...199)
+         ),
          nil,
          nil,
          StatementsNode(179...193)(

--- a/test/snapshots/whitequark/class.txt
+++ b/test/snapshots/whitequark/class.txt
@@ -4,7 +4,7 @@ ProgramNode(0...29)(
     [ClassNode(0...13)(
        [],
        (0...5),
-       ConstantReadNode(6...9)(),
+       ConstantPathNode(6...9)(ConstantReadNode(6...9)(), nil, (13...14)),
        nil,
        nil,
        nil,
@@ -13,7 +13,7 @@ ProgramNode(0...29)(
      ClassNode(15...29)(
        [],
        (15...20),
-       ConstantReadNode(21...24)(),
+       ConstantPathNode(21...24)(ConstantReadNode(21...24)(), nil, (29...30)),
        nil,
        nil,
        nil,

--- a/test/snapshots/whitequark/class_definition_in_while_cond.txt
+++ b/test/snapshots/whitequark/class_definition_in_while_cond.txt
@@ -62,7 +62,11 @@ ProgramNode(0...197)(
        ClassNode(110...139)(
          [:a],
          (110...115),
-         ConstantReadNode(116...119)(),
+         ConstantPathNode(116...119)(
+           ConstantReadNode(116...119)(),
+           nil,
+           (139...140)
+         ),
          nil,
          nil,
          StatementsNode(120...134)(
@@ -94,7 +98,11 @@ ProgramNode(0...197)(
        ClassNode(159...185)(
          [],
          (159...164),
-         ConstantReadNode(165...168)(),
+         ConstantPathNode(165...168)(
+           ConstantReadNode(165...168)(),
+           nil,
+           (185...186)
+         ),
          nil,
          nil,
          StatementsNode(170...180)(

--- a/test/snapshots/whitequark/class_super.txt
+++ b/test/snapshots/whitequark/class_super.txt
@@ -4,7 +4,7 @@ ProgramNode(0...20)(
     [ClassNode(0...20)(
        [],
        (0...5),
-       ConstantReadNode(6...9)(),
+       ConstantPathNode(6...9)(ConstantReadNode(6...9)(), nil, (20...21)),
        (10...11),
        ConstantReadNode(12...15)(),
        nil,

--- a/test/snapshots/whitequark/class_super_label.txt
+++ b/test/snapshots/whitequark/class_super_label.txt
@@ -4,7 +4,7 @@ ProgramNode(0...20)(
     [ClassNode(0...20)(
        [],
        (0...5),
-       ConstantReadNode(6...9)(),
+       ConstantPathNode(6...9)(ConstantReadNode(6...9)(), nil, (20...21)),
        (10...11),
        CallNode(12...15)(
          nil,

--- a/test/snapshots/whitequark/module.txt
+++ b/test/snapshots/whitequark/module.txt
@@ -4,7 +4,7 @@ ProgramNode(0...15)(
     [ModuleNode(0...15)(
        [],
        (0...6),
-       ConstantReadNode(7...10)(),
+       ConstantPathNode(7...10)(ConstantReadNode(7...10)(), nil, (15...16)),
        nil,
        (12...15)
      )]

--- a/test/snapshots/whitequark/numparam_outside_block.txt
+++ b/test/snapshots/whitequark/numparam_outside_block.txt
@@ -15,7 +15,7 @@ ProgramNode(0...83)(
      ClassNode(27...43)(
        [],
        (27...32),
-       ConstantReadNode(33...34)(),
+       ConstantPathNode(33...34)(ConstantReadNode(33...34)(), nil, (43...44)),
        nil,
        nil,
        StatementsNode(36...38)(
@@ -41,7 +41,7 @@ ProgramNode(0...83)(
      ModuleNode(66...83)(
        [],
        (66...72),
-       ConstantReadNode(73...74)(),
+       ConstantPathNode(73...74)(ConstantReadNode(73...74)(), nil, (83...84)),
        StatementsNode(76...78)(
          [CallNode(76...78)(nil, nil, (76...78), nil, nil, nil, nil, 2, "_1")]
        ),

--- a/test/snapshots/whitequark/parser_bug_490.txt
+++ b/test/snapshots/whitequark/parser_bug_490.txt
@@ -43,7 +43,11 @@ ProgramNode(0...132)(
               [ClassNode(63...75)(
                  [],
                  (63...68),
-                 ConstantReadNode(69...70)(),
+                 ConstantPathNode(69...70)(
+                   ConstantReadNode(69...70)(),
+                   nil,
+                   (75...76)
+                 ),
                  nil,
                  nil,
                  nil,
@@ -75,7 +79,11 @@ ProgramNode(0...132)(
               [ModuleNode(109...122)(
                  [],
                  (109...115),
-                 ConstantReadNode(116...117)(),
+                 ConstantPathNode(116...117)(
+                   ConstantReadNode(116...117)(),
+                   nil,
+                   (122...123)
+                 ),
                  nil,
                  (119...122)
                )]

--- a/test/snapshots/whitequark/parser_bug_518.txt
+++ b/test/snapshots/whitequark/parser_bug_518.txt
@@ -4,7 +4,7 @@ ProgramNode(0...15)(
     [ClassNode(0...15)(
        [],
        (0...5),
-       ConstantReadNode(6...7)(),
+       ConstantPathNode(6...7)(ConstantReadNode(6...7)(), nil, (15...16)),
        (8...9),
        ConstantReadNode(10...11)(),
        nil,


### PR DESCRIPTION
If a ClassNode has a simple path, like "Foo", it will be represented as a ConstantPathNode with a ConstantReadNode parent, and a nil child. This is so that all ClassNodes and ModuleNodes have consistent path nodes, and not path nodes which could be either ConstantReadNodes or ConstantPathNodes.

This PR simplifies how any consumer of YARP has to handle ClassNodes or ModuleNodes. Before this, the logic for splitting on path / read node had to be _both_ in the ConstantPathNode and in the ClassNode / ModuleNode. This commit minimizes the places where this splitting is duplicated, and makes the compiler (or any consumer of YARP) slightly simpler.