### PR TITLE
remove reallocs preparing for custom memory management

### DIFF
--- a/src/util/yp_newline_list.c
+++ b/src/util/yp_newline_list.c
@@ -25,7 +25,7 @@ yp_newline_list_init(yp_newline_list_t *list, const uint8_t *start, size_t capac
 bool
 yp_newline_list_append(yp_newline_list_t *list, const uint8_t *cursor) {
     if (list->size == list->capacity) {
-        size_t * original_offsets = list->offsets;
+        size_t *original_offsets = list->offsets;
 
         list->capacity = (list->capacity * 3) / 2;
         list->offsets = (size_t *) calloc(list->capacity, sizeof(size_t));

--- a/src/util/yp_newline_list.c
+++ b/src/util/yp_newline_list.c
@@ -25,8 +25,12 @@ yp_newline_list_init(yp_newline_list_t *list, const uint8_t *start, size_t capac
 bool
 yp_newline_list_append(yp_newline_list_t *list, const uint8_t *cursor) {
     if (list->size == list->capacity) {
+        size_t * original_offsets = list->offsets;
+
         list->capacity = (list->capacity * 3) / 2;
-        list->offsets = (size_t *) realloc(list->offsets, list->capacity * sizeof(size_t));
+        list->offsets = (size_t *) calloc(list->capacity, sizeof(size_t));
+        memcpy(list->offsets, original_offsets, list->size * sizeof(size_t));
+        free(original_offsets);
         if (list->offsets == NULL) return false;
     }
 

--- a/src/util/yp_string_list.c
+++ b/src/util/yp_string_list.c
@@ -12,8 +12,11 @@ yp_string_list_init(yp_string_list_t *string_list) {
 void
 yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string) {
     if (string_list->length + 1 > string_list->capacity) {
+        yp_string_t * original_string = string_list->strings;
         string_list->capacity *= 2;
-        string_list->strings = (yp_string_t *) realloc(string_list->strings, string_list->capacity * sizeof(yp_string_t));
+        string_list->strings = (yp_string_t *) malloc(string_list->capacity * sizeof(yp_string_t));
+        memcpy(string_list->strings, original_string, (string_list->length) * sizeof(yp_string_t));
+        free(original_string);
     }
 
     string_list->strings[string_list->length++] = *string;

--- a/src/util/yp_string_list.c
+++ b/src/util/yp_string_list.c
@@ -12,7 +12,7 @@ yp_string_list_init(yp_string_list_t *string_list) {
 void
 yp_string_list_append(yp_string_list_t *string_list, yp_string_t *string) {
     if (string_list->length + 1 > string_list->capacity) {
-        yp_string_t * original_string = string_list->strings;
+        yp_string_t *original_string = string_list->strings;
         string_list->capacity *= 2;
         string_list->strings = (yp_string_t *) malloc(string_list->capacity * sizeof(yp_string_t));
         memcpy(string_list->strings, original_string, (string_list->length) * sizeof(yp_string_t));


### PR DESCRIPTION
If we move to a bump/arena allocator like in https://github.com/HParker/yarp/tree/introduce-yp_malloc

we likely don't want to support realloc as it likely requires extra book keeping. Instead we can malloc and memset so our allocator has less cases to consider.