### PR TITLE
Use path.to_str().unwrap() for faster failure in build.rs

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -72,7 +72,7 @@ struct Config {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = config_path();
     let file = std::fs::File::open(&path)?;
-    println!("cargo:rerun-if-changed={}", path.display());
+    println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
     let config: Config = serde_yaml::from_reader(file)?;
 
     write_bindings(&config)?;


### PR DESCRIPTION
cc @lopopolo, @froydnj