### PR TITLE
Improve handling of line endings

### DIFF
--- a/test/comments_test.rb
+++ b/test/comments_test.rb
@@ -31,6 +31,12 @@ class CommentsTest < Test::Unit::TestCase
     assert_comment source, :__END__, 0..16
   end
 
+  def test_comment___END__crlf
+    source = "__END__\r\ncomment\r\n"
+
+    assert_comment source, :__END__, 0..18
+  end
+
   def test_comment_embedded_document
     source = <<~RUBY
       =begin

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -164,7 +164,7 @@ class ErrorsTest < Test::Unit::TestCase
 
   def test_cr_without_lf_in_percent_expression
     assert_errors expression("%\r"), "%\r", [
-      ["Invalid %% token", 0..3],
+      ["Invalid %% token", 0..2],
     ]
   end
 


### PR DESCRIPTION
Introduce three new inline helper functions:

- `match_line_ending`
- `match_line_ending_at`
- `match_line_ending_addr`

These functions are similar in signature to the `peek*` functions, but return the length of the line ending being inspected (or 0 if no line ending was found).

These functions are then used to simplify how we're detecting line endings throughout "src/yarp.c".

Also:
- test coverage backfilled for `__END__` comments with CRLF line endings.
- error message for invalid `%` tokens updated to not include the potential line endings.
- some small refactorings for readability along the way