### PR TITLE
Make the "check_manifest" rake task less intrusive.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require "rake/clean"
 task compile: :make
 task compile_no_debug: :make_no_debug
 
-task default: [:compile, :test]
+task default: [:check_manifest, :compile, :test]
 
 require_relative "templates/template"
 

--- a/rakelib/check_manifest.rake
+++ b/rakelib/check_manifest.rake
@@ -70,5 +70,3 @@ task :check_manifest => [:templates] do
 
   puts "☑  manifest looks good"
 end
-
-task test: :check_manifest


### PR DESCRIPTION
Move "check_manifest" from being a dependency of "test" to being a dependency of "default".

This makes it less annoying to have temporary files in my working directory, which I commonly do while bisecting/debugging issues found by the fuzzer.
