### PR TITLE
Provide a better inspect

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -15,6 +15,23 @@ else
   result = YARP.parse_file(ARGV[0] || "test.rb")
 end
 
-result.mark_newlines if ENV['MARK_NEWLINES']
-result = result.value.accept(YARP::DesugarVisitor.new) if ENV['DESUGAR']
-pp result
+result.mark_newlines if ENV["MARK_NEWLINES"]
+
+value = result.value
+value = value.accept(YARP::DesugarVisitor.new) if ENV["DESUGAR"]
+
+parts = {}
+parts["Comments"] = result.comments if result.comments.any?
+parts["Warnings"] = result.warnings if result.warnings.any?
+parts["Errors"] = result.errors if result.errors.any?
+
+if parts.empty?
+  puts value.inspect
+else
+  parts["AST"] = value
+  parts.each_with_index do |(key, value), index|
+    puts if index > 0
+    puts "#{key}:"
+    puts value.inspect
+  end
+end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -141,6 +141,10 @@ module YARP
     def deconstruct_keys(keys)
       { type: type, location: location }
     end
+
+    def inspect
+      "#<YARP::Comment @type=#{@type.inspect} @location=#{@location.inspect}>"
+    end
   end
 
   # This represents an error that was encountered during parsing.
@@ -155,6 +159,10 @@ module YARP
     def deconstruct_keys(keys)
       { message: message, location: location }
     end
+
+    def inspect
+      "#<YARP::ParseError @message=#{@message.inspect} @location=#{@location.inspect}>"
+    end
   end
 
   # This represents a warning that was encountered during parsing.
@@ -168,6 +176,10 @@ module YARP
 
     def deconstruct_keys(keys)
       { message: message, location: location }
+    end
+
+    def inspect
+      "#<YARP::ParseWarning @message=#{@message.inspect} @location=#{@location.inspect}>"
     end
   end
 
@@ -323,13 +335,77 @@ module YARP
         q.nest(2) do
           deconstructed = deconstruct_keys([])
           deconstructed.delete(:location)
-
           q.breakable("")
           q.seplist(deconstructed, lambda { q.comma_breakable }, :each_value) { |value| q.pp(value) }
         end
         q.breakable("")
         q.text(")")
       end
+    end
+  end
+
+  # This object is responsible for generating the output for the inspect method
+  # implementations of child nodes.
+  class NodeInspector
+    attr_reader :prefix, :output
+
+    def initialize(prefix = "")
+      @prefix = prefix
+      @output = +""
+    end
+
+    # Appends a line to the output with the current prefix.
+    def <<(line)
+      output << "#{prefix}#{line}"
+    end
+
+    # This generates a string that is used as the header of the inspect output
+    # for any given node.
+    def header(node)
+      output = +"@ #{node.class.name.split("::").last} ("
+      output << "location: (#{node.location.start_offset}...#{node.location.end_offset})"
+      output << ", newline: true" if node.newline?
+      output << ")\n"
+      output
+    end
+
+    # Generates a string that represents a list of nodes. It handles properly
+    # using the box drawing characters to make the output look nice.
+    def list(prefix, nodes)
+      output = +"(length: #{nodes.length})\n"
+      last_index = nodes.length - 1
+
+      nodes.each_with_index do |node, index|
+        pointer, preadd = (index == last_index) ? ["└── ", "    "] : ["├── ", "│   "]
+        node_prefix = "#{prefix}#{preadd}"
+        output << node.inspect(NodeInspector.new(node_prefix)).sub(node_prefix, "#{prefix}#{pointer}")
+      end
+
+      output
+    end
+
+    # Generates a string that represents a location field on a node.
+    def location(value)
+      if value
+        "(#{value.start_offset}...#{value.end_offset}) = #{value.slice.inspect}"
+      else
+        "∅"
+      end
+    end
+
+    # Generates a string that represents a child node.
+    def child_node(node, append)
+      node.inspect(child_inspector(append)).delete_prefix(prefix)
+    end
+
+    # Returns a new inspector that can be used to inspect a child node.
+    def child_inspector(append)
+      NodeInspector.new("#{prefix}#{append}")
+    end
+
+    # Returns the output as a string.
+    def to_str
+      output
     end
   end
 

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -92,6 +92,39 @@ module YARP
     <%- end -%>
     <%- end -%>
     <%- end -%>
+
+    def inspect(inspector = NodeInspector.new)
+      inspector << inspector.header(self)
+      <%- node.fields.each_with_index do |field, index| -%>
+      <%- pointer, preadd = index == node.fields.length - 1 ? ["└── ", "    "] : ["├── ", "│   "] -%>
+      <%- case field -%>
+      <%- when YARP::NodeListField -%>
+      inspector << "<%= pointer %><%= field.name %>: #{inspector.list("#{inspector.prefix}<%= preadd %>", <%= field.name %>)}"
+      <%- when YARP::LocationListField, YARP::ConstantListField -%>
+      inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
+      <%- when YARP::NodeField -%>
+      inspector << "<%= pointer %><%= field.name %>:\n"
+      inspector << inspector.child_node(<%= field.name %>, "<%= preadd %>")
+      <%- when YARP::OptionalNodeField -%>
+      if (<%= field.name %> = self.<%= field.name %>).nil?
+        inspector << "<%= pointer %><%= field.name %>: ∅\n"
+      else
+        inspector << "<%= pointer %><%= field.name %>:\n"
+        inspector << <%= field.name %>.inspect(inspector.child_inspector("<%= preadd %>")).delete_prefix(inspector.prefix)
+      end
+      <%- when YARP::ConstantField, YARP::StringField, YARP::UInt32Field -%>
+      inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
+      <%- when YARP::FlagsField -%>
+      <%- flag = flags.find { |flag| flag.name == field.kind }.tap { |flag| raise unless flag } -%>
+      inspector << "<%= pointer %><%= field.name %>: #{[<%= flag.values.map { |value| "(\"#{value.name.downcase}\" if #{value.name.downcase}?)" }.join(", ") %>].compact.join(", ")}\n"
+      <%- when YARP::LocationField, YARP::OptionalLocationField -%>
+      inspector << "<%= pointer %><%= field.name %>: #{inspector.location(<%= field.name %>)}\n"
+      <%- else -%>
+      <%- raise -%>
+      <%- end -%>
+      <%- end -%>
+      inspector.to_str
+    end
   end
 
   <%- end -%>


### PR DESCRIPTION
Templates out an inspect method to make it easier to see all of the fields. Note that I didn't override pretty printing yet, because I didn't want the diff to be massive. This changes:

```
$ bin/parse -e 'foo + 1'
#<YARP::ParseResult:0x0000000103301c78
 @comments=[],
 @errors=[],
 @source=#<YARP::Source:0x00000001032e1b30 @offsets=[0], @source="foo + 1">,
 @value=
  ProgramNode(0...7)(
    [],
    StatementsNode(0...7)([CallNode(0...7)(CallNode(0...3)(nil, nil, (0...3), nil, nil, nil, nil, 2, "foo"), nil, (4...5), nil, ArgumentsNode(6...7)([IntegerNode(6...7)()]), nil, nil, 0, "+")])
  ),
 @warnings=[]>
```

to:

```
$ bin/parse -e 'foo + 1'
@ ProgramNode (location: (0...7))
├── locals: []
└── statements:
    @ StatementsNode (location: (0...7))
    └── body: (length: 1)
        └── @ CallNode (location: (0...7))
            ├── receiver:
            │   @ CallNode (location: (0...3))
            │   ├── receiver: ∅
            │   ├── operator_loc: ∅
            │   ├── message_loc: (0...3) = "foo"
            │   ├── opening_loc: ∅
            │   ├── arguments: ∅
            │   ├── closing_loc: ∅
            │   ├── block: ∅
            │   ├── flags: variable_call
            │   └── name: "foo"
            ├── operator_loc: ∅
            ├── message_loc: (4...5) = "+"
            ├── opening_loc: ∅
            ├── arguments:
            │   @ ArgumentsNode (location: (6...7))
            │   └── arguments: (length: 1)
            │       └── @ IntegerNode (location: (6...7))
            ├── closing_loc: ∅
            ├── block: ∅
            ├── flags: 
            └── name: "+"
```