### PR TITLE
fix: unterminated regular expression with a heredoc

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6639,7 +6639,10 @@ parser_lex(yp_parser_t *parser) {
                     // through this branch twice -- once with YP_TOKEN_REGEXP_BEGIN and then again
                     // with YP_TOKEN_STRING_CONTENT. Let's avoid tracking the newline twice, by
                     // tracking it only in the REGEXP_BEGIN case.
-                    if (!(lex_mode->as.regexp.terminator == '\n' && parser->current.type != YP_TOKEN_REGEXP_BEGIN)) {
+                    if (
+                        !(lex_mode->as.regexp.terminator == '\n' && parser->current.type != YP_TOKEN_REGEXP_BEGIN)
+                        && parser->heredoc_end == NULL
+                    ) {
                         yp_newline_list_append(&parser->newline_list, breakpoint);
                     }
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -130,6 +130,14 @@ class ErrorsTest < Test::Unit::TestCase
     ]
   end
 
+  def test_unterminated_regular_expression_with_heredoc
+    source = "<<-END + /b\nEND\n"
+
+    assert_errors expression(source), source, [
+      ["Expected a closing delimiter for a regular expression.", 10..10]
+    ]
+  end
+
   def test_unterminated_xstring
     assert_errors expression("`hello"), "`hello", [
       ["Expected a closing delimiter for an xstring.", 1..1]


### PR DESCRIPTION
Previously this snippet would track the same newline twice, leading to a failed assertion in yp_newline_list_append:

```
<<-END + /b
END
```

Found via the fuzzer.