### PR TITLE
Fixing start/end location confusion found by the fuzzer

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3908,12 +3908,14 @@ yp_statements_node_location_set(yp_statements_node_t *node, const uint8_t *start
 // Append a new node to the given StatementsNode node's body.
 static void
 yp_statements_node_body_append(yp_statements_node_t *node, yp_node_t *statement) {
-    if (yp_statements_node_body_length(node) == 0) {
+    if (yp_statements_node_body_length(node) == 0 || statement->location.start < node->base.location.start) {
         node->base.location.start = statement->location.start;
+    }
+    if (statement->location.end > node->base.location.end) {
+        node->base.location.end = statement->location.end;
     }
 
     yp_node_list_append(&node->body, statement);
-    node->base.location.end = statement->location.end;
 
     // Every statement gets marked as a place where a newline can occur.
     statement->flags |= YP_NODE_FLAG_NEWLINE;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -161,6 +161,10 @@ debug_token(yp_token_t * token) {
 
 #endif
 
+/* Macros for min/max.  */
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
 /******************************************************************************/
 /* Lex mode manipulations                                                     */
 /******************************************************************************/
@@ -1240,8 +1244,8 @@ static yp_call_node_t *
 yp_call_node_binary_create(yp_parser_t *parser, yp_node_t *receiver, yp_token_t *operator, yp_node_t *argument) {
     yp_call_node_t *node = yp_call_node_create(parser);
 
-    node->base.location.start = receiver->location.start;
-    node->base.location.end = argument->location.end;
+    node->base.location.start = MIN(receiver->location.start, argument->location.start);
+    node->base.location.end = MAX(receiver->location.end, argument->location.end);
 
     node->receiver = receiver;
     node->message_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(operator);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2766,8 +2766,13 @@ yp_interpolated_regular_expression_node_create(yp_parser_t *parser, const yp_tok
 
 static inline void
 yp_interpolated_regular_expression_node_append(yp_interpolated_regular_expression_node_t *node, yp_node_t *part) {
+    if (node->base.location.start > part->location.start) {
+        node->base.location.start = part->location.start;
+    }
+    if (node->base.location.end < part->location.end) {
+        node->base.location.end = part->location.end;
+    }
     yp_node_list_append(&node->parts, part);
-    node->base.location.end = part->location.end;
 }
 
 static inline void
@@ -3600,8 +3605,8 @@ yp_regular_expression_node_create(yp_parser_t *parser, const yp_token_t *opening
             .type = YP_NODE_REGULAR_EXPRESSION_NODE,
             .flags = yp_regular_expression_flags_create(closing),
             .location = {
-                .start = opening->start,
-                .end = closing->end
+                .start = MIN(opening->start, closing->start),
+                .end = MAX(opening->end, closing->end)
             }
         },
         .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -22,5 +22,11 @@ module YARP
     snippet "incomplete escaped list", "%w[\\"
     snippet "incomplete escaped regex", "/a\\"
     snippet "unterminated heredoc with unterminated escape at end of file", "<<A\n\\"
+
+    snippet "statements node with multiple heredocs", <<~EOF
+      for <<A + <<B
+      A
+      B
+    EOF
   end
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -28,5 +28,10 @@ module YARP
       A
       B
     EOF
+    snippet "create a binary call node with arg before receiver", <<~EOF
+      <<-A.g/{/
+      A
+      /, ""\\
+    EOF
   end
 end

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -33,5 +33,16 @@ module YARP
       A
       /, ""\\
     EOF
+    snippet "regular expression with start and end out of order", <<~RUBY
+      <<-A.g//,
+      A
+      /{/, ''\\
+    RUBY
+    snippet "interpolated regular expression with start and end out of order", <<~RUBY
+      <<-A.g/{/,
+      A
+      a
+      /{/, ''\\
+    RUBY
   end
 end


### PR DESCRIPTION
The fuzzed snippets added in this PR are not very obvious, but they result in nodes with start locations after their end locations. This causes assertions to fail during serialization.

Primarily this is happening because locations during error recovery are "best efforts" and nodes may appear out of order in a list; but there is also an implicit assumption in nodes _are_ in location order.

To address this, this PR introduces checks on both start and end locations when a node is being appended or created.