### PR TITLE
Read template in UTF-8

### DIFF
--- a/templates/template.rb
+++ b/templates/template.rb
@@ -304,21 +304,11 @@ module YARP
     private
 
     def read_template(filepath)
-      previous_verbosity = $VERBOSE
-      previous_default_external = Encoding.default_external
-      $VERBOSE = nil
-
-      begin
-        Encoding.default_external = Encoding::UTF_8
-
-        if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
-          ERB.new(File.read(filepath), trim_mode: "-")
-        else
-          ERB.new(File.read(filepath), nil, "-")
-        end
-      ensure
-        Encoding.default_external = previous_default_external
-        $VERBOSE = previous_verbosity
+      template = File.read(filepath, encoding: Encoding::UTF_8)
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        ERB.new(template, trim_mode: "-")
+      else
+        ERB.new(template, nil, "-")
       end
     end
 

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -266,7 +266,6 @@ module YARP
       template = File.expand_path("../#{filepath}", __dir__)
 
       erb = read_template(template)
-      erb.filename = template
 
       non_ruby_heading = <<~HEADING
       /******************************************************************************/
@@ -305,9 +304,17 @@ module YARP
 
     def read_template(filepath)
       template = File.read(filepath, encoding: Encoding::UTF_8)
-      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+      erb = erb(template)
+      erb.filename = filepath
+      erb
+    end
+
+    if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+      def erb(template)
         ERB.new(template, trim_mode: "-")
-      else
+      end
+    else
+      def erb
         ERB.new(template, nil, "-")
       end
     end


### PR DESCRIPTION
Explicitly specify the encoding, instead of `Encoding.default_external` temporarily.