### PR TITLE
Match EOF after newline behavior

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -630,6 +630,14 @@ module YARP
               end
 
             Token.new([[lineno, column], event, value, lex_state])
+
+          when :on_eof
+            prev_token = result_value[index-1][0]
+            if prev_token.type == :COMMENT && prev_token.location.end_offset < token.location.start_offset
+              tokens << Token.new([[lineno, 0], :on_nl, source.byteslice(result_value[index-1].first.location.end_offset...token.location.start_offset), lex_state])
+            end
+
+            Token.new([[lineno, column], event, value, lex_state])
           else
             Token.new([[lineno, column], event, value, lex_state])
           end

--- a/test/fixtures/indented_file_end.txt
+++ b/test/fixtures/indented_file_end.txt
@@ -1,0 +1,4 @@
+    def hi
+    
+    end # hi there
+    

--- a/test/snapshots/indented_file_end.txt
+++ b/test/snapshots/indented_file_end.txt
@@ -1,0 +1,18 @@
+ProgramNode(4...23)(
+  [],
+  StatementsNode(4...23)(
+    [DefNode(4...23)(
+       (8...10),
+       nil,
+       nil,
+       nil,
+       [],
+       (4...7),
+       nil,
+       nil,
+       nil,
+       nil,
+       (20...23)
+     )]
+  )
+)


### PR DESCRIPTION
in Ripper EOL after whitespace is returned as a on_nl node with the whitespace as the content.