### PR TITLE
Prevent GitHub pages failure on forks

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'ruby/yarp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
When the repo is forked, the GitHub Pages action will run but fail, for example:

https://github.com/andyw8/yarp/actions/runs/6015582054

I _think_ this will solve it.