### PR TITLE
fix: report syntax error for invalid hex escape, and avoid double-reporting

### DIFF
--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -29,9 +29,9 @@ typedef enum {
     YP_UNESCAPE_ALL
 } yp_unescape_type_t;
 
-// Unescape the contents of the given token into the given string using the
-// given unescape mode.
+// Unescape the contents of the given token into the given string using the given unescape mode.
 YP_EXPORTED_FUNCTION void yp_unescape_manipulate_string(yp_parser_t *parser, yp_string_t *string, yp_unescape_type_t unescape_type);
+void yp_unescape_manipulate_char_literal(yp_parser_t *parser, yp_string_t *string, yp_unescape_type_t unescape_type);
 
 // Accepts a source string and a type of unescaping and returns the unescaped version.
 // The caller must yp_string_free(result); after calling this function.

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -91,9 +91,10 @@ unescape_hexadecimal_digit(const uint8_t value) {
 // Scan the 1-2 digits of hexadecimal into the value. Returns the number of
 // digits scanned.
 static inline size_t
-unescape_hexadecimal(const uint8_t *backslash, uint8_t *value, const uint8_t *end) {
+unescape_hexadecimal(const uint8_t *backslash, uint8_t *value, const uint8_t *end, yp_list_t *error_list) {
     *value = 0;
     if (backslash + 2 >= end || !yp_char_is_hexadecimal_digit(backslash[2])) {
+        if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid hex escape.");
         return 2;
     }
     *value = unescape_hexadecimal_digit(backslash[2]);
@@ -223,7 +224,7 @@ unescape(
         // \xnn         hexadecimal bit pattern, where nn is 1-2 hexadecimal digits ([0-9a-fA-F])
         case 'x': {
             uint8_t value;
-            const uint8_t *cursor = backslash + unescape_hexadecimal(backslash, &value, end);
+            const uint8_t *cursor = backslash + unescape_hexadecimal(backslash, &value, end, error_list);
 
             if (dest) {
                 dest[(*dest_length)++] = unescape_char(value, flags);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7548,6 +7548,17 @@ yp_symbol_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openin
 }
 
 static yp_string_node_t *
+yp_char_literal_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *opening, const yp_token_t *content, const yp_token_t *closing, yp_unescape_type_t unescape_type) {
+    yp_string_node_t *node = yp_string_node_create(parser, opening, content, closing);
+
+    assert((content->end - content->start) >= 0);
+    yp_string_shared_init(&node->unescaped, content->start, content->end);
+
+    yp_unescape_manipulate_char_literal(parser, &node->unescaped, unescape_type);
+    return node;
+}
+
+static yp_string_node_t *
 yp_string_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *opening, const yp_token_t *content, const yp_token_t *closing, yp_unescape_type_t unescape_type) {
     yp_string_node_t *node = yp_string_node_create(parser, opening, content, closing);
 
@@ -10921,7 +10932,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             yp_token_t closing = not_provided(parser);
 
-            return (yp_node_t *) yp_string_node_create_and_unescape(parser, &opening, &content, &closing, YP_UNESCAPE_ALL);
+            return (yp_node_t *) yp_char_literal_node_create_and_unescape(parser, &opening, &content, &closing, YP_UNESCAPE_ALL);
         }
         case YP_TOKEN_CLASS_VARIABLE: {
             parser_lex(parser);

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -608,7 +608,6 @@ module YARP
 
       assert_errors expected, '"\u{0000001}"', [
         ["invalid Unicode escape.", 4..11],
-        ["invalid Unicode escape.", 4..11]
       ]
     end
 
@@ -617,13 +616,11 @@ module YARP
 
       assert_errors expected, '"\u{000z}"', [
         ["unterminated Unicode escape", 7..7],
-        ["unterminated Unicode escape", 7..7]
       ]
     end
 
     def test_unterminated_unicode_brackets_should_be_a_syntax_error
       assert_errors expression('?\\u{3'), '?\\u{3', [
-        ["invalid Unicode escape.", 1..5],
         ["invalid Unicode escape.", 1..5],
       ]
     end

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -603,6 +603,12 @@ module YARP
       ]
     end
 
+    def test_invalid_hex_escape
+      assert_errors expression('"\\xx"'), '"\\xx"', [
+        ["Invalid hex escape.", 1..3],
+      ]
+    end
+
     def test_do_not_allow_more_than_6_hexadecimal_digits_in_u_Unicode_character_notation
       expected = StringNode(Location(), Location(), Location(), "\u0001")
 


### PR DESCRIPTION
    
Closes #1367

## Fix 1: report syntax error for invalid hex escape

This change passes in an error list to `escape.c:unescape_hexadecimal` and reports a syntax error if the first character isn't hexadecimal, e,g:

```ruby
  def test_invalid_hex_escape
    assert_errors expression('"\\xx"'), '"\\xx"', [
      ["Invalid hex escape.", 1..3],
    ]
  end
```

## Fix 2: avoid double-reporting of syntax errors during string unescaping

Essentially, this change updates `yp_unescape_calculate_difference` to not create syntax errors, and we rely entirely on `yp_unescape_manipulate_string` to report syntax errors.

To do that, this PR adds another (!) parameter to `unescape`: `yp_list_t *error_list`. When present, `unescape` reports syntax errors (and otherwise does not).

However, an edge case that needed to be addressed is reporting syntax errors in this case:

```ruby
?\u{1234 2345}
```

In a string context, it's possible to have multiple codepoints by doing something like `"\u{1234 2345}"`; however, in the character literal context, this is a syntax error -- only a single codepoint is allowed.

Unfortunately, when `yp_unescape_manipulate_string` is called, there's nothing to indicate that we are in a "character literal" context and that only a single codepoint is valid. `yp_unescape_calculate_difference` has this context, but no longer reports errors; `yp_unescape_manipulate_string` doesn't have this context and so no syntax error is reported.

To make this work, this PR:

- introduces a new static utility function, `yarp.c:yp_char_literal_node_create_and_unescape`, which is called when we're parsing `YP_TOKEN_CHARACTER_LITERAL`
- introduces a new (unexported) function, `yp_unescape_manipulate_char_literal` which does the same thing as `yp_unescape_manipulate_string` but tells `unescape` that only a single codepoint is expected


## Things reviewers should focus on ...

Well, I'm adding a new public function, which is a notable decision. Maybe this doesn't need to be a public function, since we only call it in one place, when parsing `YP_TOKEN_CHARACTER_LITERAL`?

It also feels funny to me that we're exercising the same code path twice, once during lexing and again during parsing. There may be something deeper we can do avoid unescaping twice, like saving the result on the token.

I'm open to other suggestions on how to fix this.