### PR TITLE
Split warning and error reporting

### DIFF
--- a/include/yarp/diagnostic.h
+++ b/include/yarp/diagnostic.h
@@ -3,6 +3,7 @@
 
 #include "yarp/defines.h"
 #include "yarp/util/yp_list.h"
+#include "yarp/parser.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -15,8 +16,11 @@ typedef struct {
     const char *message;
 } yp_diagnostic_t;
 
-// Append a diagnostic to the given list of diagnostics.
-bool yp_diagnostic_list_append(yp_list_t *list, const uint8_t *start, const uint8_t *end, const char *message);
+// Append a diagnostic to the given list of warning diagnostics.
+bool yp_diagnostic_warning_list_append(yp_parser_t *parser, const uint8_t *start, const uint8_t *end, const char *message);
+
+// Append a diagnostic to the given list of error diagnostics.
+bool yp_diagnostic_error_list_append(yp_parser_t *parser, const uint8_t *start, const uint8_t *end, const char *message);
 
 // Deallocate the internal state of the given diagnostic list.
 void yp_diagnostic_list_free(yp_list_t *list);

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -11,6 +11,18 @@ yp_diagnostic_list_append(yp_list_t *list, const uint8_t *start, const uint8_t *
     return true;
 }
 
+// Append an error to the error diagnostic list.
+bool
+yp_diagnostic_error_list_append(yp_parser_t *parser, const uint8_t *start, const uint8_t *end, const char *message) {
+    return yp_diagnostic_list_append(&parser->error_list, start, end, message);
+}
+
+// Append a warning to the warning diagnostic list.
+bool
+yp_diagnostic_warning_list_append(yp_parser_t *parser, const uint8_t *start, const uint8_t *end, const char *message) {
+    return yp_diagnostic_list_append(&parser->warning_list, start, end, message);
+}
+
 // Deallocate the internal state of the given diagnostic list.
 void
 yp_diagnostic_list_free(yp_list_t *list) {

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -91,10 +91,10 @@ unescape_hexadecimal_digit(const uint8_t value) {
 // Scan the 1-2 digits of hexadecimal into the value. Returns the number of
 // digits scanned.
 static inline size_t
-unescape_hexadecimal(const uint8_t *backslash, uint8_t *value, const uint8_t *end, yp_list_t *error_list) {
+unescape_hexadecimal(yp_parser_t *parser, const uint8_t *backslash, uint8_t *value, const uint8_t *end, bool report_errors) {
     *value = 0;
     if (backslash + 2 >= end || !yp_char_is_hexadecimal_digit(backslash[2])) {
-        if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid hex escape.");
+        if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Invalid hex escape.");
         return 2;
     }
     *value = unescape_hexadecimal_digit(backslash[2]);
@@ -121,7 +121,7 @@ unescape_unicode(const uint8_t *string, size_t length, uint32_t *value) {
 // 32-bit value to write. Writes the UTF-8 representation of the value to the
 // string and returns the number of bytes written.
 static inline size_t
-unescape_unicode_write(uint8_t *dest, uint32_t value, const uint8_t *start, const uint8_t *end, yp_list_t *error_list) {
+unescape_unicode_write(yp_parser_t *parser, uint8_t *dest, uint32_t value, const uint8_t *start, const uint8_t *end, bool report_errors ) {
     if (value <= 0x7F) {
         // 0xxxxxxx
         dest[0] = (uint8_t) value;
@@ -157,7 +157,7 @@ unescape_unicode_write(uint8_t *dest, uint32_t value, const uint8_t *start, cons
     // If we get here, then the value is too big. This is an error, but we don't
     // want to just crash, so instead we'll add an error to the error list and put
     // in a replacement character instead.
-    if (error_list) yp_diagnostic_list_append(error_list, start, end, "Invalid Unicode escape sequence.");
+    if (report_errors) yp_diagnostic_error_list_append(parser, start, end, "Invalid Unicode escape sequence.");
     dest[0] = 0xEF;
     dest[1] = 0xBF;
     dest[2] = 0xBD;
@@ -194,7 +194,7 @@ unescape(
     const uint8_t *backslash,
     const uint8_t *end,
     const uint8_t flags,
-    yp_list_t *error_list
+    bool report_errors
 ) {
     switch (backslash[1]) {
         case 'a':
@@ -224,7 +224,7 @@ unescape(
         // \xnn         hexadecimal bit pattern, where nn is 1-2 hexadecimal digits ([0-9a-fA-F])
         case 'x': {
             uint8_t value;
-            const uint8_t *cursor = backslash + unescape_hexadecimal(backslash, &value, end, error_list);
+            const uint8_t *cursor = backslash + unescape_hexadecimal(parser, backslash, &value, end, report_errors);
 
             if (dest) {
                 dest[(*dest_length)++] = unescape_char(value, flags);
@@ -235,7 +235,7 @@ unescape(
         // \unnnn       Unicode character, where nnnn is exactly 4 hexadecimal digits ([0-9a-fA-F])
         case 'u': {
             if ((flags & YP_UNESCAPE_FLAG_CONTROL) | (flags & YP_UNESCAPE_FLAG_META)) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Unicode escape sequence cannot be used with control or meta flags.");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Unicode escape sequence cannot be used with control or meta flags.");
                 return backslash + 2;
             }
 
@@ -252,11 +252,11 @@ unescape(
 
                     // \u{nnnn} character literal allows only 1-6 hexadecimal digits
                     if (hexadecimal_length > 6) {
-                        if (error_list) yp_diagnostic_list_append(error_list, unicode_cursor, unicode_cursor + hexadecimal_length, "invalid Unicode escape.");
+                        if (report_errors) yp_diagnostic_error_list_append(parser, unicode_cursor, unicode_cursor + hexadecimal_length, "invalid Unicode escape.");
                     }
                     // there are not hexadecimal characters
                     else if (hexadecimal_length == 0) {
-                        if (error_list) yp_diagnostic_list_append(error_list, unicode_cursor, unicode_cursor + hexadecimal_length, "unterminated Unicode escape");
+                        if (report_errors) yp_diagnostic_error_list_append(parser, unicode_cursor, unicode_cursor + hexadecimal_length, "unterminated Unicode escape");
                         return unicode_cursor;
                     }
 
@@ -269,7 +269,7 @@ unescape(
                     uint32_t value;
                     unescape_unicode(unicode_start, (size_t) (unicode_cursor - unicode_start), &value);
                     if (dest) {
-                        *dest_length += unescape_unicode_write(dest + *dest_length, value, unicode_start, unicode_cursor, error_list);
+                        *dest_length += unescape_unicode_write(parser, dest + *dest_length, value, unicode_start, unicode_cursor, report_errors);
                     }
 
                     unicode_cursor += yp_strspn_whitespace(unicode_cursor, end - unicode_cursor);
@@ -277,13 +277,13 @@ unescape(
 
                 // ?\u{nnnn} character literal should contain only one codepoint and cannot be like ?\u{nnnn mmmm}
                 if (flags & YP_UNESCAPE_FLAG_EXPECT_SINGLE && codepoints_count > 1) {
-                    if (error_list) yp_diagnostic_list_append(error_list, extra_codepoints_start, unicode_cursor - 1, "Multiple codepoints at single character literal");
+                    if (report_errors) yp_diagnostic_error_list_append(parser, extra_codepoints_start, unicode_cursor - 1, "Multiple codepoints at single character literal");
                 }
 
                 if (unicode_cursor < end && *unicode_cursor == '}') {
                     unicode_cursor++;
                 } else {
-                    if (error_list) yp_diagnostic_list_append(error_list, backslash, unicode_cursor, "invalid Unicode escape.");
+                    if (report_errors) yp_diagnostic_error_list_append(parser, backslash, unicode_cursor, "invalid Unicode escape.");
                 }
 
                 return unicode_cursor;
@@ -293,12 +293,12 @@ unescape(
                 unescape_unicode(backslash + 2, 4, &value);
 
                 if (dest) {
-                    *dest_length += unescape_unicode_write(dest + *dest_length, value, backslash + 2, backslash + 6, error_list);
+                    *dest_length += unescape_unicode_write(parser, dest + *dest_length, value, backslash + 2, backslash + 6, report_errors);
                 }
                 return backslash + 6;
             }
 
-            if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid Unicode escape sequence");
+            if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Invalid Unicode escape sequence");
             return backslash + 2;
         }
         // \c\M-x       meta control character, where x is an ASCII printable character
@@ -306,18 +306,18 @@ unescape(
         // \cx          control character, where x is an ASCII printable character
         case 'c':
             if (backslash + 2 >= end) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Invalid control escape sequence");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Invalid control escape sequence");
                 return end;
             }
 
             if (flags & YP_UNESCAPE_FLAG_CONTROL) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Control escape sequence cannot be doubled.");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Control escape sequence cannot be doubled.");
                 return backslash + 2;
             }
 
             switch (backslash[2]) {
                 case '\\':
-                    return unescape(parser, dest, dest_length, backslash + 2, end, flags | YP_UNESCAPE_FLAG_CONTROL, error_list);
+                    return unescape(parser, dest, dest_length, backslash + 2, end, flags | YP_UNESCAPE_FLAG_CONTROL, report_errors);
                 case '?':
                     if (dest) {
                         dest[(*dest_length)++] = unescape_char(0x7f, flags);
@@ -325,7 +325,7 @@ unescape(
                     return backslash + 3;
                 default: {
                     if (!char_is_ascii_printable(backslash[2])) {
-                        if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Invalid control escape sequence");
+                        if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Invalid control escape sequence");
                         return backslash + 2;
                     }
 
@@ -339,23 +339,23 @@ unescape(
         // \C-?         delete, ASCII 7Fh (DEL)
         case 'C':
             if (backslash + 3 >= end) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Invalid control escape sequence");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Invalid control escape sequence");
                 return end;
             }
 
             if (flags & YP_UNESCAPE_FLAG_CONTROL) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Control escape sequence cannot be doubled.");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Control escape sequence cannot be doubled.");
                 return backslash + 2;
             }
 
             if (backslash[2] != '-') {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Invalid control escape sequence");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Invalid control escape sequence");
                 return backslash + 2;
             }
 
             switch (backslash[3]) {
                 case '\\':
-                    return unescape(parser, dest, dest_length, backslash + 3, end, flags | YP_UNESCAPE_FLAG_CONTROL, error_list);
+                    return unescape(parser, dest, dest_length, backslash + 3, end, flags | YP_UNESCAPE_FLAG_CONTROL, report_errors);
                 case '?':
                     if (dest) {
                         dest[(*dest_length)++] = unescape_char(0x7f, flags);
@@ -363,7 +363,7 @@ unescape(
                     return backslash + 4;
                 default:
                     if (!char_is_ascii_printable(backslash[3])) {
-                        if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid control escape sequence");
+                        if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Invalid control escape sequence");
                         return backslash + 2;
                     }
 
@@ -377,22 +377,22 @@ unescape(
         // \M-x         meta character, where x is an ASCII printable character
         case 'M': {
             if (backslash + 3 >= end) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 1, "Invalid control escape sequence");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 1, "Invalid control escape sequence");
                 return end;
             }
 
             if (flags & YP_UNESCAPE_FLAG_META) {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Meta escape sequence cannot be doubled.");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Meta escape sequence cannot be doubled.");
                 return backslash + 2;
             }
 
             if (backslash[2] != '-') {
-                if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid meta escape sequence");
+                if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Invalid meta escape sequence");
                 return backslash + 2;
             }
 
             if (backslash[3] == '\\') {
-                return unescape(parser, dest, dest_length, backslash + 3, end, flags | YP_UNESCAPE_FLAG_META, error_list);
+                return unescape(parser, dest, dest_length, backslash + 3, end, flags | YP_UNESCAPE_FLAG_META, report_errors);
             }
 
             if (char_is_ascii_printable(backslash[3])) {
@@ -402,7 +402,7 @@ unescape(
                 return backslash + 4;
             }
 
-            if (error_list) yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Invalid meta escape sequence");
+            if (report_errors) yp_diagnostic_error_list_append(parser, backslash, backslash + 2, "Invalid meta escape sequence");
             return backslash + 3;
         }
         // \n
@@ -474,7 +474,7 @@ yp_unescape_manipulate_string_or_char_literal(yp_parser_t *parser, yp_string_t *
     // within the string.
     uint8_t *allocated = malloc(string->length);
     if (allocated == NULL) {
-        yp_diagnostic_list_append(&parser->error_list, string->source, string->source + string->length, "Failed to allocate memory for unescaping.");
+        yp_diagnostic_error_list_append(parser, string->source, string->source + string->length, "Failed to allocate memory for unescaping.");
         return;
     }
 
@@ -525,7 +525,7 @@ yp_unescape_manipulate_string_or_char_literal(yp_parser_t *parser, yp_string_t *
                     flags |= YP_UNESCAPE_FLAG_EXPECT_SINGLE;
                 }
 
-                cursor = unescape(parser, dest, &dest_length, backslash, end, flags, &parser->error_list);
+                cursor = unescape(parser, dest, &dest_length, backslash, end, flags, true);
                 break;
         }
 
@@ -592,7 +592,7 @@ yp_unescape_calculate_difference(yp_parser_t *parser, const uint8_t *backslash, 
                 flags |= YP_UNESCAPE_FLAG_EXPECT_SINGLE;
             }
 
-            const uint8_t *cursor = unescape(parser, NULL, 0, backslash, parser->end, flags, NULL);
+            const uint8_t *cursor = unescape(parser, NULL, 0, backslash, parser->end, flags, false);
             assert(cursor > backslash);
 
             return (size_t) (cursor - backslash);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -533,8 +533,8 @@ typedef struct {
 static void
 yp_arguments_validate(yp_parser_t *parser, yp_arguments_t *arguments) {
     if (arguments->block != NULL && arguments->implicit_block) {
-        yp_diagnostic_list_append(
-            &parser->error_list,
+        yp_diagnostic_error_list_append(
+            parser,
             arguments->block->base.location.start,
             arguments->block->base.location.end,
             "both block arg and actual block given"
@@ -631,14 +631,14 @@ parse_decimal_number(yp_parser_t *parser, const uint8_t *start, const uint8_t *e
     unsigned long value = strtoul(digits, &endptr, 10);
 
     if ((digits == endptr) || (*endptr != '\0') || (errno == ERANGE)) {
-        yp_diagnostic_list_append(&parser->error_list, start, end, "invalid decimal number");
+        yp_diagnostic_error_list_append(parser, start, end, "invalid decimal number");
         value = UINT32_MAX;
     }
 
     free(digits);
 
     if (value > UINT32_MAX) {
-        yp_diagnostic_list_append(&parser->error_list, start, end, "invalid decimal number");
+        yp_diagnostic_error_list_append(parser, start, end, "invalid decimal number");
         value = UINT32_MAX;
     }
 
@@ -4621,7 +4621,7 @@ yp_parser_parameter_name_check(yp_parser_t *parser, yp_token_t *name) {
     yp_constant_id_t constant_id = yp_parser_constant_id_token(parser, name);
 
     if (yp_constant_id_list_includes(&parser->current_scope->locals, constant_id)) {
-        yp_diagnostic_list_append(&parser->error_list, name->start, name->end, "Duplicated parameter name.");
+        yp_diagnostic_error_list_append(parser, name->start, name->end, "Duplicated parameter name.");
     }
 }
 
@@ -4962,7 +4962,7 @@ parser_lex_encoding_comment(yp_parser_t *parser) {
     // didn't understand the encoding that the user was trying to use. In this
     // case we'll keep using the default encoding but add an error to the
     // parser to indicate an unsuccessful parse.
-    yp_diagnostic_list_append(&parser->error_list, encoding_start, encoding_end, "Could not understand the encoding specified in the magic comment.");
+    yp_diagnostic_error_list_append(parser, encoding_start, encoding_end, "Could not understand the encoding specified in the magic comment.");
 }
 
 /******************************************************************************/
@@ -5122,7 +5122,7 @@ lex_optional_float_suffix(yp_parser_t *parser) {
             parser->current.end += yp_strspn_decimal_number(parser->current.end, parser->end - parser->current.end);
             type = YP_TOKEN_FLOAT;
         } else {
-            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Missing exponent.");
+            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Missing exponent.");
             type = YP_TOKEN_FLOAT;
         }
     }
@@ -5143,7 +5143,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
                 if (yp_char_is_decimal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_decimal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid decimal number.");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid decimal number.");
                 }
 
                 break;
@@ -5155,7 +5155,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
                 if (yp_char_is_binary_digit(peek(parser))) {
                     parser->current.end += yp_strspn_binary_number(parser->current.end, parser->end - parser->current.end);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid binary number.");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid binary number.");
                 }
 
                 break;
@@ -5167,7 +5167,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
                 if (yp_char_is_octal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_octal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid octal number.");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid octal number.");
                 }
 
                 break;
@@ -5192,7 +5192,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
                 if (yp_char_is_hexadecimal_digit(peek(parser))) {
                     parser->current.end += yp_strspn_hexadecimal_number(parser->current.end, parser->end - parser->current.end);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid hexadecimal number.");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid hexadecimal number.");
                 }
 
                 break;
@@ -5222,7 +5222,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
     // If the last character that we consumed was an underscore, then this is
     // actually an invalid integer value, and we should return an invalid token.
     if (peek_offset(parser, -1) == '_') {
-        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Number literal cannot end with a `_`.");
+        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Number literal cannot end with a `_`.");
     }
 
     return type;
@@ -5274,7 +5274,7 @@ lex_numeric(yp_parser_t *parser) {
 static yp_token_type_t
 lex_global_variable(yp_parser_t *parser) {
     if (parser->current.end >= parser->end) {
-        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid global variable.");
+        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid global variable.");
         return YP_TOKEN_GLOBAL_VARIABLE;
     }
 
@@ -5315,7 +5315,7 @@ lex_global_variable(yp_parser_t *parser) {
                 } while (parser->current.end < parser->end && (width = char_is_identifier(parser, parser->current.end)) > 0);
 
                 // $0 isn't allowed to be followed by anything.
-                yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid global variable.");
+                yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid global variable.");
             }
 
             return YP_TOKEN_GLOBAL_VARIABLE;
@@ -5346,7 +5346,7 @@ lex_global_variable(yp_parser_t *parser) {
             } else {
                 // If we get here, then we have a $ followed by something that isn't
                 // recognized as a global variable.
-                yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid global variable.");
+                yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid global variable.");
             }
 
             return YP_TOKEN_GLOBAL_VARIABLE;
@@ -5686,7 +5686,7 @@ lex_question_mark(yp_parser_t *parser) {
     }
 
     if (parser->current.end >= parser->end) {
-        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Incomplete character syntax.");
+        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Incomplete character syntax.");
         return YP_TOKEN_CHARACTER_LITERAL;
     }
 
@@ -5737,9 +5737,9 @@ lex_at_variable(yp_parser_t *parser) {
             parser->current.end += width;
         }
     } else if (type == YP_TOKEN_CLASS_VARIABLE) {
-        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Incomplete class variable.");
+        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Incomplete class variable.");
     } else {
-        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Incomplete instance variable.");
+        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Incomplete instance variable.");
     }
 
     // If we're lexing an embedded variable, then we need to pop back into the
@@ -5838,7 +5838,7 @@ lex_embdoc(yp_parser_t *parser) {
         parser_lex_callback(parser);
     }
 
-    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unterminated embdoc");
+    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unterminated embdoc");
 
     comment->end = parser->current.end;
     yp_list_append(&parser->comment_list, (yp_list_node_t *) comment);
@@ -6268,7 +6268,7 @@ parser_lex(yp_parser_t *parser) {
                     yp_token_type_t type = YP_TOKEN_STAR;
 
                     if (lex_state_spcarg_p(parser, space_seen)) {
-                        yp_diagnostic_list_append(&parser->warning_list, parser->current.start, parser->current.end, "`*' interpreted as argument prefix");
+                        yp_diagnostic_warning_list_append(parser, parser->current.start, parser->current.end, "`*' interpreted as argument prefix");
                         type = YP_TOKEN_USTAR;
                     } else if (lex_state_beg_p(parser)) {
                         type = YP_TOKEN_USTAR;
@@ -6412,7 +6412,7 @@ parser_lex(yp_parser_t *parser) {
                                         // this is not a valid heredoc declaration. In this case we
                                         // will add an error, but we will still return a heredoc
                                         // start.
-                                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unterminated heredoc.");
+                                        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unterminated heredoc.");
                                         body_start = parser->end;
                                     } else {
                                         // Otherwise, we want to indicate that the body of the
@@ -6605,8 +6605,8 @@ parser_lex(yp_parser_t *parser) {
 
                     bool spcarg = lex_state_spcarg_p(parser, space_seen);
                     if (spcarg) {
-                        yp_diagnostic_list_append(
-                            &parser->warning_list,
+                        yp_diagnostic_warning_list_append(
+                            parser,
                             parser->current.start,
                             parser->current.end,
                             "ambiguous first argument; put parentheses or a space even after `+` operator"
@@ -6654,8 +6654,8 @@ parser_lex(yp_parser_t *parser) {
 
                     bool spcarg = lex_state_spcarg_p(parser, space_seen);
                     if (spcarg) {
-                        yp_diagnostic_list_append(
-                            &parser->warning_list,
+                        yp_diagnostic_warning_list_append(
+                            parser,
                             parser->current.start,
                             parser->current.end,
                             "ambiguous first argument; put parentheses or a space even after `-` operator"
@@ -6756,7 +6756,7 @@ parser_lex(yp_parser_t *parser) {
                     }
 
                     if (lex_state_spcarg_p(parser, space_seen)) {
-                        yp_diagnostic_list_append(&parser->warning_list, parser->current.start, parser->current.end, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
+                        yp_diagnostic_warning_list_append(parser, parser->current.start, parser->current.end, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
                         lex_mode_push_regexp(parser, '\0', '/');
                         LEX(YP_TOKEN_REGEXP_BEGIN);
                     }
@@ -6795,7 +6795,7 @@ parser_lex(yp_parser_t *parser) {
                     // going to say it's the percent operator because we don't want to move into the
                     // string lex mode unnecessarily.
                     if ((lex_state_beg_p(parser) || lex_state_arg_p(parser)) && (parser->current.end >= parser->end)) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected end of input");
+                        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unexpected end of input");
                         LEX(YP_TOKEN_PERCENT);
                     }
 
@@ -6920,7 +6920,7 @@ parser_lex(yp_parser_t *parser) {
                                 // unparseable. In this case we'll just drop it from the parser
                                 // and skip past it and hope that the next token is something
                                 // that we can parse.
-                                yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid %% token");
+                                yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid %% token");
                                 goto lex_next_token;
                         }
                     }
@@ -6956,7 +6956,7 @@ parser_lex(yp_parser_t *parser) {
                         // token as we've exhausted all of the other options. We'll skip past
                         // it and return the next token.
                         if (!width) {
-                            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid token.");
+                            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid token.");
                             goto lex_next_token;
                         }
 
@@ -7905,7 +7905,7 @@ static void
 expect(yp_parser_t *parser, yp_token_type_t type, const char *message) {
     if (accept(parser, type)) return;
 
-    yp_diagnostic_list_append(&parser->error_list, parser->previous.end, parser->previous.end, message);
+    yp_diagnostic_error_list_append(parser, parser->previous.end, parser->previous.end, message);
 
     parser->previous =
         (yp_token_t) { .type = YP_TOKEN_MISSING, .start = parser->previous.end, .end = parser->previous.end };
@@ -7925,7 +7925,7 @@ expect_any(yp_parser_t *parser, const char*message, size_t count, ...) {
 
     va_end(types);
 
-    yp_diagnostic_list_append(&parser->error_list, parser->previous.end, parser->previous.end, message);
+    yp_diagnostic_error_list_append(parser, parser->previous.end, parser->previous.end, message);
     parser->previous =
         (yp_token_t) { .type = YP_TOKEN_MISSING, .start = parser->previous.end, .end = parser->previous.end };
 }
@@ -8041,7 +8041,7 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
             /* fallthrough */
         case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
             assert(sizeof(yp_global_variable_target_node_t) == sizeof(yp_numbered_reference_read_node_t));
-            yp_diagnostic_list_append(&parser->error_list, target->location.start, target->location.end, "Can't set variable");
+            yp_diagnostic_error_list_append(parser, target->location.start, target->location.end, "Can't set variable");
             /* fallthrough */
         case YP_NODE_GLOBAL_VARIABLE_READ_NODE:
             assert(sizeof(yp_global_variable_target_node_t) == sizeof(yp_global_variable_read_node_t));
@@ -8104,7 +8104,7 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
                     target->type = YP_NODE_LOCAL_VARIABLE_TARGET_NODE;
 
                     if (token_is_numbered_parameter(message.start, message.end)) {
-                        yp_diagnostic_list_append(&parser->error_list, message.start, message.end, "reserved for numbered parameter");
+                        yp_diagnostic_error_list_append(parser, message.start, message.end, "reserved for numbered parameter");
                     }
 
                     return target;
@@ -8148,7 +8148,7 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
             // In this case we have a node that we don't know how to convert
             // into a target. We need to treat it as an error. For now, we'll
             // mark it as an error and just skip right past it.
-            yp_diagnostic_list_append(&parser->error_list, target->location.start, target->location.end, "Unexpected write target.");
+            yp_diagnostic_error_list_append(parser, target->location.start, target->location.end, "Unexpected write target.");
             return target;
     }
 }
@@ -8173,7 +8173,7 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
         }
         case YP_NODE_BACK_REFERENCE_READ_NODE:
         case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
-            yp_diagnostic_list_append(&parser->error_list, target->location.start, target->location.end, "Can't set variable");
+            yp_diagnostic_error_list_append(parser, target->location.start, target->location.end, "Can't set variable");
             /* fallthrough */
         case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
             yp_global_variable_write_node_t *node = yp_global_variable_write_node_create(parser, target, operator, value);
@@ -8245,7 +8245,7 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
                     target = (yp_node_t *) yp_local_variable_write_node_create(parser, constant_id, 0, value, &message, operator);
 
                     if (token_is_numbered_parameter(message.start, message.end)) {
-                        yp_diagnostic_list_append(&parser->error_list, message.start, message.end, "reserved for numbered parameter");
+                        yp_diagnostic_error_list_append(parser, message.start, message.end, "reserved for numbered parameter");
                     }
 
                     return target;
@@ -8318,7 +8318,7 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
             // In this case we have a node that we don't know how to convert into a
             // target. We need to treat it as an error. For now, we'll mark it as an
             // error and just skip right past it.
-            yp_diagnostic_list_append(&parser->error_list, operator->start, operator->end, "Unexpected `='.");
+            yp_diagnostic_error_list_append(parser, operator->start, operator->end, "Unexpected `='.");
             return target;
     }
 }
@@ -8363,7 +8363,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                 // others yet.
 
                 if (has_splat) {
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Multiple splats in multi-assignment.");
+                    yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Multiple splats in multi-assignment.");
                 }
 
                 yp_token_t star_operator = parser->previous;
@@ -8429,7 +8429,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                         // If we get here, then we weren't able to parse anything at all, so
                         // we need to return a missing node.
                         yp_node_destroy(parser, (yp_node_t *) result);
-                        yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Expected index after for.");
+                        yp_diagnostic_error_list_append(parser, operator.start, operator.end, "Expected index after for.");
                         return (yp_node_t *) yp_missing_node_create(parser, operator.start, operator.end);
                     }
 
@@ -8539,7 +8539,7 @@ parse_assocs(yp_parser_t *parser, yp_node_t *node) {
                 if (token_begins_expression_p(parser->current.type)) {
                     value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an expression after ** in hash.");
                 } else if (yp_parser_local_depth(parser, &operator) == -1) {
-                    yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Expected an expression after ** in hash.");
+                    yp_diagnostic_error_list_append(parser, operator.start, operator.end, "Expected an expression after ** in hash.");
                 }
 
                 element = (yp_node_t *) yp_assoc_splat_node_create(parser, value, &operator);
@@ -8618,7 +8618,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
 
     while (!match_type_p(parser, YP_TOKEN_EOF)) {
         if (parsed_block_argument) {
-            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected argument after block argument.");
+            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unexpected argument after block argument.");
         }
 
         yp_node_t *argument = NULL;
@@ -8627,7 +8627,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
             case YP_TOKEN_USTAR_STAR:
             case YP_TOKEN_LABEL: {
                 if (parsed_bare_hash) {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected bare hash.");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unexpected bare hash.");
                 }
 
                 yp_keyword_hash_node_t *hash = yp_keyword_hash_node_create(parser);
@@ -8648,7 +8648,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                 if (token_begins_expression_p(parser->current.type)) {
                     expression = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected to be able to parse an argument.");
                 } else if (yp_parser_local_depth(parser, &operator) == -1) {
-                    yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "unexpected & when parent method is not forwarding.");
+                    yp_diagnostic_error_list_append(parser, operator.start, operator.end, "unexpected & when parent method is not forwarding.");
                 }
 
                 argument = (yp_node_t *)yp_block_argument_node_create(parser, &operator, expression);
@@ -8662,7 +8662,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
 
                 if (match_any_type_p(parser, 2, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_COMMA)) {
                     if (yp_parser_local_depth(parser, &parser->previous) == -1) {
-                        yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "unexpected * when parent method is not forwarding.");
+                        yp_diagnostic_error_list_append(parser, operator.start, operator.end, "unexpected * when parent method is not forwarding.");
                     }
 
                     argument = (yp_node_t *) yp_splat_node_create(parser, &operator, NULL);
@@ -8670,7 +8670,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                     yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");
 
                     if (parsed_bare_hash) {
-                        yp_diagnostic_list_append(&parser->error_list, operator.start, expression->location.end, "Unexpected splat argument after double splat.");
+                        yp_diagnostic_error_list_append(parser, operator.start, expression->location.end, "Unexpected splat argument after double splat.");
                     }
 
                     argument = (yp_node_t *) yp_splat_node_create(parser, &operator, expression);
@@ -8690,7 +8690,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                         argument = (yp_node_t *) yp_range_node_create(parser, NULL, &operator, right);
                     } else {
                         if (yp_parser_local_depth(parser, &parser->previous) == -1) {
-                            yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "unexpected ... when parent method is not forwarding.");
+                            yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "unexpected ... when parent method is not forwarding.");
                         }
 
                         argument = (yp_node_t *)yp_forwarding_arguments_node_create(parser, &parser->previous);
@@ -8706,7 +8706,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
 
                 if (yp_symbol_node_label_p(argument) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
                     if (parsed_bare_hash) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected bare hash argument.");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected bare hash argument.");
                     }
 
                     yp_token_t operator;
@@ -8786,7 +8786,7 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
 
         if (node->parameters.size > 0 && match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
             if (parsed_splat) {
-                yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected splat after splat.");
+                yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected splat after splat.");
             }
 
             param = (yp_node_t *) yp_splat_node_create(parser, &parser->previous, NULL);
@@ -8798,7 +8798,7 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
             param = (yp_node_t *) parse_required_destructured_parameter(parser);
         } else if (accept(parser, YP_TOKEN_USTAR)) {
             if (parsed_splat) {
-                yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected splat after splat.");
+                yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected splat after splat.");
             }
 
             yp_token_t star = parser->previous;
@@ -8878,12 +8878,12 @@ update_parameter_state(yp_parser_t *parser, yp_token_t *token, yp_parameters_ord
     }
 
     if (token->type == YP_TOKEN_USTAR && *current == YP_PARAMETERS_ORDER_AFTER_OPTIONAL) {
-        yp_diagnostic_list_append(&parser->error_list, token->start, token->end, "Unexpected parameter *");
+        yp_diagnostic_error_list_append(parser, token->start, token->end, "Unexpected parameter *");
     }
 
     if (*current == YP_PARAMETERS_ORDER_NOTHING_AFTER || state > *current) {
         // We know what transition we failed on, so we can provide a better error here.
-        yp_diagnostic_list_append(&parser->error_list, token->start, token->end, "Unexpected parameter order");
+        yp_diagnostic_error_list_append(parser, token->start, token->end, "Unexpected parameter order");
     } else if (state < *current) {
         *current = state;
     }
@@ -8938,7 +8938,7 @@ parse_parameters(
                 if (params->block == NULL) {
                     yp_parameters_node_block_set(params, param);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, param->base.location.start, param->base.location.end, "Unexpected multiple block parameter");
+                    yp_diagnostic_error_list_append(parser, param->base.location.start, param->base.location.end, "Unexpected multiple block parameter");
                     yp_parameters_node_posts_append(params, (yp_node_t *) param);
                 }
 
@@ -8946,7 +8946,7 @@ parse_parameters(
             }
             case YP_TOKEN_UDOT_DOT_DOT: {
                 if (!allows_forwarding_parameter) {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected ...");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unexpected ...");
                 }
                 if (order > YP_PARAMETERS_ORDER_NOTHING_AFTER) {
                     update_parameter_state(parser, &parser->current, &order);
@@ -8969,16 +8969,16 @@ parse_parameters(
                 parser_lex(parser);
                 switch (parser->previous.type) {
                     case YP_TOKEN_CONSTANT:
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Formal argument cannot be a constant");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Formal argument cannot be a constant");
                         break;
                     case YP_TOKEN_INSTANCE_VARIABLE:
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Formal argument cannot be an instance variable");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Formal argument cannot be an instance variable");
                         break;
                     case YP_TOKEN_GLOBAL_VARIABLE:
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Formal argument cannot be a global variable");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Formal argument cannot be a global variable");
                         break;
                     case YP_TOKEN_CLASS_VARIABLE:
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Formal argument cannot be a class variable");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Formal argument cannot be a class variable");
                         break;
                     default: break;
                 }
@@ -9095,7 +9095,7 @@ parse_parameters(
                 if (params->rest == NULL) {
                     yp_parameters_node_rest_set(params, param);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, param->base.location.start, param->base.location.end, "Unexpected multiple splat parameters.");
+                    yp_diagnostic_error_list_append(parser, param->base.location.start, param->base.location.end, "Unexpected multiple splat parameters.");
                     yp_parameters_node_posts_append(params, (yp_node_t *) param);
                 }
 
@@ -9129,7 +9129,7 @@ parse_parameters(
                 if (params->keyword_rest == NULL) {
                     yp_parameters_node_keyword_rest_set(params, param);
                 } else {
-                    yp_diagnostic_list_append(&parser->error_list, param->location.start, param->location.end, "Unexpected multiple double splat parameters.");
+                    yp_diagnostic_error_list_append(parser, param->location.start, param->location.end, "Unexpected multiple double splat parameters.");
                     yp_parameters_node_posts_append(params, param);
                 }
 
@@ -9147,11 +9147,11 @@ parse_parameters(
                         if (params->rest == NULL) {
                             yp_parameters_node_rest_set(params, param);
                         } else {
-                            yp_diagnostic_list_append(&parser->error_list, param->base.location.start, param->base.location.end, "Unexpected multiple splat parameters.");
+                            yp_diagnostic_error_list_append(parser, param->base.location.start, param->base.location.end, "Unexpected multiple splat parameters.");
                             yp_parameters_node_posts_append(params, (yp_node_t *) param);
                         }
                     } else {
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected ','.");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected ','.");
                     }
                 }
 
@@ -9778,7 +9778,7 @@ parse_string_part(yp_parser_t *parser) {
         }
         default:
             parser_lex(parser);
-            yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Could not understand string part");
+            yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Could not understand string part");
             return NULL;
     }
 }
@@ -9896,7 +9896,7 @@ parse_undef_argument(yp_parser_t *parser) {
             return parse_symbol(parser, &lex_mode, YP_LEX_STATE_NONE);
         }
         default:
-            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Expected a bare word or symbol argument.");
+            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Expected a bare word or symbol argument.");
             return (yp_node_t *) yp_missing_node_create(parser, parser->current.start, parser->current.end);
     }
 }
@@ -9938,7 +9938,7 @@ parse_alias_argument(yp_parser_t *parser, bool first) {
             parser_lex(parser);
             return (yp_node_t *) yp_global_variable_read_node_create(parser, &parser->previous);
         default:
-            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Expected a bare word, symbol or global variable argument.");
+            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Expected a bare word, symbol or global variable argument.");
             return (yp_node_t *) yp_missing_node_create(parser, parser->current.start, parser->current.end);
     }
 }
@@ -10470,13 +10470,13 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
                     case YP_TOKEN_STRING_BEGIN:
                         key = parse_expression(parser, YP_BINDING_POWER_MAX, "Expected a key in the hash pattern.");
                         if (!yp_symbol_node_label_p(key)) {
-                            yp_diagnostic_list_append(&parser->error_list, key->location.start, key->location.end, "Expected a label as the key in the hash pattern.");
+                            yp_diagnostic_error_list_append(parser, key->location.start, key->location.end, "Expected a label as the key in the hash pattern.");
                         }
 
                         break;
                     default:
                         parser_lex(parser);
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Expected a key in the hash pattern.");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Expected a key in the hash pattern.");
                         key = (yp_node_t *) yp_missing_node_create(parser, parser->previous.start, parser->previous.end);
                         break;
                 }
@@ -10511,7 +10511,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
                     return (yp_node_t *) yp_range_node_create(parser, NULL, &operator, right);
                 }
                 default: {
-                    yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Expected an expression after the range operator.");
+                    yp_diagnostic_error_list_append(parser, operator.start, operator.end, "Expected an expression after the range operator.");
                     yp_node_t *right = (yp_node_t *) yp_missing_node_create(parser, operator.start, operator.end);
                     return (yp_node_t *) yp_range_node_create(parser, NULL, &operator, right);
                 }
@@ -10599,7 +10599,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
                 default: {
                     // If we get here, then we have a pin operator followed by something
                     // not understood. We'll create a missing node and return that.
-                    yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Expected a variable after the pin operator.");
+                    yp_diagnostic_error_list_append(parser, operator.start, operator.end, "Expected a variable after the pin operator.");
                     yp_node_t *variable = (yp_node_t *) yp_missing_node_create(parser, operator.start, operator.end);
                     return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
                 }
@@ -10623,7 +10623,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
             return parse_pattern_constant_path(parser, node);
         }
         default:
-            yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, message);
+            yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, message);
             return (yp_node_t *) yp_missing_node_create(parser, parser->current.start, parser->current.end);
     }
 }
@@ -10667,7 +10667,7 @@ parse_pattern_primitives(yp_parser_t *parser, const char *message) {
                 break;
             }
             default: {
-                yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, message);
+                yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, message);
                 yp_node_t *right = (yp_node_t *) yp_missing_node_create(parser, parser->current.start, parser->current.end);
 
                 if (node == NULL) {
@@ -10759,7 +10759,7 @@ parse_pattern(yp_parser_t *parser, bool top_pattern, const char *message) {
                 // will continue to parse the rest of the patterns, but we will indicate
                 // it as an error.
                 if (trailing_rest) {
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected rest pattern.");
+                    yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected rest pattern.");
                 }
 
                 trailing_rest = true;
@@ -10848,7 +10848,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     element = (yp_node_t *) yp_splat_node_create(parser, &operator, expression);
                 } else if (match_any_type_p(parser, 2, YP_TOKEN_LABEL, YP_TOKEN_USTAR_STAR)) {
                     if (parsed_bare_hash) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Unexpected bare hash.");
+                        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Unexpected bare hash.");
                     }
 
                     yp_keyword_hash_node_t *hash = yp_keyword_hash_node_create(parser);
@@ -10864,7 +10864,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
                     if (yp_symbol_node_label_p(element) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
                         if (parsed_bare_hash) {
-                            yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected bare hash.");
+                            yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected bare hash.");
                         }
 
                         yp_keyword_hash_node_t *hash = yp_keyword_hash_node_create(parser);
@@ -11284,7 +11284,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 case YP_NODE_SYMBOL_NODE:
                 case YP_NODE_INTERPOLATED_SYMBOL_NODE: {
                     if (!YP_NODE_TYPE_P(old_name, YP_NODE_SYMBOL_NODE) && !YP_NODE_TYPE_P(old_name, YP_NODE_INTERPOLATED_SYMBOL_NODE)) {
-                        yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, "Expected a bare word or symbol argument.");
+                        yp_diagnostic_error_list_append(parser, old_name->location.start, old_name->location.end, "Expected a bare word or symbol argument.");
                     }
                     break;
                 }
@@ -11293,10 +11293,10 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     if (YP_NODE_TYPE_P(old_name, YP_NODE_BACK_REFERENCE_READ_NODE) || YP_NODE_TYPE_P(old_name, YP_NODE_NUMBERED_REFERENCE_READ_NODE) || YP_NODE_TYPE_P(old_name, YP_NODE_GLOBAL_VARIABLE_READ_NODE)) {
                         if (YP_NODE_TYPE_P(old_name, YP_NODE_NUMBERED_REFERENCE_READ_NODE)) {
-                            yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, "Can't make alias for number variables.");
+                            yp_diagnostic_error_list_append(parser, old_name->location.start, old_name->location.end, "Can't make alias for number variables.");
                         }
                     } else {
-                        yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, "Expected a global variable.");
+                        yp_diagnostic_error_list_append(parser, old_name->location.start, old_name->location.end, "Expected a global variable.");
                     }
                     break;
                 }
@@ -11432,7 +11432,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             if (accept(parser, YP_TOKEN_KEYWORD_ELSE)) {
                 if (case_node->conditions.size < 1) {
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected else without no when clauses in case statement.");
+                    yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected else without no when clauses in case statement.");
                 }
 
                 yp_token_t else_keyword = parser->previous;
@@ -11473,8 +11473,8 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_begin_node_end_keyword_set(begin_node, &parser->previous);
 
             if ((begin_node->else_clause != NULL) && (begin_node->rescue_clause == NULL)) {
-                yp_diagnostic_list_append(
-                    &parser->error_list,
+                yp_diagnostic_error_list_append(
+                    parser,
                     begin_node->else_clause->base.location.start,
                     begin_node->else_clause->base.location.end,
                     "else without rescue is useless"
@@ -11524,7 +11524,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                         (parser->current_context->context == YP_CONTEXT_CLASS) ||
                         (parser->current_context->context == YP_CONTEXT_MODULE)
                     ) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid return in class/module body");
+                        yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Invalid return in class/module body");
                     }
                     return (yp_node_t *) yp_return_node_create(parser, &keyword, arguments.arguments);
                 }
@@ -11590,7 +11590,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *constant_path = parse_expression(parser, YP_BINDING_POWER_INDEX, "Expected to find a class name after `class`.");
             yp_token_t name = parser->previous;
             if (name.type != YP_TOKEN_CONSTANT) {
-                yp_diagnostic_list_append(&parser->error_list, name.start, name.end, "Expected a constant name after `class`.");
+                yp_diagnostic_error_list_append(parser, name.start, name.end, "Expected a constant name after `class`.");
             }
 
             yp_token_t inheritance_operator;
@@ -11627,7 +11627,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
 
             if (context_def_p(parser)) {
-                yp_diagnostic_list_append(&parser->error_list, class_keyword.start, class_keyword.end, "Class definition in method body");
+                yp_diagnostic_error_list_append(parser, class_keyword.start, class_keyword.end, "Class definition in method body");
             }
 
             yp_constant_id_list_t locals = parser->current_scope->locals;
@@ -11666,7 +11666,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                         name = parse_method_definition_name(parser);
 
                         if (name.type == YP_TOKEN_MISSING) {
-                            yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
+                            yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
                         }
                     } else {
                         name = parser->previous;
@@ -11734,7 +11734,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
                         name = parse_method_definition_name(parser);
                         if (name.type == YP_TOKEN_MISSING) {
-                            yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
+                            yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
                         }
                     } else {
                         name = identifier;
@@ -11764,7 +11764,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     name = parse_method_definition_name(parser);
 
                     if (name.type == YP_TOKEN_MISSING) {
-                        yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
+                        yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Expected a method name after receiver.");
                     }
                     break;
             }
@@ -11818,7 +11818,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             if (accept(parser, YP_TOKEN_EQUAL)) {
                 if (token_is_setter_name(&name)) {
-                    yp_diagnostic_list_append(&parser->error_list, name.start, name.end, "Setter method cannot be defined in an endless method definition");
+                    yp_diagnostic_error_list_append(parser, name.start, name.end, "Setter method cannot be defined in an endless method definition");
                 }
                 equal = parser->previous;
 
@@ -12053,7 +12053,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // syntax error. We handle that here as well.
             name = parser->previous;
             if (name.type != YP_TOKEN_CONSTANT) {
-                yp_diagnostic_list_append(&parser->error_list, name.start, name.end, "Expected to find a module name after `module`.");
+                yp_diagnostic_error_list_append(parser, name.start, name.end, "Expected to find a module name after `module`.");
             }
 
             yp_parser_scope_push(parser, true);
@@ -12077,7 +12077,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `module` statement.");
 
             if (context_def_p(parser)) {
-                yp_diagnostic_list_append(&parser->error_list, module_keyword.start, module_keyword.end, "Module definition in method body");
+                yp_diagnostic_error_list_append(parser, module_keyword.start, module_keyword.end, "Module definition in method body");
             }
 
             return (yp_node_t *) yp_module_node_create(parser, &locals, &module_keyword, constant_path, &name, statements, &parser->previous);
@@ -12878,7 +12878,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     // parsed. If it cannot be concatenated with the previous
                     // node, then we'll need to add a syntax error.
                     if (!YP_NODE_TYPE_P(node, YP_NODE_STRING_NODE) && !YP_NODE_TYPE_P(node, YP_NODE_INTERPOLATED_STRING_NODE)) {
-                        yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Unexpected string concatenation.");
+                        yp_diagnostic_error_list_append(parser, node->location.start, node->location.end, "Unexpected string concatenation.");
                     }
 
                     // Either way we will create a concat node to hold the
@@ -12967,7 +12967,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an = sign, but we don't know what it's for. We
                     // need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected `='.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Unexpected `='.");
                     return node;
             }
         }
@@ -12975,7 +12975,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             switch (YP_NODE_TYPE(node)) {
                 case YP_NODE_BACK_REFERENCE_READ_NODE:
                 case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
-                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
+                    yp_diagnostic_error_list_append(parser, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
                 case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
@@ -13040,7 +13040,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                         yp_constant_id_t constant_id = yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
 
                         if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
-                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                            yp_diagnostic_error_list_append(parser, message_loc.start, message_loc.end, "reserved for numbered parameter");
                         }
 
                         parser_lex(parser);
@@ -13059,7 +13059,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                 }
                 case YP_NODE_MULTI_WRITE_NODE: {
                     parser_lex(parser);
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Cannot use `&&=' on a multi-write.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Cannot use `&&=' on a multi-write.");
                     return node;
                 }
                 default:
@@ -13068,7 +13068,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an &&= sign, but we don't know what it's for.
                     // We need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected `&&='.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Unexpected `&&='.");
                     return node;
             }
         }
@@ -13076,7 +13076,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             switch (YP_NODE_TYPE(node)) {
                 case YP_NODE_BACK_REFERENCE_READ_NODE:
                 case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
-                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
+                    yp_diagnostic_error_list_append(parser, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
                 case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
@@ -13141,7 +13141,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                         yp_constant_id_t constant_id = yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
 
                         if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
-                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                            yp_diagnostic_error_list_append(parser, message_loc.start, message_loc.end, "reserved for numbered parameter");
                         }
 
                         parser_lex(parser);
@@ -13160,7 +13160,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                 }
                 case YP_NODE_MULTI_WRITE_NODE: {
                     parser_lex(parser);
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Cannot use `||=' on a multi-write.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Cannot use `||=' on a multi-write.");
                     return node;
                 }
                 default:
@@ -13169,7 +13169,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an ||= sign, but we don't know what it's for.
                     // We need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected `||='.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Unexpected `||='.");
                     return node;
             }
         }
@@ -13187,7 +13187,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             switch (YP_NODE_TYPE(node)) {
                 case YP_NODE_BACK_REFERENCE_READ_NODE:
                 case YP_NODE_NUMBERED_REFERENCE_READ_NODE:
-                    yp_diagnostic_list_append(&parser->error_list, node->location.start, node->location.end, "Can't set variable");
+                    yp_diagnostic_error_list_append(parser, node->location.start, node->location.end, "Can't set variable");
                 /* fallthrough */
                 case YP_NODE_GLOBAL_VARIABLE_READ_NODE: {
                     parser_lex(parser);
@@ -13252,7 +13252,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                         yp_constant_id_t constant_id = yp_parser_local_add_location(parser, message_loc.start, message_loc.end);
 
                         if (token_is_numbered_parameter(message_loc.start, message_loc.end)) {
-                            yp_diagnostic_list_append(&parser->error_list, message_loc.start, message_loc.end, "reserved for numbered parameter");
+                            yp_diagnostic_error_list_append(parser, message_loc.start, message_loc.end, "reserved for numbered parameter");
                         }
 
                         parser_lex(parser);
@@ -13271,7 +13271,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                 }
                 case YP_NODE_MULTI_WRITE_NODE: {
                     parser_lex(parser);
-                    yp_diagnostic_list_append(&parser->error_list, token.start, token.end, "Unexpected operator.");
+                    yp_diagnostic_error_list_append(parser, token.start, token.end, "Unexpected operator.");
                     return node;
                 }
                 default:
@@ -13280,7 +13280,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     // In this case we have an operator but we don't know what it's for.
                     // We need to treat it as an error. For now, we'll mark it as an error
                     // and just skip right past it.
-                    yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, "Unexpected operator.");
+                    yp_diagnostic_error_list_append(parser, parser->previous.start, parser->previous.end, "Unexpected operator.");
                     return node;
             }
         }
@@ -13384,7 +13384,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     break;
                 }
                 default: {
-                    yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Expected a valid method name");
+                    yp_diagnostic_error_list_append(parser, parser->current.start, parser->current.end, "Expected a valid method name");
                     message = (yp_token_t) { .type = YP_TOKEN_MISSING, .start = parser->previous.end, .end = parser->previous.end };
                 }
             }
@@ -13534,7 +13534,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     return (yp_node_t *) yp_call_node_shorthand_create(parser, node, &delimiter, &arguments);
                 }
                 default: {
-                    yp_diagnostic_list_append(&parser->error_list, delimiter.start, delimiter.end, "Expected identifier or constant after '::'");
+                    yp_diagnostic_error_list_append(parser, delimiter.start, delimiter.end, "Expected identifier or constant after '::'");
                     yp_node_t *child = (yp_node_t *) yp_missing_node_create(parser, delimiter.start, delimiter.end);
                     return (yp_node_t *)yp_constant_path_node_create(parser, node, &delimiter, child);
                 }
@@ -13635,7 +13635,7 @@ parse_expression(yp_parser_t *parser, yp_binding_power_t binding_power, const ch
     // parse_expression_prefix is going to be a missing node. In that case we need
     // to add the error message to the parser's error list.
     if (YP_NODE_TYPE_P(node, YP_NODE_MISSING_NODE)) {
-        yp_diagnostic_list_append(&parser->error_list, recovery.end, recovery.end, message);
+        yp_diagnostic_error_list_append(parser, recovery.end, recovery.end, message);
         return node;
     }
 


### PR DESCRIPTION
This has the side effect of using parser instead of the error list directly making arena allocation easier.

Alternative to make https://github.com/ruby/yarp/pull/1395 easier.