### PR TITLE
[rust] fix accessing optional locations

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -246,7 +246,8 @@ fn write_node(file: &mut File, node: &Node) -> Result<(), Box<dyn std::error::Er
             NodeFieldType::OptionalLocation => {
                 writeln!(file, "    pub fn {}(&self) -> Option<Location<'pr>> {{", field.name)?;
                 writeln!(file, "        let pointer: *mut yp_location_t = unsafe {{ &mut (*self.pointer).{} }};", field.name)?;
-                writeln!(file, "        if pointer.is_null() {{")?;
+                writeln!(file, "        let start = unsafe {{ (*pointer).start }};")?;
+                writeln!(file, "        if start.is_null() {{")?;
                 writeln!(file, "            None")?;
                 writeln!(file, "        }} else {{")?;
                 writeln!(file, "            Some(Location {{ pointer: unsafe {{ NonNull::new_unchecked(pointer) }}, marker: PhantomData }})")?;


### PR DESCRIPTION
Per the use of `OptionalLocation` pieces from `config.yml` elsewhere, e.g.:

https://github.com/ruby/yarp/blob/4d2f7afe1fd880f98b68d851eb9049af64b35fc5/templates/ext/yarp/api_node.c.erb#L170-L171

we should be looking at the `start` of the `yp_location_t` we're accessing to determine if the location is present, rather than the address of the `yp_location_t` itself (which will never be null).