### PR TITLE
Encoding-dependent escapes

### DIFF
--- a/fuzz/unescape.c
+++ b/fuzz/unescape.c
@@ -6,12 +6,10 @@ unescape(const char *input, size_t size, yp_unescape_type_t type) {
     yp_parser_init(&parser, input, size, "unescape.c");
 
     yp_string_t string = YP_EMPTY_STRING;
-    yp_list_t error_list = YP_LIST_EMPTY;
-    yp_unescape_manipulate_string(&parser, input, size, &string, type, &error_list);
+    yp_unescape_manipulate_string(&parser, &string, type);
 
     yp_parser_free(&parser);
     yp_string_free(&string);
-    yp_list_free(&error_list);
 }
 
 void

--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -31,12 +31,14 @@ typedef enum {
 
 // Unescape the contents of the given token into the given string using the
 // given unescape mode.
-YP_EXPORTED_FUNCTION void yp_unescape_manipulate_string(yp_parser_t *parser, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list);
+YP_EXPORTED_FUNCTION void yp_unescape_manipulate_string(yp_parser_t *parser, yp_string_t *string, yp_unescape_type_t unescape_type);
 
 // Accepts a source string and a type of unescaping and returns the unescaped version.
 // The caller must yp_string_free(result); after calling this function.
 YP_EXPORTED_FUNCTION bool yp_unescape_string(const char *start, size_t length, yp_unescape_type_t unescape_type, yp_string_t *result);
 
-YP_EXPORTED_FUNCTION size_t yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list);
+// Returns the number of bytes that encompass the first escape sequence in the
+// given string.
+size_t yp_unescape_calculate_difference(yp_parser_t *parser, const char *value, yp_unescape_type_t unescape_type, bool expect_single_codepoint);
 
 #endif

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3600,7 +3600,7 @@ yp_symbol_node_label_create(yp_parser_t *parser, const yp_token_t *token) {
             assert((label.end - label.start) >= 0);
             yp_string_shared_init(&node->unescaped, label.start, label.end);
 
-            yp_unescape_manipulate_string(parser, &node->unescaped, YP_UNESCAPE_ALL, &parser->error_list);
+            yp_unescape_manipulate_string(parser, &node->unescaped, YP_UNESCAPE_ALL);
             break;
         }
         case YP_TOKEN_MISSING: {
@@ -5077,7 +5077,7 @@ lex_question_mark(yp_parser_t *parser) {
 
     if (parser->current.start[1] == '\\') {
         lex_state_set(parser, YP_LEX_STATE_END);
-        parser->current.end += yp_unescape_calculate_difference(parser->current.start + 1, parser->end, YP_UNESCAPE_ALL, true, &parser->error_list);
+        parser->current.end += yp_unescape_calculate_difference(parser, parser->current.start + 1, YP_UNESCAPE_ALL, true);
         return YP_TOKEN_CHARACTER_LITERAL;
     } else {
         size_t encoding_width = parser->encoding.char_width(parser->current.end, parser->end - parser->current.end);
@@ -6471,7 +6471,7 @@ parser_lex(yp_parser_t *parser) {
                 // and find the next breakpoint.
                 if (*breakpoint == '\\') {
                     yp_unescape_type_t unescape_type = lex_mode->as.list.interpolation ? YP_UNESCAPE_ALL : YP_UNESCAPE_MINIMAL;
-                    size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, unescape_type, false, &parser->error_list);
+                    size_t difference = yp_unescape_calculate_difference(parser, breakpoint, unescape_type, false);
 
                     // If the result is an escaped newline, then we need to
                     // track that newline.
@@ -6584,7 +6584,7 @@ parser_lex(yp_parser_t *parser) {
                 // literally. In this case we'll skip past the next character
                 // and find the next breakpoint.
                 if (*breakpoint == '\\') {
-                    size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, false, &parser->error_list);
+                    size_t difference = yp_unescape_calculate_difference(parser, breakpoint, YP_UNESCAPE_ALL, false);
 
                     // If the result is an escaped newline, then we need to
                     // track that newline.
@@ -6725,7 +6725,7 @@ parser_lex(yp_parser_t *parser) {
                         // literally. In this case we'll skip past the next character and
                         // find the next breakpoint.
                         yp_unescape_type_t unescape_type = parser->lex_modes.current->as.string.interpolation ? YP_UNESCAPE_ALL : YP_UNESCAPE_MINIMAL;
-                        size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, unescape_type, false, &parser->error_list);
+                        size_t difference = yp_unescape_calculate_difference(parser, breakpoint, unescape_type, false);
 
                         // If the result is an escaped newline, then we need to
                         // track that newline.
@@ -6900,7 +6900,7 @@ parser_lex(yp_parser_t *parser) {
                             breakpoint += 2;
                         } else {
                             yp_unescape_type_t unescape_type = (quote == YP_HEREDOC_QUOTE_SINGLE) ? YP_UNESCAPE_MINIMAL : YP_UNESCAPE_ALL;
-                            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, unescape_type, false, &parser->error_list);
+                            size_t difference = yp_unescape_calculate_difference(parser, breakpoint, unescape_type, false);
 
                             yp_newline_list_check_append(&parser->newline_list, breakpoint + difference - 1);
 
@@ -6956,7 +6956,7 @@ yp_regular_expression_node_create_and_unescape(yp_parser_t *parser, const yp_tok
     assert((content->end - content->start) >= 0);
     yp_string_shared_init(&node->unescaped, content->start, content->end);
 
-    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type, &parser->error_list);
+    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type);
     return node;
 }
 
@@ -6967,7 +6967,7 @@ yp_symbol_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openin
     assert((content->end - content->start) >= 0);
     yp_string_shared_init(&node->unescaped, content->start, content->end);
 
-    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type, &parser->error_list);
+    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type);
     return node;
 }
 
@@ -6978,7 +6978,7 @@ yp_string_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openin
     assert((content->end - content->start) >= 0);
     yp_string_shared_init(&node->unescaped, content->start, content->end);
 
-    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type, &parser->error_list);
+    yp_unescape_manipulate_string(parser, &node->unescaped, unescape_type);
     return node;
 }
 
@@ -6989,7 +6989,7 @@ yp_xstring_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openi
     assert((content->end - content->start) >= 0);
     yp_string_shared_init(&node->unescaped, content->start, content->end);
 
-    yp_unescape_manipulate_string(parser, &node->unescaped, YP_UNESCAPE_ALL, &parser->error_list);
+    yp_unescape_manipulate_string(parser, &node->unescaped, YP_UNESCAPE_ALL);
     return node;
 }
 
@@ -9324,7 +9324,7 @@ parse_heredoc_dedent(yp_parser_t *parser, yp_node_t *node, yp_heredoc_quote_t qu
             yp_node_destroy(parser, node);
         } else {
             string->length = dest_length;
-            yp_unescape_manipulate_string(parser, string, (quote == YP_HEREDOC_QUOTE_SINGLE) ? YP_UNESCAPE_MINIMAL : YP_UNESCAPE_ALL, &parser->error_list);
+            yp_unescape_manipulate_string(parser, string, (quote == YP_HEREDOC_QUOTE_SINGLE) ? YP_UNESCAPE_MINIMAL : YP_UNESCAPE_ALL);
             nodes->nodes[write_index++] = node;
         }
 


### PR DESCRIPTION
When an escape occurs in a string, we can't blindly move forward by a single byte. We need to check the width according to the current encoding.

This is a trade-off, we could return immediately after realizing the `\` is not actually escaping something. However that means we need to handle escaped newlines in every caller. This makes it a little easier.

This gets one more file off @HParker's branch: 406bd8fb31b6eb0552606473c16baddf-act-mdlb.txt