### PR TITLE
fix: octal, hex, and unicode strings at the end of a file

### DIFF
--- a/src/unescape.c
+++ b/src/unescape.c
@@ -538,6 +538,10 @@ size_t
 yp_unescape_calculate_difference(yp_parser_t *parser, const uint8_t *backslash, yp_unescape_type_t unescape_type, bool expect_single_codepoint) {
     assert(unescape_type != YP_UNESCAPE_NONE);
 
+    if (backslash + 1 >= parser->end) {
+        return 0;
+    }
+
     switch (backslash[1]) {
         case '\\':
         case '\'':

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -274,6 +274,8 @@ unescape(yp_parser_t *parser, uint8_t *dest, size_t *dest_length, const uint8_t 
 
                 if (unicode_cursor < end && *unicode_cursor == '}') {
                     unicode_cursor++;
+                } else {
+                    yp_diagnostic_list_append(&parser->error_list, backslash, unicode_cursor, "invalid Unicode escape.");
                 }
                 return unicode_cursor;
             }

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -621,6 +621,13 @@ module YARP
       ]
     end
 
+    def test_unterminated_unicode_brackets_should_be_a_syntax_error
+      assert_errors expression('?\\u{3'), '?\\u{3', [
+        ["invalid Unicode escape.", 1..5],
+        ["invalid Unicode escape.", 1..5],
+      ]
+    end
+
     def test_method_parameters_after_block
       expected = DefNode(
         Location(),

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -26,6 +26,15 @@ module YARP
     snippet "escaped octal at end of file 2", '"\\33'
     snippet "escaped hex at end of file 1", '"\\x'
     snippet "escaped hex at end of file 2", '"\\x3'
+    snippet "escaped unicode at end of file 1", '"\\u{3'
+    snippet "escaped unicode at end of file 2", '"\\u{33'
+    snippet "escaped unicode at end of file 3", '"\\u{333'
+    snippet "escaped unicode at end of file 4", '"\\u{3333'
+    snippet "escaped unicode at end of file 5", '"\\u{33333'
+    snippet "escaped unicode at end of file 6", '"\\u{333333'
+    snippet "escaped unicode at end of file 7", '"\\u3'
+    snippet "escaped unicode at end of file 8", '"\\u33'
+    snippet "escaped unicode at end of file 9", '"\\u333'
 
     snippet "statements node with multiple heredocs", <<~EOF
       for <<A + <<B

--- a/test/yarp/fuzzer_test.rb
+++ b/test/yarp/fuzzer_test.rb
@@ -22,6 +22,10 @@ module YARP
     snippet "incomplete escaped list", "%w[\\"
     snippet "incomplete escaped regex", "/a\\"
     snippet "unterminated heredoc with unterminated escape at end of file", "<<A\n\\"
+    snippet "escaped octal at end of file 1", '"\\3'
+    snippet "escaped octal at end of file 2", '"\\33'
+    snippet "escaped hex at end of file 1", '"\\x'
+    snippet "escaped hex at end of file 2", '"\\x3'
 
     snippet "statements node with multiple heredocs", <<~EOF
       for <<A + <<B


### PR DESCRIPTION
These were causing invalid memory access.

Also:
- clean up handling of EOF after `"\\"` by moving the check from `parser_lex` into `yp_unescape_calculate_difference`
- report a syntax error for unterminated bracket-style unicode strings, like `\u{1234`
