### PR TITLE
Fixing end-of-file issues found by the fuzzer

### DIFF
--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -83,7 +83,21 @@ dump(int argc, VALUE *argv, VALUE self) {
 
     yp_string_t input;
     input_load_string(&input, string);
-    return dump_input(&input, check_string(filepath));
+
+#ifdef YARP_DEBUG_MODE_BUILD
+    size_t length = yp_string_length(&input);
+    char* dup = malloc(length);
+    memcpy(dup, yp_string_source(&input), length);
+    yp_string_constant_init(&input, dup, length);
+#endif
+
+    VALUE value = dump_input(&input, check_string(filepath));
+
+#ifdef YARP_DEBUG_MODE_BUILD
+    free(dup);
+#endif
+
+    return value;
 }
 
 // Dump the AST corresponding to the given file to a string.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6581,7 +6581,7 @@ parser_lex(yp_parser_t *parser) {
                         LEX(YP_TOKEN_COLON_COLON);
                     }
 
-                    if (lex_state_end_p(parser) || yp_char_is_whitespace(*parser->current.end) || peek(parser) == '#') {
+                    if (lex_state_end_p(parser) || yp_char_is_whitespace(peek(parser)) || peek(parser) == '#') {
                         lex_state_set(parser, YP_LEX_STATE_BEG);
                         LEX(YP_TOKEN_COLON);
                     }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7091,6 +7091,12 @@ parser_lex(yp_parser_t *parser) {
                 // literally. In this case we'll skip past the next character
                 // and find the next breakpoint.
                 if (*breakpoint == '\\') {
+                    // Check that we're not at the end of the file.
+                    if (breakpoint + 1 >= parser->end) {
+                        breakpoint = NULL;
+                        continue;
+                    }
+
                     size_t difference = yp_unescape_calculate_difference(parser, breakpoint, YP_UNESCAPE_ALL, false);
 
                     // If the result is an escaped newline ...

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -380,6 +380,9 @@ lex_state_arg_p(yp_parser_t *parser) {
 
 static inline bool
 lex_state_spcarg_p(yp_parser_t *parser, bool space_seen) {
+    if (parser->current.end >= parser->end) {
+        return false;
+    }
     return lex_state_arg_p(parser) && space_seen && !yp_char_is_whitespace(*parser->current.end);
 }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7224,6 +7224,12 @@ parser_lex(yp_parser_t *parser) {
                         breakpoint = yp_strpbrk(parser, breakpoint + 1, breakpoints, parser->end - (breakpoint + 1));
                         break;
                     case '\\': {
+                        // Check that we're not at the end of the file.
+                        if (breakpoint + 1 >= parser->end) {
+                            breakpoint = NULL;
+                            break;
+                        }
+
                         // If we hit escapes, then we need to treat the next token
                         // literally. In this case we'll skip past the next character and
                         // find the next breakpoint.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5124,6 +5124,11 @@ lex_numeric(yp_parser_t *parser) {
 
 static yp_token_type_t
 lex_global_variable(yp_parser_t *parser) {
+    if (parser->current.end >= parser->end) {
+        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid global variable.");
+        return YP_TOKEN_GLOBAL_VARIABLE;
+    }
+
     switch (*parser->current.end) {
         case '~':  // $~: match-data
         case '*':  // $*: argv

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7413,6 +7413,12 @@ parser_lex(yp_parser_t *parser) {
                         break;
                     }
                     case '\\': {
+                        // Check that we're not at the end of the file.
+                        if (breakpoint + 1 >= parser->end) {
+                            breakpoint = NULL;
+                            break;
+                        }
+
                         // If we hit an escape, then we need to skip past
                         // however many characters the escape takes up. However
                         // it's important that if \n or \r\n are escaped that we

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5908,7 +5908,7 @@ parser_lex(yp_parser_t *parser) {
                             // Here we look for a "." or "&." following a "\n".
                             const char *following = next_newline(next_content, parser->end - next_content);
 
-                            while (following && (following < parser->end)) {
+                            while (following && (following + 1 < parser->end)) {
                                 following++;
                                 following += yp_strspn_inline_whitespace(following, parser->end - following);
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6952,6 +6952,12 @@ parser_lex(yp_parser_t *parser) {
                 // literally. In this case we'll skip past the next character
                 // and find the next breakpoint.
                 if (*breakpoint == '\\') {
+                    // Check that we're not at the end of the file.
+                    if (breakpoint + 1 >= parser->end) {
+                        breakpoint = NULL;
+                        continue;
+                    }
+
                     yp_unescape_type_t unescape_type = lex_mode->as.list.interpolation ? YP_UNESCAPE_ALL : YP_UNESCAPE_MINIMAL;
                     size_t difference = yp_unescape_calculate_difference(parser, breakpoint, unescape_type, false);
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5921,7 +5921,7 @@ parser_lex(yp_parser_t *parser) {
 
                                 // If this is not followed by a comment, then we can break out
                                 // of this loop.
-                                if (*following != '#') break;
+                                if (peek_at(parser, following) != '#') break;
 
                                 // If there is a comment, then we need to find the end of the
                                 // comment and continue searching from there.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4997,7 +4997,8 @@ lex_numeric_prefix(yp_parser_t *parser) {
             // 0d1111 is a decimal number
             case 'd':
             case 'D':
-                if (yp_char_is_decimal_digit(*++parser->current.end)) {
+                parser->current.end++;
+                if (yp_char_is_decimal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_decimal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
                     yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid decimal number.");
@@ -5008,7 +5009,8 @@ lex_numeric_prefix(yp_parser_t *parser) {
             // 0b1111 is a binary number
             case 'b':
             case 'B':
-                if (yp_char_is_binary_digit(*++parser->current.end)) {
+                parser->current.end++;
+                if (yp_char_is_binary_digit(peek(parser))) {
                     parser->current.end += yp_strspn_binary_number(parser->current.end, parser->end - parser->current.end);
                 } else {
                     yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid binary number.");
@@ -5019,7 +5021,8 @@ lex_numeric_prefix(yp_parser_t *parser) {
             // 0o1111 is an octal number
             case 'o':
             case 'O':
-                if (yp_char_is_octal_digit(*++parser->current.end)) {
+                parser->current.end++;
+                if (yp_char_is_octal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_octal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
                     yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid octal number.");
@@ -5043,7 +5046,8 @@ lex_numeric_prefix(yp_parser_t *parser) {
             // 0x1111 is a hexadecimal number
             case 'x':
             case 'X':
-                if (yp_char_is_hexadecimal_digit(*++parser->current.end)) {
+                parser->current.end++;
+                if (yp_char_is_hexadecimal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_hexadecimal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
                     yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid hexadecimal number.");

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -1106,6 +1106,12 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expected, "def foo(a = 1,b,*c);end", [["Unexpected parameter *", 16..17]]
   end
 
+  def test_unterminated_global_variable
+    assert_errors expression("$"), "$", [
+      ["Invalid global variable.", 0..1]
+    ]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -21,4 +21,5 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete binary number", "0b"
   snippet "incomplete octal number", "0o"
   snippet "incomplete hex number", "0x"
+  snippet "incomplete escaped list", "%w[\\"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -15,4 +15,5 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete global variable", "$"
   snippet "incomplete symbol", ":"
   snippet "incomplete escaped string", '"\\'
+  snippet "trailing comment", "1\n#\n"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -16,4 +16,5 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete symbol", ":"
   snippet "incomplete escaped string", '"\\'
   snippet "trailing comment", "1\n#\n"
+  snippet "trailing asterisk", "a *"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# These tests are simply to exercise snippets found by the fuzzer that caused invalid memory access.
+class FuzzerTest < Test::Unit::TestCase
+  class << self
+    def snippet(name, source)
+      test "fuzzer #{name}" do
+        YARP.dump(source)
+      end
+    end
+  end
+end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -23,4 +23,5 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete hex number", "0x"
   snippet "incomplete escaped list", "%w[\\"
   snippet "incomplete escaped regex", "/a\\"
+  snippet "unterminated heredoc with unterminated escape at end of file", "<<A\n\\"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -14,4 +14,5 @@ class FuzzerTest < Test::Unit::TestCase
 
   snippet "incomplete global variable", "$"
   snippet "incomplete symbol", ":"
+  snippet "incomplete escaped string", '"\\'
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -11,4 +11,6 @@ class FuzzerTest < Test::Unit::TestCase
       end
     end
   end
+
+  snippet "incomplete global variable", "$"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -13,4 +13,5 @@ class FuzzerTest < Test::Unit::TestCase
   end
 
   snippet "incomplete global variable", "$"
+  snippet "incomplete symbol", ":"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -16,6 +16,7 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete symbol", ":"
   snippet "incomplete escaped string", '"\\'
   snippet "trailing comment", "1\n#\n"
+  snippet "comment followed by whitespace at end of file", "1\n#\n "
   snippet "trailing asterisk", "a *"
   snippet "incomplete decimal number", "0d"
   snippet "incomplete binary number", "0b"

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -17,4 +17,8 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete escaped string", '"\\'
   snippet "trailing comment", "1\n#\n"
   snippet "trailing asterisk", "a *"
+  snippet "incomplete decimal number", "0d"
+  snippet "incomplete binary number", "0b"
+  snippet "incomplete octal number", "0o"
+  snippet "incomplete hex number", "0x"
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -22,4 +22,5 @@ class FuzzerTest < Test::Unit::TestCase
   snippet "incomplete octal number", "0o"
   snippet "incomplete hex number", "0x"
   snippet "incomplete escaped list", "%w[\\"
+  snippet "incomplete escaped regex", "/a\\"
 end


### PR DESCRIPTION
## What's changed

I've introduced a new test file, `test/yarp/fuzzer_test.rb` to exercise the snippets. These snippets all caused invalid memory access that is caught by valgrind.

You can run these tests with:

```
bundle exec rake test:valgrind TESTOPTS=-n/fuzzer/
```

I've also enabled valgrind debugging for `YARP.dump` similar to what has been done in `YARP.parse`.

The fixes here are mostly small and should be uncontroversial.

## Reviewers should pay attention to ...

The commit fixing "$" at the end of a file. I've introduced a label and some `goto`s to unify error handling in `lex_global_variable`. This may violate the informal style guide and/or your sensibilities, in which case let me know and I'll change it.
 