### PR TITLE
Add ParseResult#attach_comments! to tie comments to their locations

### DIFF
--- a/test/yarp/comments_test.rb
+++ b/test/yarp/comments_test.rb
@@ -55,6 +55,30 @@ module YARP
       assert_comment source, :embdoc, 0..24
     end
 
+    def test_attaching_comments
+      source = <<~RUBY
+        # Foo class
+        class Foo
+          # bar method
+          def bar
+            # baz invocation
+            baz
+          end # bar end
+        end # Foo end
+      RUBY
+
+      result = YARP.parse(source)
+      result.attach_comments!
+      tree = result.value
+      class_node = tree.statements.body.first
+      method_node = class_node.body.body.first
+      call_node = method_node.body.body.first
+
+      assert_equal("# Foo class\n# Foo end\n", class_node.location.comments.map { |c| c.location.slice }.join)
+      assert_equal("# bar method\n# bar end\n", method_node.location.comments.map { |c| c.location.slice }.join)
+      assert_equal("# baz invocation\n", call_node.location.comments.map { |c| c.location.slice }.join)
+    end
+
     private
 
     def assert_comment(source, type, location)


### PR DESCRIPTION
Development tools like RDoc or LSPs need to show comments in certain situations as they are considered documentation. The most prominent example is to implement hover in an LSP, where we want to show the documentation for a given node.

Currently, there's no easy way to figure out which comments are associated with each node. Let's bring in SyntaxTree's algorithm for attaching comments to locations so that we can easily ask a location what comments exist there.