### PR TITLE
Fix lex compat with BOM

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -12878,6 +12878,8 @@ yp_parser_metadata(yp_parser_t *parser, const char *metadata) {
 // Initialize a parser with the given start and end pointers.
 YP_EXPORTED_FUNCTION void
 yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char *filepath) {
+    assert(source != NULL);
+
     // Set filepath to the file that was passed
     if (!filepath) filepath = "";
     yp_string_t filepath_string;
@@ -12946,14 +12948,15 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size, const char 
     size_t newline_size = size / 22;
     yp_newline_list_init(&parser->newline_list, source, newline_size < 4 ? 4 : newline_size);
 
-    assert(source != NULL);
+    // Skip past the UTF-8 BOM if it exists.
     if (size >= 3 && (unsigned char) source[0] == 0xef && (unsigned char) source[1] == 0xbb && (unsigned char) source[2] == 0xbf) {
-        // If the first three bytes of the source are the UTF-8 BOM, then we'll skip
-        // over them.
         parser->current.end += 3;
-    } else if (size >= 2 && source[0] == '#' && source[1] == '!') {
-        // If the first two bytes of the source are a shebang, then we'll indicate
-        // that the encoding comment is at the end of the shebang.
+        parser->encoding_comment_start += 3;
+    }
+
+    // If the first two bytes of the source are a shebang, then we'll indicate
+    // that the encoding comment is at the end of the shebang.
+    if (peek(parser) == '#' && peek_offset(parser, 1) == '!') {
         const char *encoding_comment_start = next_newline(source, (ptrdiff_t) size);
         if (encoding_comment_start) {
             parser->encoding_comment_start = encoding_comment_start + 1;

--- a/test/bom_test.rb
+++ b/test/bom_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Don't bother checking this on these engines, this is such a specific Ripper
+# test.
+return if RUBY_ENGINE == "jruby" || RUBY_ENGINE == "truffleruby"
+
+require "yarp_test_helper"
+
+class BOMTest < Test::Unit::TestCase
+  def test_ident
+    assert_bom("foo")
+  end
+
+  def test_back_reference
+    assert_bom("$+")
+  end
+
+  def test_instance_variable
+    assert_bom("@foo")
+  end
+
+  def test_class_variable
+    assert_bom("@@foo")
+  end
+
+  def test_global_variable
+    assert_bom("$foo")
+  end
+
+  def test_numbered_reference
+    assert_bom("$1")
+  end
+
+  def test_percents
+    assert_bom("%i[]")
+    assert_bom("%r[]")
+    assert_bom("%s[]")
+    assert_bom("%q{}")
+    assert_bom("%w[]")
+    assert_bom("%x[]")
+    assert_bom("%I[]")
+    assert_bom("%W[]")
+    assert_bom("%Q{}")
+  end
+
+  def test_string
+    assert_bom("\"\"")
+    assert_bom("''")
+  end
+
+  private
+
+  def assert_bom(source)
+    bommed = "\xEF\xBB\xBF#{source}"
+    assert_equal YARP.lex_ripper(bommed), YARP.lex_compat(bommed).value
+  end
+end


### PR DESCRIPTION
* BOM should not impact looking for the encoding string
* We should re-encode tokens when the encoding changes
* BOM should change the column of comments only

Fixes one more file in the remaining parse errors.