### PR TITLE
Fix optional comment for Java fields

### DIFF
--- a/templates/java/org/yarp/Nodes.java.erb
+++ b/templates/java/org/yarp/Nodes.java.erb
@@ -190,7 +190,10 @@ public abstract class Nodes {
         public final int serializedLength;
         <%- end -%>
         <%- node.fields.each do |field| -%>
-        public final <%= field.java_type %> <%= field.name %>;<%= ' // optional' if field.class.name.start_with?('Optional') %>
+        <%- if field.class.name.include?('Optional') -%>
+        /** optional (can be null) */
+        <%- end -%>
+        public final <%= field.java_type %> <%= field.name %>;
         <%- end -%>
 
         <%-


### PR DESCRIPTION
* The field class name now starts with YARP::.