### PR TITLE
[rust] add `ConstantId` wrapper for `yp_constant_id_t`

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -556,6 +556,16 @@ impl<'pr> ConstantId<'pr> {{
     fn new(parser: NonNull<yp_parser_t>, id: yp_constant_id_t) -> Self {{
         ConstantId {{ parser, id, marker: PhantomData }}
     }}
+
+    /// Returns a byte slice for the constant ID.
+    #[must_use]
+    pub fn as_slice(&self) -> &'pr [u8] {{
+        unsafe {{
+            let pool = &(*self.parser.as_ptr()).constant_pool;
+            let constant = &(*pool.constants.offset(isize::try_from(self.id).expect("id should be in range")));
+            std::slice::from_raw_parts(constant.start.cast::<u8>(), constant.length)
+        }}
+    }}
 }}
 
 impl std::fmt::Debug for ConstantId<'_> {{

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -179,7 +179,7 @@ impl<'pr> ParseResult<'pr> {
     /// Returns the root node of the parse result.
     #[must_use]
     pub fn node(&self) -> Node<'pr> {
-        Node::new(self.node.as_ptr())
+        Node::new(self.parser, self.node.as_ptr())
     }
 }
 

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -328,4 +328,19 @@ mod tests {
         let upcast_node = node.as_module_node().unwrap().as_node();
         assert!(matches!(upcast_node, Node::ModuleNode { .. }));
     }
+
+    #[test]
+    fn constant_id_test() {
+        let source = "module Foo; x = 1; end";
+        let result = parse(source.as_ref());
+
+        let node = result.node();
+        let module = node.as_program_node().unwrap().statements().body().iter().next().unwrap();
+        let module = module.as_module_node().unwrap();
+        let locals = module.locals().iter().collect::<Vec<_>>();
+
+        assert_eq!(locals.len(), 1);
+
+        assert_eq!(locals[0].as_slice(), b"x");
+    }
 }


### PR DESCRIPTION
The ultimate goal of this PR is to add something like the proposed `ConstantId::as_slice`.

The design proposed here threads `yp_parser_t` into the various Rust structures.  This is necessary because `ConstantId` needs access to the associated parser it was created from so it can index into the parser's constant pool.

I can imagine an alternate world where one provides `yarp::Parser` (or similar) to `ConstantId::as_slice` instead, and any other place that requires some global state from `yp_parser_t`.  (If you squint, this is the same sort of idea that `ParseResult::as_slice` implements, except the latter function does it backwards and is probably redundant with `Location::as_slice`.)  I think the design adopted in this PR is the better one, because it gives stronger guarantees about tying the parser and the constant ID together, ultimately making things easier to use and requiring less checking in the implementation.

I think it's possible that the `PhantomData` on `ConstantId` is acceptable to the compiler, but ultimately somewhat superfluous, and would welcome better ideas from somebody who knows more about Rust FFI than I do.