### PR TITLE
add a location accessor on generic `Node`

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -675,6 +675,17 @@ impl<'pr> Node<'pr> {{
     writeln!(file, "    }}")?;
     writeln!(file)?;
 
+    writeln!(file, "    /// Returns the location of this node.")?;
+    writeln!(file, "    #[must_use]")?;
+    writeln!(file, "    pub fn location(&self) -> Location<'pr> {{")?;
+    writeln!(file, "        match *self {{")?;
+    for node in &config.nodes {
+        writeln!(file, "            Self::{} {{ pointer, .. }} => Location {{ pointer: unsafe {{ NonNull::new_unchecked(&mut (*pointer.cast::<yp_node_t>()).location) }}, marker: PhantomData }},", node.name)?;
+    }
+    writeln!(file, "        }}")?;
+    writeln!(file, "    }}")?;
+    writeln!(file)?;
+
     for node in &config.nodes {
         writeln!(file, "    /// Returns the node as a `{}`.", node.name)?;
         writeln!(file, "    #[must_use]")?;

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -252,6 +252,11 @@ mod tests {
 
         assert_eq!(slice, "222");
 
+        let location = node.location();
+        let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();
+
+        assert_eq!(slice, "222");
+
         let slice = std::str::from_utf8(location.as_slice()).unwrap();
 
         assert_eq!(slice, "222");


### PR DESCRIPTION
This came up when trying to write code against this crate; sometimes you just want the location of a node without caring about the specific kind of node that it is.

The helper is possibly superfluous, but it makes things slightly more readable IMHO.