### PR TITLE
Add a ScopeNode and a way to create scope nodes from existing nodes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1686,6 +1686,20 @@ nodes:
 
           return 1
           ^^^^^^^^
+  - name: ScopeNode
+    child_nodes:
+      - name: parameters
+        type: node?
+        kind: ParametersNode
+      - name: statements
+        type: node?
+        kind: StatementsNode
+      - name: locals
+        type: constant[]
+    comment: |
+      Used only to retrieve the scope, not an
+      actual semantically meaningful node
+
   - name: SelfNode
     comment: |
       Represents the `self` keyword.

--- a/config.yml
+++ b/config.yml
@@ -1686,20 +1686,6 @@ nodes:
 
           return 1
           ^^^^^^^^
-  - name: ScopeNode
-    child_nodes:
-      - name: parameters
-        type: node?
-        kind: ParametersNode
-      - name: statements
-        type: node?
-        kind: StatementsNode
-      - name: locals
-        type: constant[]
-    comment: |
-      Used only to retrieve the scope, not an
-      actual semantically meaningful node
-
   - name: SelfNode
     comment: |
       Represents the `self` keyword.

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -31,7 +31,7 @@ void yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buf
 void yp_print_node(yp_parser_t *parser, yp_node_t *node);
 
 // Generate a scope node for a DefNode and ClassNode
-void yp_get_scope_node(yp_node_t *node, yp_scope_node_t *dest);
+void yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest);
 
 // The YARP version and the serialization format.
 YP_EXPORTED_FUNCTION const char * yp_version(void);

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -30,6 +30,9 @@ void yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buf
 
 void yp_print_node(yp_parser_t *parser, yp_node_t *node);
 
+// Generate a scope node for a DefNode and ClassNode
+void yp_get_scope_node(yp_node_t *node, yp_scope_node_t *dest);
+
 // The YARP version and the serialization format.
 YP_EXPORTED_FUNCTION const char * yp_version(void);
 

--- a/include/yarp/node.h
+++ b/include/yarp/node.h
@@ -41,6 +41,6 @@ YP_EXPORTED_FUNCTION const char * yp_node_type_to_str(yp_node_type_t node_type);
 typedef struct yp_scope_node {
     yp_node_t base;
     struct yp_parameters_node *parameters;
-    struct yp_statements_node *statements;
+    yp_node_t *body;
     yp_constant_id_list_t locals;
 } yp_scope_node_t;

--- a/include/yarp/node.h
+++ b/include/yarp/node.h
@@ -34,3 +34,13 @@ YP_EXPORTED_FUNCTION const char * yp_node_type_to_str(yp_node_type_t node_type);
 #define YP_EMPTY_LOCATION_LIST ((yp_location_list_t) { .locations = NULL, .size = 0, .capacity = 0 })
 
 #endif // YARP_NODE_H
+
+// ScopeNodes are helper nodes, and will never
+// be part of the AST. We manually declare them
+// here to avoid generating them
+typedef struct yp_scope_node {
+    yp_node_t base;
+    struct yp_parameters_node *parameters;
+    struct yp_statements_node *statements;
+    yp_constant_id_list_t locals;
+} yp_scope_node_t;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1017,7 +1017,7 @@ yp_block_argument_node_create(yp_parser_t *parser, const yp_token_t *operator, y
 }
 
 static void
-YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_statements_node_t *statements, yp_constant_id_list_t locals, const char *start, const char *end, yp_scope_node_t *dest)
+YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_node_t *body, yp_constant_id_list_t locals, const char *start, const char *end, yp_scope_node_t *dest)
 {
     *dest = (yp_scope_node_t) {
          {
@@ -1025,7 +1025,7 @@ YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_st
              .location = { .start = start, .end = end },
          },
         .parameters = parameters,
-        .statements = statements,
+        .body = body,
         .locals = locals,
     };
     return;
@@ -1035,34 +1035,41 @@ YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_st
 void
 yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
     yp_parameters_node_t *parameters = NULL;
-    yp_statements_node_t *statements;
+    yp_node_t *body;
     yp_constant_id_list_t locals;
     const char *start = node->location.start;
     const char *end = node->location.end;
 
     switch (node->type) {
+      case YP_NODE_BLOCK_NODE: {
+          yp_block_node_t *block_node = (yp_block_node_t *) node;
+          body = (yp_node_t *)block_node->body;
+          locals = block_node->locals;
+          parameters = block_node->parameters->parameters;
+          break;
+      }
       case YP_NODE_CLASS_NODE: {
           yp_class_node_t *class_node = (yp_class_node_t *) node;
-          statements = (yp_statements_node_t *)class_node->body;
+          body = (yp_node_t *)class_node->body;
           locals = class_node->locals;
           break;
       }
       case YP_NODE_DEF_NODE: {
           yp_def_node_t *def_node = (yp_def_node_t *) node;
           parameters = def_node->parameters;
-          statements = (yp_statements_node_t *)def_node->body;
+          body = (yp_node_t *)def_node->body;
           locals = def_node->locals;
           break;
       }
       case YP_NODE_MODULE_NODE: {
           yp_module_node_t *module_node = (yp_module_node_t *) node;
-          statements = (yp_statements_node_t *)module_node->body;
+          body = (yp_node_t *)module_node->body;
           locals = module_node->locals;
           break;
       }
       case YP_NODE_SINGLETON_CLASS_NODE: {
           yp_singleton_class_node_t *singleton_class_node = (yp_singleton_class_node_t *) node;
-          statements = (yp_statements_node_t *)singleton_class_node->body;
+          body = (yp_node_t *)singleton_class_node->body;
           locals = singleton_class_node->locals;
           break;
       }
@@ -1072,7 +1079,7 @@ yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
         return;
     }
 
-    yp_scope_node_create(parameters, statements, locals, start, end, dest);
+    yp_scope_node_create(parameters, body, locals, start, end, dest);
     return;
 }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1041,6 +1041,12 @@ yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
     const char *end = node->location.end;
 
     switch (node->type) {
+      case YP_NODE_CLASS_NODE: {
+          yp_class_node_t *class_node = (yp_class_node_t *) node;
+          statements = (yp_statements_node_t *)class_node->body;
+          locals = class_node->locals;
+          break;
+      }
       case YP_NODE_DEF_NODE: {
           yp_def_node_t *def_node = (yp_def_node_t *) node;
           parameters = def_node->parameters;
@@ -1048,14 +1054,12 @@ yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
           locals = def_node->locals;
           break;
       }
-
-      case YP_NODE_CLASS_NODE: {
-          yp_class_node_t *class_node = (yp_class_node_t *) node;
-          statements = (yp_statements_node_t *)class_node->body;
-          locals = class_node->locals;
+      case YP_NODE_MODULE_NODE: {
+          yp_module_node_t *module_node = (yp_module_node_t *) node;
+          statements = (yp_statements_node_t *)module_node->body;
+          locals = module_node->locals;
           break;
       }
-
       case YP_NODE_SINGLETON_CLASS_NODE: {
           yp_singleton_class_node_t *singleton_class_node = (yp_singleton_class_node_t *) node;
           statements = (yp_statements_node_t *)singleton_class_node->body;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1033,7 +1033,7 @@ YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_st
 
 // TODO: Implement this for all other nodes which can have a scope
 void
-yp_get_scope_node(yp_node_t *node, yp_scope_node_t *dest) {
+yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
     yp_parameters_node_t *parameters = NULL;
     yp_statements_node_t *statements;
     yp_constant_id_list_t locals;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1016,6 +1016,62 @@ yp_block_argument_node_create(yp_parser_t *parser, const yp_token_t *operator, y
     return node;
 }
 
+static void
+YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_statements_node_t *statements, yp_constant_id_list_t locals, const char *start, const char *end, yp_scope_node_t *dest)
+{
+    *dest = (yp_scope_node_t) {
+         {
+             .type = YP_NODE_SCOPE_NODE,
+             .location = { .start = start, .end = end },
+         },
+        .parameters = parameters,
+        .statements = statements,
+        .locals = locals,
+    };
+    return;
+}
+
+// TODO: Implement this for all other nodes which can have a scope
+void
+yp_get_scope_node(yp_node_t *node, yp_scope_node_t *dest) {
+    yp_parameters_node_t *parameters = NULL;
+    yp_statements_node_t *statements;
+    yp_constant_id_list_t locals;
+    const char *start = node->location.start;
+    const char *end = node->location.end;
+
+    switch (node->type) {
+      case YP_NODE_DEF_NODE: {
+          yp_def_node_t *def_node = (yp_def_node_t *) node;
+          parameters = def_node->parameters;
+          statements = (yp_statements_node_t *)def_node->body;
+          locals = def_node->locals;
+          break;
+      }
+
+      case YP_NODE_CLASS_NODE: {
+          yp_class_node_t *class_node = (yp_class_node_t *) node;
+          statements = (yp_statements_node_t *)class_node->body;
+          locals = class_node->locals;
+          break;
+      }
+
+      case YP_NODE_SINGLETON_CLASS_NODE: {
+          yp_singleton_class_node_t *singleton_class_node = (yp_singleton_class_node_t *) node;
+          statements = (yp_statements_node_t *)singleton_class_node->body;
+          locals = singleton_class_node->locals;
+          break;
+      }
+
+      default:
+        assert(false && "unreachable");
+        return;
+    }
+
+    yp_scope_node_create(parameters, statements, locals, start, end, dest);
+    return;
+}
+
 // Allocate and initialize a new BlockNode node.
 static yp_block_node_t *
 yp_block_node_create(yp_parser_t *parser, yp_constant_id_list_t *locals, const yp_token_t *opening, yp_block_parameters_node_t *parameters, yp_node_t *body, const yp_token_t *closing) {

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1017,7 +1017,7 @@ yp_block_argument_node_create(yp_parser_t *parser, const yp_token_t *operator, y
 }
 
 static void
-YP_ATTRIBUTE_UNUSED yp_scope_node_create(yp_parameters_node_t *parameters, yp_node_t *body, yp_constant_id_list_t locals, const char *start, const char *end, yp_scope_node_t *dest)
+yp_scope_node_create(yp_parameters_node_t *parameters, yp_node_t *body, yp_constant_id_list_t locals, const char *start, const char *end, yp_scope_node_t *dest)
 {
     *dest = (yp_scope_node_t) {
          {
@@ -1043,33 +1043,35 @@ yp_scope_node_init(yp_node_t *node, yp_scope_node_t *dest) {
     switch (node->type) {
       case YP_NODE_BLOCK_NODE: {
           yp_block_node_t *block_node = (yp_block_node_t *) node;
-          body = (yp_node_t *)block_node->body;
+          body = block_node->body;
           locals = block_node->locals;
-          parameters = block_node->parameters->parameters;
+          if (block_node->parameters) {
+              parameters = block_node->parameters->parameters;
+          }
           break;
       }
       case YP_NODE_CLASS_NODE: {
           yp_class_node_t *class_node = (yp_class_node_t *) node;
-          body = (yp_node_t *)class_node->body;
+          body = class_node->body;
           locals = class_node->locals;
           break;
       }
       case YP_NODE_DEF_NODE: {
           yp_def_node_t *def_node = (yp_def_node_t *) node;
           parameters = def_node->parameters;
-          body = (yp_node_t *)def_node->body;
+          body = def_node->body;
           locals = def_node->locals;
           break;
       }
       case YP_NODE_MODULE_NODE: {
           yp_module_node_t *module_node = (yp_module_node_t *) node;
-          body = (yp_node_t *)module_node->body;
+          body = module_node->body;
           locals = module_node->locals;
           break;
       }
       case YP_NODE_SINGLETON_CLASS_NODE: {
           yp_singleton_class_node_t *singleton_class_node = (yp_singleton_class_node_t *) node;
-          body = (yp_node_t *)singleton_class_node->body;
+          body = singleton_class_node->body;
           locals = singleton_class_node->locals;
           break;
       }

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -50,6 +50,7 @@ enum yp_node_type {
 <%- nodes.each_with_index do |node, index| -%>
     <%= node.type %> = <%= index + 1 %>,
 <%- end -%>
+    YP_NODE_SCOPE_NODE
 };
 
 typedef uint16_t yp_node_type_t;

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -115,6 +115,10 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
     memsize->node_count++;
 
     switch (YP_NODE_TYPE(node)) {
+        // We do not calculate memsize of a ScopeNode
+        // as it should never be generated
+        case YP_NODE_SCOPE_NODE:
+          return;
         <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         case <%= node.type %>: {

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -16,6 +16,10 @@ prettyprint_location(yp_buffer_t *buffer, yp_parser_t *parser, yp_location_t *lo
 static void
 prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
     switch (YP_NODE_TYPE(node)) {
+        // We do not need to print a ScopeNode as it's not part
+        // of the AST
+        case YP_NODE_SCOPE_NODE:
+          return;
         <%- nodes.each do |node| -%>
         case <%= node.type %>: {
             yp_buffer_append_str(buffer, "<%= node.name %>(", <%= node.name.length + 1 %>);

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -33,6 +33,10 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
     serialize_location(parser, &node->location, buffer);
 
     switch (YP_NODE_TYPE(node)) {
+        // We do not need to serialize a ScopeNode ever as
+        // it is not part of the AST
+        case YP_NODE_SCOPE_NODE:
+          return;
         <%- nodes.each do |node| -%>
         case <%= node.type %>: {
             <%- if node.needs_serialized_length? -%>

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -36,7 +36,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
         // We do not need to serialize a ScopeNode ever as
         // it is not part of the AST
         case YP_NODE_SCOPE_NODE:
-          return;
+            return;
         <%- nodes.each do |node| -%>
         case <%= node.type %>: {
             <%- if node.needs_serialized_length? -%>


### PR DESCRIPTION
This commit creates a scope node, and exposes a method to get ScopeNodes from other existing nodes. It still has TODOs around creating ScopeNodes for other types of nodes, which will be done in future commits.