### PR TITLE
Constant on block parameter node

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -549,6 +549,8 @@ nodes:
                      ^^^^^^^^^^^^^^
   - name: BlockParameterNode
     fields:
+      - name: name
+        type: constant?
       - name: name_loc
         type: location?
       - name: operator_loc

--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -25,6 +25,9 @@ enum NodeFieldType {
     #[serde(rename = "constant")]
     Constant,
 
+    #[serde(rename = "constant?")]
+    OptionalConstant,
+
     #[serde(rename = "constant[]")]
     ConstantList,
 
@@ -226,6 +229,16 @@ fn write_node(file: &mut File, node: &Node) -> Result<(), Box<dyn std::error::Er
             NodeFieldType::Constant => {
                 writeln!(file, "    pub fn {}(&self) -> ConstantId<'pr> {{", field.name)?;
                 writeln!(file, "        ConstantId::new(self.parser, unsafe {{ (*self.pointer).{} }})", field.name)?;
+                writeln!(file, "    }}")?;
+            },
+            NodeFieldType::OptionalConstant => {
+                writeln!(file, "    pub fn {}(&self) -> Option<ConstantId<'pr>> {{", field.name)?;
+                writeln!(file, "        let id = unsafe {{ (*self.pointer).{} }};", field.name)?;
+                writeln!(file, "        if id == 0 {{")?;
+                writeln!(file, "            None")?;
+                writeln!(file, "        }} else {{")?;
+                writeln!(file, "            Some(ConstantId::new(self.parser, id))")?;
+                writeln!(file, "        }}")?;
                 writeln!(file, "    }}")?;
             },
             NodeFieldType::ConstantList => {

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -437,6 +437,13 @@ yp_parser_constant_id_token(yp_parser_t *parser, const yp_token_t *token) {
     return yp_parser_constant_id_location(parser, token->start, token->end);
 }
 
+// Retrieve the constant pool id for the given token. If the token is not
+// provided, then return 0.
+static inline yp_constant_id_t
+yp_parser_optional_constant_id_token(yp_parser_t *parser, const yp_token_t *token) {
+    return token->type == YP_TOKEN_NOT_PROVIDED ? 0 : yp_parser_constant_id_token(parser, token);
+}
+
 // Mark any range nodes in this subtree as flipflops.
 static void
 yp_flip_flop(yp_node_t *node) {
@@ -1134,6 +1141,7 @@ yp_block_parameter_node_create(yp_parser_t *parser, const yp_token_t *name, cons
                 .end = (name->type == YP_TOKEN_NOT_PROVIDED ? operator->end : name->end)
             },
         },
+        .name = yp_parser_optional_constant_id_token(parser, name),
         .name_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(name),
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
     };

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -154,6 +154,8 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     argv[<%= index %>] = yp_string_new(&cast-><%= field.name %>, encoding);
                     <%- when YARP::ConstantField -%>
                     argv[<%= index %>] = rb_id2sym(constants[cast-><%= field.name %> - 1]);
+                    <%- when YARP::OptionalConstantField -%>
+                    argv[<%= index %>] = cast-><%= field.name %> == 0 ? Qnil : rb_id2sym(constants[cast-><%= field.name %> - 1]);
                     <%- when YARP::ConstantListField -%>
                     argv[<%= index %>] = rb_ary_new_capa(cast-><%= field.name %>.size);
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -95,7 +95,7 @@ typedef struct yp_<%= node.human %> {
     <%= case field
     when YARP::NodeField, YARP::OptionalNodeField then "struct #{field.c_type} *#{field.name}"
     when YARP::NodeListField then "struct yp_node_list #{field.name}"
-    when YARP::ConstantField then "yp_constant_id_t #{field.name}"
+    when YARP::ConstantField, YARP::OptionalConstantField then "yp_constant_id_t #{field.name}"
     when YARP::ConstantListField then "yp_constant_id_list_t #{field.name}"
     when YARP::StringField then "yp_string_t #{field.name}"
     when YARP::LocationField, YARP::OptionalLocationField then "yp_location_t #{field.name}"

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -187,6 +187,15 @@ public class Loader {
         return constantPool.get(buffer, loadVarInt());
     }
 
+    private byte[] loadOptionalConstant() {
+        if (buffer.get(buffer.position()) != 0) {
+            return loadConstant();
+        } else {
+            buffer.position(buffer.position() + 1); // continue after the 0 byte
+            return null;
+        }
+    }
+
     private byte[][] loadConstants() {
         int length = loadVarInt();
         if (length == 0) {
@@ -264,6 +273,7 @@ public class Loader {
               when YARP::StringField then "loadString()"
               when YARP::NodeListField then "loadNodes()"
               when YARP::ConstantField then "loadConstant()"
+              when YARP::OptionalConstantField then "loadOptionalConstant()"
               when YARP::ConstantListField then "loadConstants()"
               when YARP::LocationField then "loadLocation()"
               when YARP::OptionalLocationField then "loadOptionalLocation()"

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -112,7 +112,7 @@ module YARP
         inspector << "<%= pointer %><%= field.name %>:\n"
         inspector << <%= field.name %>.inspect(inspector.child_inspector("<%= preadd %>")).delete_prefix(inspector.prefix)
       end
-      <%- when YARP::ConstantField, YARP::StringField, YARP::UInt32Field -%>
+      <%- when YARP::ConstantField, YARP::OptionalConstantField, YARP::StringField, YARP::UInt32Field -%>
       inspector << "<%= pointer %><%= field.name %>: #{<%= field.name %>.inspect}\n"
       <%- when YARP::FlagsField -%>
       <%- flag = flags.find { |flag| flag.name == field.kind }.tap { |flag| raise unless flag } -%>

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -152,8 +152,7 @@ module YARP
         load_location if io.getbyte != 0
       end
 
-      def load_constant
-        index = load_varint - 1
+      def load_constant(index)
         constant = constant_pool[index]
 
         unless constant
@@ -167,6 +166,15 @@ module YARP
         end
 
         constant
+      end
+
+      def load_required_constant
+        load_constant(load_varint - 1)
+      end
+
+      def load_optional_constant
+        index = load_varint
+        load_constant(index - 1) if index != 0
       end
 
       def load_node
@@ -185,8 +193,9 @@ module YARP
             when YARP::OptionalNodeField then "load_optional_node"
             when YARP::StringField then "load_string"
             when YARP::NodeListField then "Array.new(load_varint) { load_node }"
-            when YARP::ConstantField then "load_constant"
-            when YARP::ConstantListField then "Array.new(load_varint) { load_constant }"
+            when YARP::ConstantField then "load_required_constant"
+            when YARP::OptionalConstantField then "load_optional_constant"
+            when YARP::ConstantListField then "Array.new(load_varint) { load_required_constant }"
             when YARP::LocationField then "load_location"
             when YARP::OptionalLocationField then "load_optional_location"
             when YARP::UInt32Field, YARP::FlagsField then "load_varint"

--- a/templates/src/node.c.erb
+++ b/templates/src/node.c.erb
@@ -55,12 +55,12 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
         <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
         case <%= node.type %>: {
-            <%- if node.fields.any? { |field| ![YARP::LocationField, YARP::OptionalLocationField, YARP::UInt32Field, YARP::FlagsField, YARP::ConstantField].include?(field.class) } -%>
+            <%- if node.fields.any? { |field| ![YARP::LocationField, YARP::OptionalLocationField, YARP::UInt32Field, YARP::FlagsField, YARP::ConstantField, YARP::OptionalConstantField].include?(field.class) } -%>
             yp_<%= node.human %>_t *cast = (yp_<%= node.human %>_t *) node;
             <%- end -%>
             <%- node.fields.each do |field| -%>
             <%- case field -%>
-            <%- when YARP::LocationField, YARP::OptionalLocationField, YARP::UInt32Field, YARP::FlagsField, YARP::ConstantField -%>
+            <%- when YARP::LocationField, YARP::OptionalLocationField, YARP::UInt32Field, YARP::FlagsField, YARP::ConstantField, YARP::OptionalConstantField -%>
             <%- when YARP::NodeField -%>
             yp_node_destroy(parser, (yp_node_t *)cast-><%= field.name %>);
             <%- when YARP::OptionalNodeField -%>
@@ -104,7 +104,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
             memsize->memsize += sizeof(*cast);
             <%- node.fields.each do |field| -%>
             <%- case field -%>
-            <%- when YARP::ConstantField, YARP::UInt32Field, YARP::FlagsField, YARP::LocationField, YARP::OptionalLocationField -%>
+            <%- when YARP::ConstantField, YARP::OptionalConstantField, YARP::UInt32Field, YARP::FlagsField, YARP::LocationField, YARP::OptionalLocationField -%>
             <%- when YARP::NodeField -%>
             yp_node_memsize_node((yp_node_t *)cast-><%= field.name %>, memsize);
             <%- when YARP::OptionalNodeField -%>

--- a/templates/src/prettyprint.c.erb
+++ b/templates/src/prettyprint.c.erb
@@ -49,6 +49,14 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
             char <%= field.name %>_buffer[12];
             snprintf(<%= field.name %>_buffer, sizeof(<%= field.name %>_buffer), "%u", ((yp_<%= node.human %>_t *)node)-><%= field.name %>);
             yp_buffer_append_str(buffer, <%= field.name %>_buffer, strlen(<%= field.name %>_buffer));
+            <%- when YARP::OptionalConstantField -%>
+            if (((yp_<%= node.human %>_t *)node)-><%= field.name %> == 0) {
+                yp_buffer_append_str(buffer, "nil", 3);
+            } else {
+                char <%= field.name %>_buffer[12];
+                snprintf(<%= field.name %>_buffer, sizeof(<%= field.name %>_buffer), "%u", ((yp_<%= node.human %>_t *)node)-><%= field.name %>);
+                yp_buffer_append_str(buffer, <%= field.name %>_buffer, strlen(<%= field.name %>_buffer));
+            }
             <%- when YARP::ConstantListField -%>
             yp_buffer_append_str(buffer, "[", 1);
             for (uint32_t index = 0; index < ((yp_<%= node.human %>_t *)node)-><%= field.name %>.size; index++) {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -86,7 +86,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
             for (uint32_t index = 0; index < <%= field.name %>_size; index++) {
                 yp_serialize_node(parser, (yp_node_t *) ((yp_<%= node.human %>_t *)node)-><%= field.name %>.nodes[index], buffer);
             }
-            <%- when YARP::ConstantField -%>
+            <%- when YARP::ConstantField, YARP::OptionalConstantField -%>
             yp_buffer_append_u32(buffer, yp_sizet_to_u32(((yp_<%= node.human %>_t *)node)-><%= field.name %>));
             <%- when YARP::ConstantListField -%>
             uint32_t <%= field.name %>_size = yp_sizet_to_u32(((yp_<%= node.human %>_t *)node)-><%= field.name %>.size);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -85,6 +85,18 @@ module YARP
     end
   end
 
+  # This represents a field on a node that is the ID of a string interned
+  # through the parser's constant pool and can be optionally null.
+  class OptionalConstantField < Field
+    def rbs_class
+      "Symbol?"
+    end
+
+    def java_type
+      "byte[]"
+    end
+  end
+
   # This represents a field on a node that is a list of IDs that are associated
   # with strings interned through the parser's constant pool.
   class ConstantListField < Field
@@ -195,6 +207,7 @@ module YARP
       when "node[]"     then NodeListField
       when "string"     then StringField
       when "constant"   then ConstantField
+      when "constant?"  then OptionalConstantField
       when "constant[]" then ConstantListField
       when "location"   then LocationField
       when "location?"  then OptionalLocationField
@@ -275,7 +288,8 @@ module YARP
 
       HEADING
 
-      heading = if File.extname(filepath.gsub(".erb", "")) == ".rb"
+      heading =
+        if File.extname(filepath.gsub(".erb", "")) == ".rb"
           ruby_heading
         else
           non_ruby_heading

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -644,7 +644,7 @@ module YARP
           nil,
           [],
           nil,
-          BlockParameterNode(Location(), Location())
+          BlockParameterNode(:block, Location(), Location())
         ),
         nil,
         [:block, :a],
@@ -664,7 +664,7 @@ module YARP
       expected = DefNode(
         Location(),
         nil,
-        ParametersNode([], [], [RequiredParameterNode(:a)], nil, [], nil, BlockParameterNode(nil, Location())),
+        ParametersNode([], [], [RequiredParameterNode(:a)], nil, [], nil, BlockParameterNode(nil, nil, Location())),
         nil,
         [:&, :a],
         Location(),
@@ -1087,7 +1087,7 @@ module YARP
       expected = DefNode(
         Location(),
         nil,
-        ParametersNode([RequiredParameterNode(:a), RequiredParameterNode(:b)], [], [], nil, [], nil, BlockParameterNode(Location(), Location())),
+        ParametersNode([RequiredParameterNode(:a), RequiredParameterNode(:b)], [], [], nil, [], nil, BlockParameterNode(:a, Location(), Location())),
         nil,
         [:a, :b],
         Location(),

--- a/test/yarp/snapshots/methods.txt
+++ b/test/yarp/snapshots/methods.txt
@@ -876,7 +876,7 @@ ProgramNode(0...1194)(
          nil,
          [],
          nil,
-         BlockParameterNode(789...791)((790...791), (789...790))
+         BlockParameterNode(789...791)(:b, (790...791), (789...790))
        ),
        nil,
        [:b],
@@ -897,7 +897,7 @@ ProgramNode(0...1194)(
          nil,
          [],
          nil,
-         BlockParameterNode(803...804)(nil, (803...804))
+         BlockParameterNode(803...804)(nil, nil, (803...804))
        ),
        nil,
        [:&],

--- a/test/yarp/snapshots/procs.txt
+++ b/test/yarp/snapshots/procs.txt
@@ -93,7 +93,7 @@ ProgramNode(0...266)(
            [KeywordParameterNode(113...115)((113...115), nil),
             KeywordParameterNode(117...119)((117...119), nil)],
            nil,
-           BlockParameterNode(121...123)((122...123), (121...122))
+           BlockParameterNode(121...123)(:e, (122...123), (121...122))
          ),
          [],
          nil,
@@ -120,7 +120,7 @@ ProgramNode(0...266)(
            [KeywordParameterNode(149...151)((149...151), nil),
             KeywordParameterNode(153...155)((153...155), nil)],
            KeywordRestParameterNode(157...160)((157...159), (159...160)),
-           BlockParameterNode(162...164)((163...164), (162...163))
+           BlockParameterNode(162...164)(:g, (163...164), (162...163))
          ),
          [],
          (134...135),
@@ -147,7 +147,7 @@ ProgramNode(0...266)(
            [KeywordParameterNode(191...193)((191...193), nil),
             KeywordParameterNode(195...197)((195...197), nil)],
            KeywordRestParameterNode(199...202)((199...201), (201...202)),
-           BlockParameterNode(204...206)((205...206), (204...205))
+           BlockParameterNode(204...206)(:g, (205...206), (204...205))
          ),
          [],
          (176...177),

--- a/test/yarp/snapshots/seattlerb/args_kw_block.txt
+++ b/test/yarp/snapshots/seattlerb/args_kw_block.txt
@@ -11,7 +11,7 @@ ProgramNode(0...20)(
          nil,
          [KeywordParameterNode(6...10)((6...8), IntegerNode(9...10)())],
          nil,
-         BlockParameterNode(12...14)((13...14), (12...13))
+         BlockParameterNode(12...14)(:b, (13...14), (12...13))
        ),
        nil,
        [:a, :b],

--- a/test/yarp/snapshots/seattlerb/block_arg__bare.txt
+++ b/test/yarp/snapshots/seattlerb/block_arg__bare.txt
@@ -11,7 +11,7 @@ ProgramNode(0...13)(
          nil,
          [],
          nil,
-         BlockParameterNode(6...7)(nil, (6...7))
+         BlockParameterNode(6...7)(nil, nil, (6...7))
        ),
        nil,
        [:&],

--- a/test/yarp/snapshots/seattlerb/block_arg_opt_arg_block.txt
+++ b/test/yarp/snapshots/seattlerb/block_arg_opt_arg_block.txt
@@ -23,7 +23,7 @@ ProgramNode(0...21)(
              nil,
              [],
              nil,
-             BlockParameterNode(16...18)((17...18), (16...17))
+             BlockParameterNode(16...18)(:e, (17...18), (16...17))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.txt
+++ b/test/yarp/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.txt
@@ -23,7 +23,7 @@ ProgramNode(0...25)(
              RestParameterNode(13...15)((13...14), (14...15)),
              [],
              nil,
-             BlockParameterNode(20...22)((21...22), (20...21))
+             BlockParameterNode(20...22)(:f, (21...22), (20...21))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/block_args_opt3.txt
+++ b/test/yarp/snapshots/seattlerb/block_args_opt3.txt
@@ -29,7 +29,7 @@ ProgramNode(0...42)(
              nil,
              [],
              nil,
-             BlockParameterNode(24...26)((25...26), (24...25))
+             BlockParameterNode(24...26)(:d, (25...26), (24...25))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/block_opt_splat_arg_block_omfg.txt
+++ b/test/yarp/snapshots/seattlerb/block_opt_splat_arg_block_omfg.txt
@@ -23,7 +23,7 @@ ProgramNode(0...22)(
              RestParameterNode(10...12)((10...11), (11...12)),
              [],
              nil,
-             BlockParameterNode(17...19)((18...19), (17...18))
+             BlockParameterNode(17...19)(:e, (18...19), (17...18))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/difficult3_3.txt
+++ b/test/yarp/snapshots/seattlerb/difficult3_3.txt
@@ -18,7 +18,7 @@ ProgramNode(0...17)(
              RestParameterNode(5...7)((5...6), (6...7)),
              [],
              nil,
-             BlockParameterNode(12...14)((13...14), (12...13))
+             BlockParameterNode(12...14)(:c, (13...14), (12...13))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_10_2.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_10_2.txt
@@ -23,7 +23,7 @@ ProgramNode(0...25)(
              RestParameterNode(16...18)((16...17), (17...18)),
              [],
              nil,
-             BlockParameterNode(20...22)((21...22), (20...21))
+             BlockParameterNode(20...22)(:d, (21...22), (20...21))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_11_2.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_11_2.txt
@@ -23,7 +23,7 @@ ProgramNode(0...28)(
              RestParameterNode(16...18)((16...17), (17...18)),
              [],
              nil,
-             BlockParameterNode(23...25)((24...25), (23...24))
+             BlockParameterNode(23...25)(:e, (24...25), (23...24))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_5.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_5.txt
@@ -18,7 +18,7 @@ ProgramNode(0...13)(
              nil,
              [],
              nil,
-             BlockParameterNode(8...10)((9...10), (8...9))
+             BlockParameterNode(8...10)(:b, (9...10), (8...9))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_7_2.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_7_2.txt
@@ -23,7 +23,7 @@ ProgramNode(0...22)(
              RestParameterNode(13...15)((13...14), (14...15)),
              [],
              nil,
-             BlockParameterNode(17...19)((18...19), (17...18))
+             BlockParameterNode(17...19)(:c, (18...19), (17...18))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_8_2.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_8_2.txt
@@ -23,7 +23,7 @@ ProgramNode(0...25)(
              RestParameterNode(13...15)((13...14), (14...15)),
              [],
              nil,
-             BlockParameterNode(20...22)((21...22), (20...21))
+             BlockParameterNode(20...22)(:d, (21...22), (20...21))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/iter_args_9_2.txt
+++ b/test/yarp/snapshots/seattlerb/iter_args_9_2.txt
@@ -23,7 +23,7 @@ ProgramNode(0...21)(
              nil,
              [],
              nil,
-             BlockParameterNode(16...18)((17...18), (16...17))
+             BlockParameterNode(16...18)(:c, (17...18), (16...17))
            ),
            [],
            (4...5),

--- a/test/yarp/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.txt
+++ b/test/yarp/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.txt
@@ -19,7 +19,7 @@ ProgramNode(0...23)(
            RestParameterNode(11...13)((11...12), (12...13)),
            [],
            nil,
-           BlockParameterNode(18...20)((19...20), (18...19))
+           BlockParameterNode(18...20)(:f, (19...20), (18...19))
          ),
          [],
          (2...3),

--- a/test/yarp/snapshots/unparser/corpus/literal/def.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/def.txt
@@ -781,7 +781,7 @@ ProgramNode(0...913)(
          RestParameterNode(654...658)((654...655), (655...658)),
          [],
          nil,
-         BlockParameterNode(660...666)((661...666), (660...661))
+         BlockParameterNode(660...666)(:block, (661...666), (660...661))
        ),
        StatementsNode(670...673)(
          [CallNode(670...673)(
@@ -840,7 +840,7 @@ ProgramNode(0...913)(
          nil,
          [],
          nil,
-         BlockParameterNode(729...735)((730...735), (729...730))
+         BlockParameterNode(729...735)(:block, (730...735), (729...730))
        ),
        StatementsNode(739...742)(
          [CallNode(739...742)(
@@ -873,7 +873,7 @@ ProgramNode(0...913)(
          nil,
          [],
          nil,
-         BlockParameterNode(761...767)((762...767), (761...762))
+         BlockParameterNode(761...767)(:block, (762...767), (761...762))
        ),
        StatementsNode(771...774)([LocalVariableReadNode(771...774)(:bar, 0)]),
        [:bar, :block],

--- a/test/yarp/snapshots/unparser/corpus/literal/since/31.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/since/31.txt
@@ -11,7 +11,7 @@ ProgramNode(0...51)(
          nil,
          [],
          nil,
-         BlockParameterNode(8...9)(nil, (8...9))
+         BlockParameterNode(8...9)(nil, nil, (8...9))
        ),
        StatementsNode(13...19)(
          [CallNode(13...19)(
@@ -46,7 +46,7 @@ ProgramNode(0...51)(
          nil,
          [],
          nil,
-         BlockParameterNode(36...37)(nil, (36...37))
+         BlockParameterNode(36...37)(nil, nil, (36...37))
        ),
        StatementsNode(41...47)(
          [CallNode(41...47)(

--- a/test/yarp/snapshots/whitequark/anonymous_blockarg.txt
+++ b/test/yarp/snapshots/whitequark/anonymous_blockarg.txt
@@ -11,7 +11,7 @@ ProgramNode(0...23)(
          nil,
          [],
          nil,
-         BlockParameterNode(8...9)(nil, (8...9))
+         BlockParameterNode(8...9)(nil, nil, (8...9))
        ),
        StatementsNode(12...18)(
          [CallNode(12...18)(

--- a/test/yarp/snapshots/whitequark/args.txt
+++ b/test/yarp/snapshots/whitequark/args.txt
@@ -11,7 +11,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(6...8)((7...8), (6...7))
+         BlockParameterNode(6...8)(:b, (7...8), (6...7))
        ),
        nil,
        [:b],
@@ -310,7 +310,7 @@ ProgramNode(0...690)(
             IntegerNode(241...242)()
           )],
          nil,
-         BlockParameterNode(244...246)((245...246), (244...245))
+         BlockParameterNode(244...246)(:b, (245...246), (244...245))
        ),
        nil,
        [:foo, :b],
@@ -338,7 +338,7 @@ ProgramNode(0...690)(
             IntegerNode(274...275)()
           )],
          KeywordRestParameterNode(277...282)((277...279), (279...282)),
-         BlockParameterNode(284...286)((285...286), (284...285))
+         BlockParameterNode(284...286)(:b, (285...286), (284...285))
        ),
        nil,
        [:foo, :bar, :baz, :b],
@@ -359,7 +359,7 @@ ProgramNode(0...690)(
          nil,
          [],
          KeywordRestParameterNode(300...305)((300...302), (302...305)),
-         BlockParameterNode(307...309)((308...309), (307...308))
+         BlockParameterNode(307...309)(:b, (308...309), (307...308))
        ),
        nil,
        [:baz, :b],
@@ -401,7 +401,7 @@ ProgramNode(0...690)(
          RestParameterNode(340...342)((340...341), (341...342)),
          [],
          nil,
-         BlockParameterNode(344...346)((345...346), (344...345))
+         BlockParameterNode(344...346)(:b, (345...346), (344...345))
        ),
        nil,
        [:r, :b],
@@ -422,7 +422,7 @@ ProgramNode(0...690)(
          RestParameterNode(359...361)((359...360), (360...361)),
          [],
          nil,
-         BlockParameterNode(366...368)((367...368), (366...367))
+         BlockParameterNode(366...368)(:b, (367...368), (366...367))
        ),
        nil,
        [:r, :p, :b],
@@ -456,7 +456,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(397...399)((398...399), (397...398))
+         BlockParameterNode(397...399)(:b, (398...399), (397...398))
        ),
        nil,
        [:a, :b],
@@ -477,7 +477,7 @@ ProgramNode(0...690)(
          RestParameterNode(415...417)((415...416), (416...417)),
          [],
          nil,
-         BlockParameterNode(419...421)((420...421), (419...420))
+         BlockParameterNode(419...421)(:b, (420...421), (419...420))
        ),
        nil,
        [:a, :r, :b],
@@ -498,7 +498,7 @@ ProgramNode(0...690)(
          RestParameterNode(437...439)((437...438), (438...439)),
          [],
          nil,
-         BlockParameterNode(444...446)((445...446), (444...445))
+         BlockParameterNode(444...446)(:b, (445...446), (444...445))
        ),
        nil,
        [:a, :r, :p, :b],
@@ -524,7 +524,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(467...469)((468...469), (467...468))
+         BlockParameterNode(467...469)(:b, (468...469), (467...468))
        ),
        nil,
        [:a, :o, :b],
@@ -550,7 +550,7 @@ ProgramNode(0...690)(
          RestParameterNode(490...492)((490...491), (491...492)),
          [],
          nil,
-         BlockParameterNode(494...496)((495...496), (494...495))
+         BlockParameterNode(494...496)(:b, (495...496), (494...495))
        ),
        nil,
        [:a, :o, :r, :b],
@@ -576,7 +576,7 @@ ProgramNode(0...690)(
          RestParameterNode(517...519)((517...518), (518...519)),
          [],
          nil,
-         BlockParameterNode(524...526)((525...526), (524...525))
+         BlockParameterNode(524...526)(:b, (525...526), (524...525))
        ),
        nil,
        [:a, :o, :r, :p, :b],
@@ -602,7 +602,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(550...552)((551...552), (550...551))
+         BlockParameterNode(550...552)(:b, (551...552), (550...551))
        ),
        nil,
        [:a, :o, :p, :b],
@@ -673,7 +673,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(609...611)((610...611), (609...610))
+         BlockParameterNode(609...611)(:b, (610...611), (609...610))
        ),
        nil,
        [:o, :b],
@@ -699,7 +699,7 @@ ProgramNode(0...690)(
          RestParameterNode(629...631)((629...630), (630...631)),
          [],
          nil,
-         BlockParameterNode(633...635)((634...635), (633...634))
+         BlockParameterNode(633...635)(:b, (634...635), (633...634))
        ),
        nil,
        [:o, :r, :b],
@@ -725,7 +725,7 @@ ProgramNode(0...690)(
          RestParameterNode(653...655)((653...654), (654...655)),
          [],
          nil,
-         BlockParameterNode(660...662)((661...662), (660...661))
+         BlockParameterNode(660...662)(:b, (661...662), (660...661))
        ),
        nil,
        [:o, :r, :p, :b],
@@ -751,7 +751,7 @@ ProgramNode(0...690)(
          nil,
          [],
          nil,
-         BlockParameterNode(683...685)((684...685), (683...684))
+         BlockParameterNode(683...685)(:b, (684...685), (683...684))
        ),
        nil,
        [:o, :p, :b],

--- a/test/yarp/snapshots/whitequark/blockarg.txt
+++ b/test/yarp/snapshots/whitequark/blockarg.txt
@@ -11,7 +11,7 @@ ProgramNode(0...18)(
          nil,
          [],
          nil,
-         BlockParameterNode(6...12)((7...12), (6...7))
+         BlockParameterNode(6...12)(:block, (7...12), (6...7))
        ),
        nil,
        [:block],

--- a/test/yarp/snapshots/whitequark/blockargs.txt
+++ b/test/yarp/snapshots/whitequark/blockargs.txt
@@ -46,7 +46,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(21...23)((22...23), (21...22))
+             BlockParameterNode(21...23)(:b, (22...23), (21...22))
            ),
            [],
            (20...21),
@@ -76,7 +76,7 @@ ProgramNode(0...550)(
              nil,
              [],
              KeywordRestParameterNode(32...37)((32...34), (34...37)),
-             BlockParameterNode(39...41)((40...41), (39...40))
+             BlockParameterNode(39...41)(:b, (40...41), (39...40))
            ),
            [],
            (31...32),
@@ -106,7 +106,7 @@ ProgramNode(0...550)(
              RestParameterNode(50...51)((50...51), nil),
              [],
              nil,
-             BlockParameterNode(53...55)((54...55), (53...54))
+             BlockParameterNode(53...55)(:b, (54...55), (53...54))
            ),
            [],
            (49...50),
@@ -136,7 +136,7 @@ ProgramNode(0...550)(
              RestParameterNode(64...66)((64...65), (65...66)),
              [],
              nil,
-             BlockParameterNode(71...73)((72...73), (71...72))
+             BlockParameterNode(71...73)(:b, (72...73), (71...72))
            ),
            [],
            (63...64),
@@ -166,7 +166,7 @@ ProgramNode(0...550)(
              RestParameterNode(82...84)((82...83), (83...84)),
              [],
              nil,
-             BlockParameterNode(86...88)((87...88), (86...87))
+             BlockParameterNode(86...88)(:b, (87...88), (86...87))
            ),
            [],
            (81...82),
@@ -300,7 +300,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(145...147)((146...147), (145...146))
+             BlockParameterNode(145...147)(:b, (146...147), (145...146))
            ),
            [],
            (141...142),
@@ -330,7 +330,7 @@ ProgramNode(0...550)(
              RestParameterNode(159...160)((159...160), nil),
              [],
              nil,
-             BlockParameterNode(162...164)((163...164), (162...163))
+             BlockParameterNode(162...164)(:b, (163...164), (162...163))
            ),
            [],
            (155...156),
@@ -360,7 +360,7 @@ ProgramNode(0...550)(
              RestParameterNode(176...178)((176...177), (177...178)),
              [],
              nil,
-             BlockParameterNode(183...185)((184...185), (183...184))
+             BlockParameterNode(183...185)(:b, (184...185), (183...184))
            ),
            [],
            (172...173),
@@ -390,7 +390,7 @@ ProgramNode(0...550)(
              RestParameterNode(197...199)((197...198), (198...199)),
              [],
              nil,
-             BlockParameterNode(201...203)((202...203), (201...202))
+             BlockParameterNode(201...203)(:b, (202...203), (201...202))
            ),
            [],
            (193...194),
@@ -547,7 +547,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(274...276)((275...276), (274...275))
+             BlockParameterNode(274...276)(:b, (275...276), (274...275))
            ),
            [],
            (265...266),
@@ -582,7 +582,7 @@ ProgramNode(0...550)(
              RestParameterNode(293...295)((293...294), (294...295)),
              [],
              nil,
-             BlockParameterNode(300...302)((301...302), (300...301))
+             BlockParameterNode(300...302)(:b, (301...302), (300...301))
            ),
            [],
            (284...285),
@@ -623,7 +623,7 @@ ProgramNode(0...550)(
              RestParameterNode(325...327)((325...326), (326...327)),
              [],
              nil,
-             BlockParameterNode(329...331)((330...331), (329...330))
+             BlockParameterNode(329...331)(:b, (330...331), (329...330))
            ),
            [],
            (310...311),
@@ -658,7 +658,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(351...353)((352...353), (351...352))
+             BlockParameterNode(351...353)(:b, (352...353), (351...352))
            ),
            [],
            (339...340),
@@ -811,7 +811,7 @@ ProgramNode(0...550)(
                 IntegerNode(408...409)()
               )],
              nil,
-             BlockParameterNode(411...413)((412...413), (411...412))
+             BlockParameterNode(411...413)(:b, (412...413), (411...412))
            ),
            [],
            (402...403),
@@ -848,7 +848,7 @@ ProgramNode(0...550)(
                 IntegerNode(435...436)()
               )],
              KeywordRestParameterNode(438...443)((438...440), (440...443)),
-             BlockParameterNode(445...447)((446...447), (445...446))
+             BlockParameterNode(445...447)(:b, (446...447), (445...446))
            ),
            [],
            (421...422),
@@ -913,7 +913,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(474...476)((475...476), (474...475))
+             BlockParameterNode(474...476)(:b, (475...476), (474...475))
            ),
            [],
            (468...469),
@@ -948,7 +948,7 @@ ProgramNode(0...550)(
              RestParameterNode(490...492)((490...491), (491...492)),
              [],
              nil,
-             BlockParameterNode(494...496)((495...496), (494...495))
+             BlockParameterNode(494...496)(:b, (495...496), (494...495))
            ),
            [],
            (484...485),
@@ -983,7 +983,7 @@ ProgramNode(0...550)(
              RestParameterNode(510...512)((510...511), (511...512)),
              [],
              nil,
-             BlockParameterNode(517...519)((518...519), (517...518))
+             BlockParameterNode(517...519)(:b, (518...519), (517...518))
            ),
            [],
            (504...505),
@@ -1018,7 +1018,7 @@ ProgramNode(0...550)(
              nil,
              [],
              nil,
-             BlockParameterNode(536...538)((537...538), (536...537))
+             BlockParameterNode(536...538)(:b, (537...538), (536...537))
            ),
            [],
            (527...528),


### PR DESCRIPTION
This also introduces the `constant?` as a field type, since block parameters don't necessarily have a name associated with them (e.g., `def foo(&); end`).