### PR TITLE
Rename constant pool fields to name or operator

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -662,7 +662,7 @@ nodes:
         type: location
       - name: value
         type: node
-      - name: operator_id
+      - name: operator
         type: constant
     comment: |
       Represents the use of an assignment operator on a call.
@@ -1492,7 +1492,7 @@ nodes:
         type: location
       - name: value
         type: node
-      - name: constant_id
+      - name: name
         type: constant
       - name: depth
         type: uint32
@@ -1509,9 +1509,9 @@ nodes:
         type: location
       - name: value
         type: node
-      - name: constant_id
+      - name: name
         type: constant
-      - name: operator_id
+      - name: operator
         type: constant
       - name: depth
         type: uint32
@@ -1528,7 +1528,7 @@ nodes:
         type: location
       - name: value
         type: node
-      - name: constant_id
+      - name: name
         type: constant
       - name: depth
         type: uint32
@@ -1539,7 +1539,7 @@ nodes:
           ^^^^^^^^^^^^^^^^
   - name: LocalVariableReadNode
     child_nodes:
-      - name: constant_id
+      - name: name
         type: constant
       - name: depth
         type: uint32
@@ -1552,7 +1552,7 @@ nodes:
           ^^^
   - name: LocalVariableTargetNode
     child_nodes:
-      - name: constant_id
+      - name: name
         type: constant
       - name: depth
         type: uint32
@@ -1563,7 +1563,7 @@ nodes:
           ^^^  ^^^
   - name: LocalVariableWriteNode
     child_nodes:
-      - name: constant_id
+      - name: name
         type: constant
       - name: depth
         type: uint32
@@ -1682,7 +1682,7 @@ nodes:
           ^^
   - name: OptionalParameterNode
     child_nodes:
-      - name: constant_id
+      - name: name
         type: constant
       - name: name_loc
         type: location
@@ -1883,7 +1883,7 @@ nodes:
           end
   - name: RequiredParameterNode
     child_nodes:
-      - name: constant_id
+      - name: name
         type: constant
     comment: |
       Represents a required parameter to a method, block, or lambda definition.

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -462,10 +462,10 @@ module YARP
           # order here so that we can compare properly.
           if params
             sorted = [
-              *params.requireds.grep(RequiredParameterNode).map(&:constant_id),
-              *params.optionals.map(&:constant_id),
+              *params.requireds.grep(RequiredParameterNode).map(&:name),
+              *params.optionals.map(&:name),
               *((params.rest.name ? params.rest.name.to_sym : :*) if params.rest && params.rest.operator != ","),
-              *params.posts.grep(RequiredParameterNode).map(&:constant_id),
+              *params.posts.grep(RequiredParameterNode).map(&:name),
               *params.keywords.reject(&:value).map { |param| param.name.chomp(":").to_sym },
               *params.keywords.select(&:value).map { |param| param.name.chomp(":").to_sym }
             ]
@@ -485,9 +485,9 @@ module YARP
               when RequiredDestructuredParameterNode
                 param_stack.concat(param.parameters.reverse)
               when RequiredParameterNode
-                sorted << param.constant_id
+                sorted << param.name
               when SplatNode
-                sorted << param.expression.constant_id if param.expression
+                sorted << param.expression.name if param.expression
               end
             end
 

--- a/lib/yarp/desugar_visitor.rb
+++ b/lib/yarp/desugar_visitor.rb
@@ -210,8 +210,8 @@ module YARP
     # foo && foo = bar
     def visit_local_variable_and_write_node(node)
       AndNode.new(
-        LocalVariableReadNode.new(node.constant_id, node.depth, node.name_loc),
-        LocalVariableWriteNode.new(node.constant_id, node.depth, node.name_loc, node.value, node.operator_loc, node.location),
+        LocalVariableReadNode.new(node.name, node.depth, node.name_loc),
+        LocalVariableWriteNode.new(node.name, node.depth, node.name_loc, node.value, node.operator_loc, node.location),
         node.operator_loc,
         node.location
       )
@@ -224,8 +224,8 @@ module YARP
     # foo || foo = bar
     def visit_local_variable_or_write_node(node)
       OrNode.new(
-        LocalVariableReadNode.new(node.constant_id, node.depth, node.name_loc),
-        LocalVariableWriteNode.new(node.constant_id, node.depth, node.name_loc, node.value, node.operator_loc, node.location),
+        LocalVariableReadNode.new(node.name, node.depth, node.name_loc),
+        LocalVariableWriteNode.new(node.name, node.depth, node.name_loc, node.value, node.operator_loc, node.location),
         node.operator_loc,
         node.location
       )
@@ -237,7 +237,7 @@ module YARP
     #
     # foo = foo + bar
     def visit_local_variable_operator_write_node(node)
-      desugar_operator_write_node(node, LocalVariableWriteNode, LocalVariableReadNode, arguments: [node.constant_id, node.depth])
+      desugar_operator_write_node(node, LocalVariableWriteNode, LocalVariableReadNode, arguments: [node.name, node.depth])
     end
 
     private

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1434,7 +1434,7 @@ yp_call_operator_write_node_create(yp_parser_t *parser, yp_call_node_t *target, 
         .target = target,
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value,
-        .operator_id = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1)
     };
 
     return node;
@@ -2959,7 +2959,7 @@ yp_lambda_node_create(
 
 // Allocate and initialize a new LocalVariableAndWriteNode node.
 static yp_local_variable_and_write_node_t *
-yp_local_variable_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id, uint32_t depth) {
+yp_local_variable_and_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t name, uint32_t depth) {
     assert(YP_NODE_TYPE_P(target, YP_NODE_LOCAL_VARIABLE_READ_NODE) || YP_NODE_TYPE_P(target, YP_NODE_CALL_NODE));
     assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
     yp_local_variable_and_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_and_write_node_t);
@@ -2975,7 +2975,7 @@ yp_local_variable_and_write_node_create(yp_parser_t *parser, yp_node_t *target, 
         .name_loc = target->location,
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value,
-        .constant_id = constant_id,
+        .name = name,
         .depth = depth
     };
 
@@ -2984,7 +2984,7 @@ yp_local_variable_and_write_node_create(yp_parser_t *parser, yp_node_t *target, 
 
 // Allocate and initialize a new LocalVariableOperatorWriteNode node.
 static yp_local_variable_operator_write_node_t *
-yp_local_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id, uint32_t depth) {
+yp_local_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t name, uint32_t depth) {
     yp_local_variable_operator_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_operator_write_node_t);
 
     *node = (yp_local_variable_operator_write_node_t) {
@@ -2998,8 +2998,8 @@ yp_local_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *tar
         .name_loc = target->location,
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value,
-        .constant_id = constant_id,
-        .operator_id = yp_parser_constant_id_location(parser, operator->start, operator->end - 1),
+        .name = name,
+        .operator = yp_parser_constant_id_location(parser, operator->start, operator->end - 1),
         .depth = depth
     };
 
@@ -3008,7 +3008,7 @@ yp_local_variable_operator_write_node_create(yp_parser_t *parser, yp_node_t *tar
 
 // Allocate and initialize a new LocalVariableOrWriteNode node.
 static yp_local_variable_or_write_node_t *
-yp_local_variable_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t constant_id, uint32_t depth) {
+yp_local_variable_or_write_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value, yp_constant_id_t name, uint32_t depth) {
     assert(YP_NODE_TYPE_P(target, YP_NODE_LOCAL_VARIABLE_READ_NODE) || YP_NODE_TYPE_P(target, YP_NODE_CALL_NODE));
     assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
     yp_local_variable_or_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_or_write_node_t);
@@ -3024,7 +3024,7 @@ yp_local_variable_or_write_node_create(yp_parser_t *parser, yp_node_t *target, c
         .name_loc = target->location,
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value,
-        .constant_id = constant_id,
+        .name = name,
         .depth = depth
     };
 
@@ -3041,7 +3041,7 @@ yp_local_variable_read_node_create(yp_parser_t *parser, const yp_token_t *name, 
             .type = YP_NODE_LOCAL_VARIABLE_READ_NODE,
             .location = YP_LOCATION_TOKEN_VALUE(name)
         },
-        .constant_id = yp_parser_constant_id_token(parser, name),
+        .name = yp_parser_constant_id_token(parser, name),
         .depth = depth
     };
 
@@ -3050,7 +3050,7 @@ yp_local_variable_read_node_create(yp_parser_t *parser, const yp_token_t *name, 
 
 // Allocate and initialize a new LocalVariableWriteNode node.
 static yp_local_variable_write_node_t *
-yp_local_variable_write_node_create(yp_parser_t *parser, yp_constant_id_t constant_id, uint32_t depth, yp_node_t *value, const yp_location_t *name_loc, const yp_token_t *operator) {
+yp_local_variable_write_node_create(yp_parser_t *parser, yp_constant_id_t name, uint32_t depth, yp_node_t *value, const yp_location_t *name_loc, const yp_token_t *operator) {
     yp_local_variable_write_node_t *node = YP_ALLOC_NODE(parser, yp_local_variable_write_node_t);
 
     *node = (yp_local_variable_write_node_t) {
@@ -3061,7 +3061,7 @@ yp_local_variable_write_node_create(yp_parser_t *parser, yp_constant_id_t consta
                 .end = value->location.end
             }
         },
-        .constant_id = constant_id,
+        .name = name,
         .depth = depth,
         .value = value,
         .name_loc = *name_loc,
@@ -3081,7 +3081,7 @@ yp_local_variable_target_node_create(yp_parser_t *parser, const yp_token_t *name
             .type = YP_NODE_LOCAL_VARIABLE_TARGET_NODE,
             .location = YP_LOCATION_TOKEN_VALUE(name)
         },
-        .constant_id = yp_parser_constant_id_token(parser, name),
+        .name = yp_parser_constant_id_token(parser, name),
         .depth = 0
     };
 
@@ -3279,7 +3279,7 @@ yp_optional_parameter_node_create(yp_parser_t *parser, const yp_token_t *name, c
                 .end = value->location.end
             }
         },
-        .constant_id = yp_parser_constant_id_token(parser, name),
+        .name = yp_parser_constant_id_token(parser, name),
         .name_loc = YP_LOCATION_TOKEN_VALUE(name),
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value
@@ -3630,7 +3630,7 @@ yp_required_parameter_node_create(yp_parser_t *parser, const yp_token_t *token) 
             .type = YP_NODE_REQUIRED_PARAMETER_NODE,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
-        .constant_id = yp_parser_constant_id_token(parser, token)
+        .name = yp_parser_constant_id_token(parser, token)
     };
 
     return node;
@@ -7987,7 +7987,7 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
         case YP_NODE_LOCAL_VARIABLE_READ_NODE: {
             yp_local_variable_read_node_t *local_read = (yp_local_variable_read_node_t *) target;
 
-            yp_constant_id_t constant_id = local_read->constant_id;
+            yp_constant_id_t constant_id = local_read->name;
             uint32_t depth = local_read->depth;
 
             yp_location_t name_loc = target->location;
@@ -12793,7 +12793,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     parser_lex(parser);
 
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
-                    yp_node_t *result = (yp_node_t *) yp_local_variable_and_write_node_create(parser, node, &token, value, cast->constant_id, cast->depth);
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_and_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     yp_node_destroy(parser, node);
                     return result;
@@ -12894,7 +12894,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     parser_lex(parser);
 
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
-                    yp_node_t *result = (yp_node_t *) yp_local_variable_or_write_node_create(parser, node, &token, value, cast->constant_id, cast->depth);
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_or_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     yp_node_destroy(parser, node);
                     return result;
@@ -13005,7 +13005,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     parser_lex(parser);
 
                     yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
-                    yp_node_t *result = (yp_node_t *) yp_local_variable_operator_write_node_create(parser, node, &token, value, cast->constant_id, cast->depth);
+                    yp_node_t *result = (yp_node_t *) yp_local_variable_operator_write_node_create(parser, node, &token, value, cast->name, cast->depth);
 
                     yp_node_destroy(parser, node);
                     return result;

--- a/test/yarp/library_symbols_test.rb
+++ b/test/yarp/library_symbols_test.rb
@@ -11,9 +11,9 @@ if RUBY_PLATFORM =~ /linux/
     def setup
       super
 
-      @librubyparser_a = File.expand_path(File.join(__dir__, "..", "build", "librubyparser.a"))
-      @librubyparser_so = File.expand_path(File.join(__dir__, "..", "build", "librubyparser.so"))
-      @yarp_so = File.expand_path(File.join(__dir__, "..", "lib", "yarp", "yarp.so"))
+      @librubyparser_a = File.expand_path("../../build/librubyparser.a", __dir__)
+      @librubyparser_so = File.expand_path("../../build/librubyparser.so", __dir__)
+      @yarp_so = File.expand_path("../../lib/yarp/yarp.so", __dir__)
     end
 
     # objdump runner and helpers


### PR DESCRIPTION
* `constant_id` and `operator_id` are confusing.
* Solves points 3 and 4 of https://github.com/ruby/yarp/issues/1296