### PR TITLE
add tests for `Location#join`

### DIFF
--- a/test/yarp/ruby_api_test.rb
+++ b/test/yarp/ruby_api_test.rb
@@ -31,6 +31,33 @@ class YARPRubyAPITest < Test::Unit::TestCase
     assert_equal 0.5ri, parse_expression("0.5ri").value
   end
 
+  def test_location_join
+    recv, args_node, _ = parse_expression("1234 + 567").child_nodes
+    arg = args_node.arguments[0]
+
+    joined = recv.location.join(arg.location)
+    assert_equal 0, joined.start_offset
+    assert_equal 10, joined.length
+
+    e = assert_raises RuntimeError do
+      arg.location.join(recv.location)
+    end
+    assert_equal "Incompatible locations", e.message
+
+    other_recv, other_args_node, _ = parse_expression("1234 + 567").child_nodes
+    other_arg = other_args_node.arguments[0]
+
+    e = assert_raises RuntimeError do
+      other_arg.location.join(recv.location)
+    end
+    assert_equal "Incompatible sources", e.message
+
+    e = assert_raises RuntimeError do
+      recv.location.join(other_arg.location)
+    end
+    assert_equal "Incompatible sources", e.message
+  end
+
   private
 
   def parse_expression(source)


### PR DESCRIPTION
I was adding this functionality to the `yarp` crate and noticed there were no tests for the Ruby code.