### PR TITLE
Introduce owned constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/test/serialized/
+/test/yarp/serialized/
 /top-100-gems/
 /tmp/
 /vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
 PLATFORMS
   ruby
   universal-java-17
+  universal-java-20
 
 DEPENDENCIES
   ffi

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -81,31 +81,35 @@ Each node is structured like the following table:
 | `1` | node type |
 | location | node location |
 
-Each node's child is then appended to the serialized string.
-The child node types can be determined by referencing `config.yml`.
-Depending on the type of child node, it could take a couple of different forms, described below:
+Every field on the node is then appended to the serialized string. The fields can be determined by referencing `config.yml`. Depending on the type of field, it could take a couple of different forms, described below:
 
-* `node` - A child node that is a node itself. This is structured just as like parent node.
-* `node?` - A child node that is optionally present. If the node is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just as like parent node.
-* `node[]` - A child node that is an array of nodes. This is structured as a variable-length integer length, followed by the child nodes themselves.
-* `string` - A child node that is a string. For example, this is used as the name of the method in a call node, since it cannot directly reference the source string (as in `@-` or `foo=`). This is structured as a variable-length integer byte length, followed by the string itself (_without_ a trailing null byte).
+* `node` - A field that is a node. This is structured just as like parent node.
+* `node?` - A field that is a node that is optionally present. If the node is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just as like parent node.
+* `node[]` - A field that is an array of nodes. This is structured as a variable-length integer length, followed by the child nodes themselves.
+* `string` - A field that is a string. For example, this is used as the name of the method in a call node, since it cannot directly reference the source string (as in `@-` or `foo=`). This is structured as a variable-length integer byte length, followed by the string itself (_without_ a trailing null byte).
 * `constant` - A variable-length integer that represents an index in the constant pool.
-* `constant[]` - A child node that is an array of constants. This is structured as a variable-length integer length, followed by the child constants themselves.
-* `location` - A child node that is a location. This is structured as a variable-length integer start followed by a variable-length integer length.
-* `location?` - A child node that is a location that is optionally present. If the location is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just like the `location` child node.
-* `uint32` - A child node that is a 32-bit unsigned integer. This is structured as a variable-length integer.
+* `constant?` - An optional variable-length integer that represents an index in the constant pool. If it's not present, then a single `0` byte will be written in its place.
+* `location` - A field that is a location. This is structured as a variable-length integer start followed by a variable-length integer length.
+* `location?` - A field that is a location that is optionally present. If the location is not present, then a single `0` byte will be written in its place. If it is present, then it will be structured just like the `location` child node.
+* `uint32` - A field that is a 32-bit unsigned integer. This is structured as a variable-length integer.
 
-After the syntax tree, the content pool is serialized.
-This is a list of constants that were referenced from within the tree.
-The content pool begins at the offset specified in the header.
-Each constant is structured as:
+After the syntax tree, the content pool is serialized. This is a list of constants that were referenced from within the tree. The content pool begins at the offset specified in the header. Constants can be either "owned" (in which case their contents are embedded in the serialization) or "shared" (in which case their contents represent a slice of the source string). The most significant bit of the constant indicates whether it is owned or shared.
+
+In the case that it is owned, the constant is structured as follows:
 
 | # bytes | field |
 | --- | --- |
-| `4` | the byte offset in the source |
-| `4` | the byte length in the source |
+| `4` | the byte offset in the serialization for the contents of the constant |
+| `4` | the byte length in the serialization |
 
-At the end of the serialization, the buffer is null terminated.
+Note that you will need to mask off the most significant bit for the byte offset in the serialization. In the case that it is shared, the constant is structured as follows:
+
+| # bytes | field |
+| --- | --- |
+| `4` | the byte offset in the source string for the contents of the constant |
+| `4` | the byte length in the source string |
+
+After the constant pool, the contents of the owned constants are serialized. This is just a sequence of bytes that represent the contents of the constants. At the end of the serialization, the buffer is null terminated.
 
 ## APIs
 

--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -8,6 +8,7 @@
 
 #include "yarp/defines.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -39,7 +40,8 @@ size_t yp_constant_id_list_memsize(yp_constant_id_list_t *list);
 void yp_constant_id_list_free(yp_constant_id_list_t *list);
 
 typedef struct {
-    yp_constant_id_t id;
+    unsigned int id: 31;
+    bool owned: 1;
     const uint8_t *start;
     size_t length;
     size_t hash;
@@ -57,9 +59,14 @@ typedef struct {
 // Initialize a new constant pool with a given capacity.
 bool yp_constant_pool_init(yp_constant_pool_t *pool, size_t capacity);
 
-// Insert a constant into a constant pool. Returns the id of the constant, or 0
-// if any potential calls to resize fail.
-yp_constant_id_t yp_constant_pool_insert(yp_constant_pool_t *pool, const uint8_t *start, size_t length);
+// Insert a constant into a constant pool that is a slice of a source string.
+// Returns the id of the constant, or 0 if any potential calls to resize fail.
+yp_constant_id_t yp_constant_pool_insert_shared(yp_constant_pool_t *pool, const uint8_t *start, size_t length);
+
+// Insert a constant into a constant pool from memory that is now owned by the
+// constant pool. Returns the id of the constant, or 0 if any potential calls to
+// resize fail.
+yp_constant_id_t yp_constant_pool_insert_owned(yp_constant_pool_t *pool, const uint8_t *start, size_t length);
 
 // Free the memory associated with a constant pool.
 void yp_constant_pool_free(yp_constant_pool_t *pool);

--- a/rust/yarp-sys/src/lib.rs
+++ b/rust/yarp-sys/src/lib.rs
@@ -19,20 +19,12 @@
     unused_qualifications
 )]
 
-// Allowing because we're not manually defining anything that would cause this, and
-// the bindgen-generated `bindgen_test_layout_yp_parser()` triggers this.
-#[allow(clippy::cognitive_complexity)]
-// Allowing because we're not manually defining anything that would cause this, and
-// the following bindgen-generated functions triggers this:
-// - `bindgen_test_layout_yp_call_node()`
-// - `bindgen_test_layout_yp_def_node()`
-// - `bindgen_test_layout_yp_parser()`
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::all, clippy::pedantic, clippy::cognitive_complexity)]
 #[allow(missing_copy_implementations)]
-#[allow(non_upper_case_globals)]
+#[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
-#[allow(missing_docs)]
+#[allow(non_upper_case_globals)]
 mod bindings {
     // In `build.rs`, we use `bindgen` to generate bindings based on C headers
     // and `librubyparser`. Here is where we pull in those bindings and make

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -144,30 +144,41 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
                     // <%= field.name %>
                     <%- case field -%>
                     <%- when YARP::NodeField, YARP::OptionalNodeField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_pop(value_stack);
                     <%- when YARP::NodeListField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_new_capa(cast-><%= field.name %>.size);
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {
                         rb_ary_push(argv[<%= index %>], rb_ary_pop(value_stack));
                     }
                     <%- when YARP::StringField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = yp_string_new(&cast-><%= field.name %>, encoding);
                     <%- when YARP::ConstantField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
+                    assert(cast-><%= field.name %> != 0);
                     argv[<%= index %>] = rb_id2sym(constants[cast-><%= field.name %> - 1]);
                     <%- when YARP::OptionalConstantField -%>
                     argv[<%= index %>] = cast-><%= field.name %> == 0 ? Qnil : rb_id2sym(constants[cast-><%= field.name %> - 1]);
                     <%- when YARP::ConstantListField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = rb_ary_new_capa(cast-><%= field.name %>.size);
                     for (size_t index = 0; index < cast-><%= field.name %>.size; index++) {
+                        assert(cast-><%= field.name %>.ids[index] != 0);
                         rb_ary_push(argv[<%= index %>], rb_id2sym(constants[cast-><%= field.name %>.ids[index] - 1]));
                     }
                     <%- when YARP::LocationField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = yp_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end, source);
                     <%- when YARP::OptionalLocationField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = cast-><%= field.name %>.start == NULL ? Qnil : yp_location_new(parser, cast-><%= field.name %>.start, cast-><%= field.name %>.end, source);
                     <%- when YARP::UInt32Field -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = ULONG2NUM(cast-><%= field.name %>);
                     <%- when YARP::FlagsField -%>
+#line <%= __LINE__ + 1 %> "<%= File.basename(__FILE__) %>"
                     argv[<%= index %>] = ULONG2NUM(node->flags >> <%= YARP::COMMON_FLAGS %>);
                     <%- else -%>
                     <%- raise -%>

--- a/templates/java/org/yarp/Loader.java.erb
+++ b/templates/java/org/yarp/Loader.java.erb
@@ -30,15 +30,26 @@ public class Loader {
         byte[] get(ByteBuffer buffer, int oneBasedIndex) {
             int index = oneBasedIndex - 1;
             byte[] constant = cache[index];
+
             if (constant == null) {
                 int offset = bufferOffset + index * 8;
                 int start = buffer.getInt(offset);
                 int length = buffer.getInt(offset + 4);
 
                 constant = new byte[length];
-                System.arraycopy(source, start, constant, 0, length);
+
+                if (Integer.compareUnsigned(start, 1 << 31) <= 0) {
+                    System.arraycopy(source, start, constant, 0, length);
+                } else {
+                    int position = buffer.position();
+                    buffer.position(Math.abs(start));
+                    buffer.get(constant, 0, length);
+                    buffer.position(position);
+                }
+
                 cache[index] = constant;
             }
+
             return constant;
         }
 
@@ -169,18 +180,6 @@ public class Loader {
             buffer.position(buffer.position() + 1); // continue after the 0 byte
             return null;
         }
-    }
-
-    private Nodes.Location[] loadLocations() {
-        int length = loadVarInt();
-        if (length == 0) {
-            return Nodes.Location.EMPTY_ARRAY;
-        }
-        Nodes.Location[] locations = new Nodes.Location[length];
-        for (int i = 0; i < length; i++) {
-            locations[i] = loadLocation();
-        }
-        return locations;
     }
 
     private byte[] loadConstant() {

--- a/templates/lib/yarp/serialize.rb.erb
+++ b/templates/lib/yarp/serialize.rb.erb
@@ -157,11 +157,16 @@ module YARP
 
         unless constant
           offset = constant_pool_offset + index * 8
-
           start = serialized.unpack1("L", offset: offset)
           length = serialized.unpack1("L", offset: offset + 4)
 
-          constant = input.byteslice(start, length).to_sym
+          constant =
+            if start.nobits?(1 << 31)
+              input.byteslice(start, length).to_sym
+            else
+              serialized.byteslice(start & ((1 << 31) - 1), length).to_sym
+            end
+
           constant_pool[index] = constant
         end
 

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -206,12 +206,31 @@ yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) 
         // If we find a constant at this index, serialize it at the correct
         // index in the buffer.
         if (constant->id != 0) {
-            size_t buffer_offset = offset + ((constant->id - 1) * 8);
+            size_t buffer_offset = offset + ((((size_t) constant->id) - 1) * 8);
 
-            uint32_t source_offset = yp_ptrdifft_to_u32(constant->start - parser->start);
+            if (constant->owned) {
+                // Since this is an owned constant, we are going to write its
+                // contents into the buffer after the constant pool. So
+                // effectively in place of the source offset, we have a buffer
+                // offset. We will add a leading 1 to indicate that this is a
+                // buffer offset.
+                uint32_t content_offset = yp_sizet_to_u32(buffer->length);
+                uint32_t owned_mask = (uint32_t) (1 << 31);
+
+                assert(content_offset < owned_mask);
+                content_offset |= owned_mask;
+
+                memcpy(buffer->value + buffer_offset, &content_offset, 4);
+                yp_buffer_append_bytes(buffer, constant->start, constant->length);
+            } else {
+                // Since this is a shared constant, we are going to write its
+                // source offset directly into the buffer.
+                uint32_t source_offset = yp_ptrdifft_to_u32(constant->start - parser->start);
+                memcpy(buffer->value + buffer_offset, &source_offset, 4);
+            }
+
+            // Now we can write the length of the constant into the buffer.
             uint32_t constant_length = yp_sizet_to_u32(constant->length);
-
-            memcpy(buffer->value + buffer_offset, &source_offset, 4);
             memcpy(buffer->value + buffer_offset + 4, &constant_length, 4);
         }
     }

--- a/test/yarp/parse_serialize_test.rb
+++ b/test/yarp/parse_serialize_test.rb
@@ -14,6 +14,16 @@ module YARP
       assert_equal __FILE__, find_file_node(result)&.filepath, "Expected the filepath to be set correctly"
     end
 
+    def test_parse_serialize_with_locals
+      filepath = __FILE__
+      metadata = [filepath.bytesize, filepath.b, 1, 1, 1, "foo".b].pack("LA*LLLA*")
+
+      dumped = Debug.parse_serialize_file_metadata(filepath, metadata)
+      result = YARP.load(File.read(__FILE__), dumped)
+
+      assert_kind_of ParseResult, result, "Expected the return value to be a ParseResult"
+    end
+
     private
 
     def find_file_node(result)


### PR DESCRIPTION
Before this commit, constants in the constant pool were assumed to be slices of the source string. This works in _almost_ all cases.

There are times, however, when a string needs to be synthesized. This can occur when passing in locals that need to be scoped through eval, or when generating method names like `foo=`.

After this commit, there is a single bit `owned` boolean on constants in the pool that indicates whether or not it is a slice of the source string. If it is not, it is assumed to be allocated memory that should be freed by the constant pool when the constant pool is freed.

When serializing, constants now take up 9 bytes instead of 8. The first byte indicates whether or not it is an owned string. When it is, instead of 4 bytes for the source offset and 4 bytes for the length it is instead 4 bytes for the buffer offset and 4 bytes for the length. The contents of the owned constants are embedded into the buffer after the constant pool itself.

Fixes #1373