### PR TITLE
Support LANG=C environments in template.rb

### DIFF
--- a/templates/template.rb
+++ b/templates/template.rb
@@ -339,7 +339,10 @@ end
 if __FILE__ == $0
   if ARGV.empty?
     YARP::TEMPLATES.each { |filepath| YARP.template(filepath) }
-  else
+  else # ruby/ruby
+    if ENV["LANG"] == "C"
+      Encoding.default_external = Encoding::UTF_8
+    end
     name, write_to = ARGV
     YARP.template(name, write_to: write_to)
   end


### PR DESCRIPTION
https://github.com/ruby/yarp/pull/1381 broke ruby/ruby's CI https://github.com/ruby/ruby/actions/runs/6054821565/job/16432831277, and this PR is trying to fix it.