### PR TITLE
Fix `Location#end_column`

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -95,7 +95,7 @@ module YARP
     # The column number in bytes where this location ends from the start of the
     # line.
     def end_column
-      source.column(end_offset - 1)
+      source.column(end_offset)
     end
 
     def deconstruct_keys(keys)

--- a/test/yarp/location_test.rb
+++ b/test/yarp/location_test.rb
@@ -817,6 +817,14 @@ module YARP
       node = result.value.statements.body.last
       node = yield node if block_given?
 
+      if expected.begin == 0
+        assert_equal 0, node.location.start_column
+      end
+
+      if expected.end == source.length
+        assert_equal source.split("\n").last.length, node.location.end_column
+      end
+
       assert_kind_of kind, node
       assert_equal expected.begin, node.location.start_offset
       assert_equal expected.end, node.location.end_offset


### PR DESCRIPTION
YARP's `end_column` is off by 1 compared to Syntax Tree, e.g.:

```
ruby-lsp(main):009> SyntaxTree.parse("class Foo\nend").child_nodes.first.body.first.location
=>
#<SyntaxTree::Location:0x00000001073f7a48
 @end_char=13,
 @end_column=3, # <-----
 @end_line=2,
 @start_char=0,
 @start_column=0,
 @start_line=1>
```

vs

```
ruby-lsp(main):034> location = YARP.parse("class Foo\nend").value.child_nodes.first.body.first.location
ruby-lsp(main):036> location.end_offset
=> 13
ruby-lsp(main):037> location.end_column
=> 2 # <-----
ruby-lsp(main):038> location.end_line
=> 2
ruby-lsp(main):039> location.start_offset
=> 0
ruby-lsp(main):040> location.start_column
=> 0
ruby-lsp(main):041> location.start_line
=> 1
```

This should probably be marked as a breaking change.