### PR TITLE
[rust] add `Location::join`

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -419,6 +419,17 @@ impl<'pr> Location<'pr> {{
     pub const fn new(loc: &'pr yp_location_t) -> Location<'pr> {{
         Location {{ start: loc.start, end: loc.end, marker: PhantomData }}
     }}
+
+    /// Return a Location starting at self and ending at the end of other.
+    /// Returns None if self starts after other.
+    #[must_use]
+    pub fn join(&self, other: &Location<'pr>) -> Option<Location<'pr>> {{
+        if self.start > other.start {{
+            None
+        }} else {{
+            Some(Location {{ start: self.start, end: other.end, marker: PhantomData }})
+        }}
+    }}
 }}
 
 impl std::fmt::Debug for Location<'_> {{

--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -432,6 +432,24 @@ impl<'pr> Location<'pr> {{
             Some(Location {{ parser: self.parser, start: self.start, end: other.end, marker: PhantomData }})
         }}
     }}
+
+    /// Return the start offset from the beginning of the parsed source.
+    #[must_use]
+    pub fn start_offset(&self) -> usize {{
+        unsafe {{
+            let parser_start = (*self.parser.as_ptr()).start;
+            usize::try_from(self.start.offset_from(parser_start)).expect("start should point to memory after the parser's start")
+        }}
+    }}
+
+    /// Return the end offset from the beginning of the parsed source.
+    #[must_use]
+    pub fn end_offset(&self) -> usize {{
+        unsafe {{
+            let parser_start = (*self.parser.as_ptr()).start;
+            usize::try_from(self.end.offset_from(parser_start)).expect("end should point to memory after the parser's start")
+        }}
+    }}
 }}
 
 impl std::fmt::Debug for Location<'_> {{

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -262,6 +262,22 @@ mod tests {
         let not_joined = location.join(&recv_loc);
         assert!(not_joined.is_none());
 
+        {
+            let result = parse(source.as_ref());
+            let node = result.node();
+            let node = node.as_program_node().unwrap().statements().body().iter().next().unwrap();
+            let node = node.as_call_node().unwrap().receiver().unwrap();
+            let plus = node.as_call_node().unwrap();
+            let node = plus.arguments().unwrap().arguments().iter().next().unwrap();
+
+            let location = node.as_integer_node().unwrap().location();
+            let not_joined = recv_loc.join(&location);
+            assert!(not_joined.is_none());
+
+            let not_joined = location.join(&recv_loc);
+            assert!(not_joined.is_none());
+        }
+
         let location = node.location();
         let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();
 

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -245,12 +245,22 @@ mod tests {
         let node = result.node();
         let node = node.as_program_node().unwrap().statements().body().iter().next().unwrap();
         let node = node.as_call_node().unwrap().receiver().unwrap();
-        let node = node.as_call_node().unwrap().arguments().unwrap().arguments().iter().next().unwrap();
+        let plus = node.as_call_node().unwrap();
+        let node = plus.arguments().unwrap().arguments().iter().next().unwrap();
 
         let location = node.as_integer_node().unwrap().location();
         let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();
 
         assert_eq!(slice, "222");
+
+        let recv_loc = plus.receiver().unwrap().location();
+        assert_eq!(recv_loc.as_slice(), b"111");
+
+        let joined = recv_loc.join(&location).unwrap();
+        assert_eq!(joined.as_slice(), b"111 + 222");
+
+        let not_joined = location.join(&recv_loc);
+        assert!(not_joined.is_none());
 
         let location = node.location();
         let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -252,9 +252,13 @@ mod tests {
         let slice = std::str::from_utf8(result.as_slice(&location)).unwrap();
 
         assert_eq!(slice, "222");
+        assert_eq!(6, location.start_offset());
+        assert_eq!(9, location.end_offset());
 
         let recv_loc = plus.receiver().unwrap().location();
         assert_eq!(recv_loc.as_slice(), b"111");
+        assert_eq!(0, recv_loc.start_offset());
+        assert_eq!(3, recv_loc.end_offset());
 
         let joined = recv_loc.join(&location).unwrap();
         assert_eq!(joined.as_slice(), b"111 + 222");

--- a/rust/yarp/src/lib.rs
+++ b/rust/yarp/src/lib.rs
@@ -140,8 +140,8 @@ impl<'pr> ParseResult<'pr> {
     pub fn as_slice(&self, location: &Location<'pr>) -> &'pr [u8] {
         let root = self.source.as_ptr();
 
-        let start = usize::try_from(unsafe { location.start().offset_from(root) }).expect("start should point to memory after root");
-        let end = usize::try_from(unsafe { location.end().offset_from(root) }).expect("end should point to memory after root");
+        let start = usize::try_from(unsafe { location.start.offset_from(root) }).expect("start should point to memory after root");
+        let end = usize::try_from(unsafe { location.end.offset_from(root) }).expect("end should point to memory after root");
 
         &self.source[start..end]
     }


### PR DESCRIPTION
This function helps eliminate the need for exposing raw pointers in the public API, and is just plain easier to read than dealing with a bunch of offset arithmetic.