### PR TITLE
rename `as_byte_slice` to `as_slice`

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -415,7 +415,7 @@ impl<'pr> Location<'pr> {{
 
     /// Returns a byte slice for the range.
     #[must_use]
-    pub fn as_byte_slice(&self) -> &'pr [u8] {{
+    pub fn as_slice(&self) -> &'pr [u8] {{
         let start: *mut u8 = self.start() as *mut u8;
         let end: *mut u8 = self.end() as *mut u8;
 
@@ -428,7 +428,7 @@ impl<'pr> Location<'pr> {{
 
 impl std::fmt::Debug for Location<'_> {{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
-        let slice: &[u8] = self.as_byte_slice();
+        let slice: &[u8] = self.as_slice();
 
         let mut visible = String::new();
         visible.push('"');

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -252,7 +252,7 @@ mod tests {
 
         assert_eq!(slice, "222");
 
-        let slice = std::str::from_utf8(location.as_byte_slice()).unwrap();
+        let slice = std::str::from_utf8(location.as_slice()).unwrap();
 
         assert_eq!(slice, "222");
     }


### PR DESCRIPTION
Per the subject, as requested by @kddnewton in post-commit review in #1301 