### PR TITLE
Avoid an extra "stop" parameter to yp_strspn_whitespace_newlines

### DIFF
--- a/include/yarp/util/yp_char.h
+++ b/include/yarp/util/yp_char.h
@@ -15,7 +15,7 @@ size_t yp_strspn_whitespace(const uint8_t *string, ptrdiff_t length);
 // whitespace while also tracking the location of each newline. Disallows
 // searching past the given maximum number of characters.
 size_t
-yp_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, yp_newline_list_t *newline_list, bool stop_at_newline);
+yp_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, yp_newline_list_t *newline_list);
 
 // Returns the number of characters at the start of the string that are inline
 // whitespace. Disallows searching past the given maximum number of characters.

--- a/src/util/yp_char.c
+++ b/src/util/yp_char.c
@@ -75,7 +75,7 @@ yp_strspn_whitespace(const uint8_t *string, ptrdiff_t length) {
 // whitespace while also tracking the location of each newline. Disallows
 // searching past the given maximum number of characters.
 size_t
-yp_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, yp_newline_list_t *newline_list, bool stop_at_newline) {
+yp_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, yp_newline_list_t *newline_list) {
     if (length <= 0) return 0;
 
     size_t size = 0;
@@ -83,12 +83,7 @@ yp_strspn_whitespace_newlines(const uint8_t *string, ptrdiff_t length, yp_newlin
 
     while (size < maximum && (yp_byte_table[string[size]] & YP_CHAR_BIT_WHITESPACE)) {
         if (string[size] == '\n') {
-            if (stop_at_newline) {
-                return size + 1;
-            }
-            else {
-                yp_newline_list_append(newline_list, string + size);
-            }
+            yp_newline_list_append(newline_list, string + size);
         }
 
         size++;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7045,9 +7045,16 @@ parser_lex(yp_parser_t *parser) {
             // going to trim it off the beginning and create a new token.
             size_t whitespace;
 
-            bool should_stop = parser->heredoc_end;
+            if (parser->heredoc_end) {
+                whitespace = yp_strspn_inline_whitespace(parser->current.end, parser->end - parser->current.end);
+                if (peek_offset(parser, (ptrdiff_t)whitespace) == '\n') {
+                    whitespace += 1;
+                }
+            } else {
+                whitespace = yp_strspn_whitespace_newlines(parser->current.end, parser->end - parser->current.end, &parser->newline_list);
+            }
 
-            if ((whitespace = yp_strspn_whitespace_newlines(parser->current.end, parser->end - parser->current.end, &parser->newline_list, should_stop)) > 0) {
+            if (whitespace > 0) {
                 parser->current.end += whitespace;
                 if (peek_offset(parser, -1) == '\n') {
                     // mutates next_start


### PR DESCRIPTION
and use yp_strspn_inline_whitespace instead.

Partially reverts implementation details from #1152

cc @tenderlove 