### PR TITLE
Multi target node

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1751,20 +1751,30 @@ nodes:
 
           module Foo end
           ^^^^^^^^^^^^^^
-  - name: MultiWriteNode
+  - name: MultiTargetNode
     fields:
       - name: targets
         type: node[]
-      - name: operator_loc
-        type: location?
-      - name: value
-        type: node?
       - name: lparen_loc
         type: location?
       - name: rparen_loc
         type: location?
     comment: |
       Represents a multi-target expression.
+
+          a, b, c = 1, 2, 3
+          ^^^^^^^
+  - name: MultiWriteNode
+    fields:
+      - name: target
+        type: node
+        kind: MultiTargetNode
+      - name: operator_loc
+        type: location
+      - name: value
+        type: node
+    comment: |
+      Represents a write to a multi-target expression.
 
           a, b, c = 1, 2, 3
           ^^^^^^^^^^^^^^^^^

--- a/config.yml
+++ b/config.yml
@@ -1766,9 +1766,12 @@ nodes:
           ^^^^^^^
   - name: MultiWriteNode
     fields:
-      - name: target
-        type: node
-        kind: MultiTargetNode
+      - name: targets
+        type: node[]
+      - name: lparen_loc
+        type: location?
+      - name: rparen_loc
+        type: location?
       - name: operator_loc
         type: location
       - name: value

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3365,10 +3365,16 @@ yp_multi_write_node_create(yp_parser_t *parser, yp_multi_target_node_t *target, 
                 .end = value->location.end
             }
         },
-        .target = target,
+        .targets = target->targets,
+        .lparen_loc = target->lparen_loc,
+        .rparen_loc = target->rparen_loc,
         .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
         .value = value
     };
+
+    // Explicitly do not call yp_node_destroy here because we want to keep
+    // around all of the information within the MultiWriteNode node.
+    free(target);
 
     return node;
 }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3320,32 +3320,27 @@ yp_module_node_create(yp_parser_t *parser, yp_constant_id_list_t *locals, const 
     return node;
 }
 
-// Allocate a new MultiWriteNode node.
-static yp_multi_write_node_t *
-yp_multi_write_node_create(yp_parser_t *parser, const yp_token_t *operator, yp_node_t *value, const yp_location_t *lparen_loc, const yp_location_t *rparen_loc) {
-    yp_multi_write_node_t *node = YP_ALLOC_NODE(parser, yp_multi_write_node_t);
+// Allocate and initialize new MultiTargetNode node.
+static yp_multi_target_node_t *
+yp_multi_target_node_create(yp_parser_t *parser) {
+    yp_multi_target_node_t *node = YP_ALLOC_NODE(parser, yp_multi_target_node_t);
 
-    *node = (yp_multi_write_node_t) {
+    *node = (yp_multi_target_node_t) {
         {
-            .type = YP_MULTI_WRITE_NODE,
-            .location = {
-                .start = lparen_loc->start,
-                .end = value == NULL ? rparen_loc->end : value->location.end
-            },
+            .type = YP_MULTI_TARGET_NODE,
+            .location = { .start = NULL, .end = NULL }
         },
-        .operator_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(operator),
-        .value = value,
-        .lparen_loc = *lparen_loc,
-        .rparen_loc = *rparen_loc,
-        .targets = YP_EMPTY_NODE_LIST
+        .targets = YP_EMPTY_NODE_LIST,
+        .lparen_loc = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE,
+        .rparen_loc = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE
     };
 
     return node;
 }
 
-// Append a target to a MultiWriteNode node.
+// Append a target to a MultiTargetNode node.
 static void
-yp_multi_write_node_targets_append(yp_multi_write_node_t *node, yp_node_t *target) {
+yp_multi_target_node_targets_append(yp_multi_target_node_t *node, yp_node_t *target) {
     yp_node_list_append(&node->targets, target);
 
     if (node->base.location.start == NULL || (node->base.location.start > target->location.start)) {
@@ -3357,9 +3352,25 @@ yp_multi_write_node_targets_append(yp_multi_write_node_t *node, yp_node_t *targe
     }
 }
 
-static inline void
-yp_multi_write_node_operator_loc_set(yp_multi_write_node_t *node, const yp_token_t *operator) {
-    node->operator_loc = YP_OPTIONAL_LOCATION_TOKEN_VALUE(operator);
+// Allocate a new MultiWriteNode node.
+static yp_multi_write_node_t *
+yp_multi_write_node_create(yp_parser_t *parser, yp_multi_target_node_t *target, const yp_token_t *operator, yp_node_t *value) {
+    yp_multi_write_node_t *node = YP_ALLOC_NODE(parser, yp_multi_write_node_t);
+
+    *node = (yp_multi_write_node_t) {
+        {
+            .type = YP_MULTI_WRITE_NODE,
+            .location = {
+                .start = target->base.location.start,
+                .end = value->location.end
+            }
+        },
+        .target = target,
+        .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+        .value = value
+    };
+
+    return node;
 }
 
 // Allocate and initialize a new NextNode node.
@@ -8073,7 +8084,7 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
             assert(sizeof(yp_instance_variable_target_node_t) == sizeof(yp_instance_variable_read_node_t));
             target->type = YP_INSTANCE_VARIABLE_TARGET_NODE;
             return target;
-        case YP_MULTI_WRITE_NODE:
+        case YP_MULTI_TARGET_NODE:
             return target;
         case YP_SPLAT_NODE: {
             yp_splat_node_t *splat = (yp_splat_node_t *) target;
@@ -8082,13 +8093,10 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
                 splat->expression = parse_target(parser, splat->expression);
             }
 
-            yp_token_t operator = not_provided(parser);
-            yp_location_t location = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE;
+            yp_multi_target_node_t *multi_target = yp_multi_target_node_create(parser);
+            yp_multi_target_node_targets_append(multi_target, (yp_node_t *) splat);
 
-            yp_multi_write_node_t *multi_write = yp_multi_write_node_create(parser, &operator, NULL, &location, &location);
-            yp_multi_write_node_targets_append(multi_write, (yp_node_t *) splat);
-
-            return (yp_node_t *) multi_write;
+            return (yp_node_t *) multi_target;
         }
         case YP_CALL_NODE: {
             yp_call_node_t *call = (yp_call_node_t *) target;
@@ -8214,14 +8222,8 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
             yp_node_destroy(parser, target);
             return write_node;
         }
-        case YP_MULTI_WRITE_NODE: {
-            yp_multi_write_node_t *multi_write = (yp_multi_write_node_t *) target;
-            yp_multi_write_node_operator_loc_set(multi_write, operator);
-
-            multi_write->value = value;
-            multi_write->base.location.end = value->location.end;
-            return (yp_node_t *) multi_write;
-        }
+        case YP_MULTI_TARGET_NODE:
+            return (yp_node_t *) yp_multi_write_node_create(parser, (yp_multi_target_node_t *) target, operator, value);
         case YP_SPLAT_NODE: {
             yp_splat_node_t *splat = (yp_splat_node_t *) target;
 
@@ -8229,11 +8231,10 @@ parse_write(yp_parser_t *parser, yp_node_t *target, yp_token_t *operator, yp_nod
                 splat->expression = parse_write(parser, splat->expression, operator, value);
             }
 
-            yp_location_t location = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE;
-            yp_multi_write_node_t *multi_write = yp_multi_write_node_create(parser, operator, value, &location, &location);
-            yp_multi_write_node_targets_append(multi_write, (yp_node_t *) splat);
+            yp_multi_target_node_t *multi_target = yp_multi_target_node_create(parser);
+            yp_multi_target_node_targets_append(multi_target, (yp_node_t *) splat);
 
-            return (yp_node_t *) multi_write;
+            return (yp_node_t *) yp_multi_write_node_create(parser, multi_target, operator, value);
         }
         case YP_CALL_NODE: {
             yp_call_node_t *call = (yp_call_node_t *) target;
@@ -8364,11 +8365,9 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
         }
     }
 
-    yp_location_t lparen_loc = YP_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE;
-    yp_multi_write_node_t *result = yp_multi_write_node_create(parser, &operator, NULL, &lparen_loc, &lparen_loc);
-
+    yp_multi_target_node_t *result = yp_multi_target_node_create(parser);
     if (first_target != NULL) {
-        yp_multi_write_node_targets_append(result, first_target);
+        yp_multi_target_node_targets_append(result, first_target);
     }
 
     bool has_splat = false;
@@ -8393,7 +8392,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                 }
 
                 yp_node_t *splat = (yp_node_t *) yp_splat_node_create(parser, &star_operator, name);
-                yp_multi_write_node_targets_append(result, splat);
+                yp_multi_target_node_targets_append(result, splat);
                 has_splat = true;
             } else if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
                 // Here we have a parenthesized list of targets. We'll recurse down into
@@ -8407,39 +8406,29 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                 expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN_AFTER_MULTI);
                 yp_token_t rparen = parser->previous;
 
-                if (YP_NODE_TYPE_P(child_target, YP_MULTI_WRITE_NODE) && first_target == NULL && result->targets.size == 0) {
+                if (YP_NODE_TYPE_P(child_target, YP_MULTI_TARGET_NODE) && first_target == NULL && result->targets.size == 0) {
                     yp_node_destroy(parser, (yp_node_t *) result);
-                    result = (yp_multi_write_node_t *) child_target;
+                    result = (yp_multi_target_node_t *) child_target;
                     result->base.location.start = lparen.start;
                     result->base.location.end = rparen.end;
                     result->lparen_loc = YP_LOCATION_TOKEN_VALUE(&lparen);
                     result->rparen_loc = YP_LOCATION_TOKEN_VALUE(&rparen);
                 } else {
-                    yp_multi_write_node_t *target;
+                    yp_multi_target_node_t *target;
 
-                    if (YP_NODE_TYPE_P(child_target, YP_MULTI_WRITE_NODE)) {
-                        target = (yp_multi_write_node_t *) child_target;
-                        target->base.location.start = lparen.start;
-                        target->base.location.end = rparen.end;
-                        target->lparen_loc = YP_LOCATION_TOKEN_VALUE(&lparen);
-                        target->rparen_loc = YP_LOCATION_TOKEN_VALUE(&rparen);
+                    if (YP_NODE_TYPE_P(child_target, YP_MULTI_TARGET_NODE)) {
+                        target = (yp_multi_target_node_t *) child_target;
                     } else {
-                        yp_token_t operator = not_provided(parser);
-
-                        target = yp_multi_write_node_create(
-                            parser,
-                            &operator,
-                            NULL,
-                            &YP_LOCATION_TOKEN_VALUE(&lparen),
-                            &YP_LOCATION_TOKEN_VALUE(&rparen)
-                        );
-
-                        yp_multi_write_node_targets_append(target, child_target);
+                        target = yp_multi_target_node_create(parser);
+                        yp_multi_target_node_targets_append(target, child_target);
                     }
 
                     target->base.location.start = lparen.start;
                     target->base.location.end = rparen.end;
-                    yp_multi_write_node_targets_append(result, (yp_node_t *) target);
+                    target->lparen_loc = YP_LOCATION_TOKEN_VALUE(&lparen);
+                    target->rparen_loc = YP_LOCATION_TOKEN_VALUE(&rparen);
+
+                    yp_multi_target_node_targets_append(result, (yp_node_t *) target);
                 }
             } else {
                 if (!token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_USTAR)) {
@@ -8455,14 +8444,14 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                     // We need to indicate this somehow in the tree, so we'll add an
                     // anonymous splat.
                     yp_node_t *splat = (yp_node_t *) yp_splat_node_create(parser, &parser->previous, NULL);
-                    yp_multi_write_node_targets_append(result, splat);
+                    yp_multi_target_node_targets_append(result, splat);
                     return (yp_node_t *) result;
                 }
 
                 yp_node_t *target = parse_expression(parser, binding_power, YP_ERR_EXPECT_EXPRESSION_AFTER_COMMA);
                 target = parse_target(parser, target);
 
-                yp_multi_write_node_targets_append(result, target);
+                yp_multi_target_node_targets_append(result, target);
             }
         } while (accept(parser, YP_TOKEN_COMMA));
     }
@@ -9674,7 +9663,7 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
 // can be transformed into write targets.
 #define YP_CASE_WRITABLE YP_CLASS_VARIABLE_READ_NODE: case YP_CONSTANT_PATH_NODE: \
     case YP_CONSTANT_READ_NODE: case YP_GLOBAL_VARIABLE_READ_NODE: case YP_LOCAL_VARIABLE_READ_NODE: \
-    case YP_INSTANCE_VARIABLE_READ_NODE: case YP_MULTI_WRITE_NODE: case YP_BACK_REFERENCE_READ_NODE: \
+    case YP_INSTANCE_VARIABLE_READ_NODE: case YP_MULTI_TARGET_NODE: case YP_BACK_REFERENCE_READ_NODE: \
     case YP_NUMBERED_REFERENCE_READ_NODE
 
 // Parse a node that is part of a string. If the subsequent tokens cannot be
@@ -10949,29 +10938,27 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_accepts_block_stack_pop(parser);
 
                 // If we have a single statement and are ending on a right parenthesis,
-                // then we need to check if this is possibly a multiple assignment node.
-                if (binding_power == YP_BINDING_POWER_STATEMENT && YP_NODE_TYPE_P(statement, YP_MULTI_WRITE_NODE)) {
-                    yp_multi_write_node_t *multi_statement = (yp_multi_write_node_t *) statement;
+                // then we need to check if this is possibly a multiple target node.
+                if (binding_power == YP_BINDING_POWER_STATEMENT && YP_NODE_TYPE_P(statement, YP_MULTI_TARGET_NODE)) {
+                    yp_node_t *target;
+                    yp_multi_target_node_t *multi_target = (yp_multi_target_node_t *) statement;
 
-                    if (multi_statement->value == NULL) {
-                        yp_location_t lparen_loc = YP_LOCATION_TOKEN_VALUE(&opening);
-                        yp_location_t rparen_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
-                        yp_multi_write_node_t *multi_write;
+                    yp_location_t lparen_loc = YP_LOCATION_TOKEN_VALUE(&opening);
+                    yp_location_t rparen_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
 
-                        if (multi_statement->lparen_loc.start == NULL) {
-                            multi_write = (yp_multi_write_node_t *) statement;
-                            multi_write->base.location.start = lparen_loc.start;
-                            multi_write->base.location.end = rparen_loc.end;
-                            multi_write->lparen_loc = lparen_loc;
-                            multi_write->rparen_loc = rparen_loc;
-                        } else {
-                            yp_token_t operator = not_provided(parser);
-                            multi_write = yp_multi_write_node_create(parser, &operator, NULL, &lparen_loc, &rparen_loc);
-                            yp_multi_write_node_targets_append(multi_write, statement);
-                        }
-
-                        return parse_targets(parser, (yp_node_t *) multi_write, YP_BINDING_POWER_INDEX);
+                    if (multi_target->lparen_loc.start == NULL) {
+                        multi_target->base.location.start = lparen_loc.start;
+                        multi_target->base.location.end = rparen_loc.end;
+                        multi_target->lparen_loc = lparen_loc;
+                        multi_target->rparen_loc = rparen_loc;
+                        target = (yp_node_t *) multi_target;
+                    } else {
+                        yp_multi_target_node_t *parent_target = yp_multi_target_node_create(parser);
+                        yp_multi_target_node_targets_append(parent_target, (yp_node_t *) multi_target);
+                        target = (yp_node_t *) parent_target;
                     }
+
+                    return parse_targets(parser, target, YP_BINDING_POWER_INDEX);
                 }
 
                 // If we have a single statement and are ending on a right parenthesis

--- a/test/yarp/location_test.rb
+++ b/test/yarp/location_test.rb
@@ -223,7 +223,7 @@ module YARP
 
     def test_ClassVariableTargetNode
       assert_location(ClassVariableTargetNode, "@@foo, @@bar = baz", 0...5) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -251,7 +251,7 @@ module YARP
 
     def test_ConstantPathTargetNode
       assert_location(ConstantPathTargetNode, "::Foo, ::Bar = baz", 0...5) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -280,7 +280,7 @@ module YARP
 
     def test_ConstantTargetNode
       assert_location(ConstantTargetNode, "Foo, Bar = baz", 0...3) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -378,7 +378,7 @@ module YARP
 
     def test_GlobalVariableTargetNode
       assert_location(GlobalVariableTargetNode, "$foo, $bar = baz", 0...4) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -430,7 +430,7 @@ module YARP
 
     def test_InstanceVariableTargetNode
       assert_location(InstanceVariableTargetNode, "@foo, @bar = baz", 0...4) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -517,7 +517,7 @@ module YARP
 
     def test_LocalVariableTargetNode
       assert_location(LocalVariableTargetNode, "foo, bar = baz", 0...3) do |node|
-        node.targets.first
+        node.target.targets.first
       end
     end
 
@@ -535,6 +535,11 @@ module YARP
 
     def test_ModuleNode
       assert_location(ModuleNode, "module Foo end")
+    end
+
+    def test_MultiTargetNode
+      assert_location(MultiTargetNode, "for foo, bar in baz do end", 4...12, &:index)
+      assert_location(MultiTargetNode, "foo, bar = baz", 0...8, &:target)
     end
 
     def test_MultiWriteNode
@@ -690,7 +695,7 @@ module YARP
     end
 
     def test_SplatNode
-      assert_location(SplatNode, "*foo = bar", 0...4) { |node| node.targets.first }
+      assert_location(SplatNode, "*foo = bar", 0...4) { |node| node.target.targets.first }
     end
 
     def test_StatementsNode

--- a/test/yarp/location_test.rb
+++ b/test/yarp/location_test.rb
@@ -223,7 +223,7 @@ module YARP
 
     def test_ClassVariableTargetNode
       assert_location(ClassVariableTargetNode, "@@foo, @@bar = baz", 0...5) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -251,7 +251,7 @@ module YARP
 
     def test_ConstantPathTargetNode
       assert_location(ConstantPathTargetNode, "::Foo, ::Bar = baz", 0...5) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -280,7 +280,7 @@ module YARP
 
     def test_ConstantTargetNode
       assert_location(ConstantTargetNode, "Foo, Bar = baz", 0...3) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -378,7 +378,7 @@ module YARP
 
     def test_GlobalVariableTargetNode
       assert_location(GlobalVariableTargetNode, "$foo, $bar = baz", 0...4) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -430,7 +430,7 @@ module YARP
 
     def test_InstanceVariableTargetNode
       assert_location(InstanceVariableTargetNode, "@foo, @bar = baz", 0...4) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -517,7 +517,7 @@ module YARP
 
     def test_LocalVariableTargetNode
       assert_location(LocalVariableTargetNode, "foo, bar = baz", 0...3) do |node|
-        node.target.targets.first
+        node.targets.first
       end
     end
 
@@ -539,7 +539,7 @@ module YARP
 
     def test_MultiTargetNode
       assert_location(MultiTargetNode, "for foo, bar in baz do end", 4...12, &:index)
-      assert_location(MultiTargetNode, "foo, bar = baz", 0...8, &:target)
+      assert_location(MultiTargetNode, "foo, (bar, baz) = qux", 5...15) { |node| node.targets.last }
     end
 
     def test_MultiWriteNode
@@ -695,7 +695,7 @@ module YARP
     end
 
     def test_SplatNode
-      assert_location(SplatNode, "*foo = bar", 0...4) { |node| node.target.targets.first }
+      assert_location(SplatNode, "*foo = bar", 0...4) { |node| node.targets.first }
     end
 
     def test_StatementsNode

--- a/test/yarp/snapshots/arrays.txt
+++ b/test/yarp/snapshots/arrays.txt
@@ -317,52 +317,50 @@ ProgramNode(0...511)(
        "[]="
      ),
      MultiWriteNode(191...212)(
-       MultiTargetNode(191...205)(
-         [CallNode(191...197)(
-            CallNode(191...194)(
-              nil,
-              nil,
-              (191...194),
-              nil,
-              nil,
-              nil,
-              nil,
-              2,
-              "foo"
-            ),
+       [CallNode(191...197)(
+          CallNode(191...194)(
             nil,
-            (194...197),
-            (194...195),
-            ArgumentsNode(195...196)([IntegerNode(195...196)()]),
-            (196...197),
             nil,
-            0,
-            "[]="
+            (191...194),
+            nil,
+            nil,
+            nil,
+            nil,
+            2,
+            "foo"
           ),
-          CallNode(199...205)(
-            CallNode(199...202)(
-              nil,
-              nil,
-              (199...202),
-              nil,
-              nil,
-              nil,
-              nil,
-              2,
-              "bar"
-            ),
+          nil,
+          (194...197),
+          (194...195),
+          ArgumentsNode(195...196)([IntegerNode(195...196)()]),
+          (196...197),
+          nil,
+          0,
+          "[]="
+        ),
+        CallNode(199...205)(
+          CallNode(199...202)(
             nil,
-            (202...205),
-            (202...203),
-            ArgumentsNode(203...204)([IntegerNode(203...204)()]),
-            (204...205),
             nil,
-            0,
-            "[]="
-          )],
-         nil,
-         nil
-       ),
+            (199...202),
+            nil,
+            nil,
+            nil,
+            nil,
+            2,
+            "bar"
+          ),
+          nil,
+          (202...205),
+          (202...203),
+          ArgumentsNode(203...204)([IntegerNode(203...204)()]),
+          (204...205),
+          nil,
+          0,
+          "[]="
+        )],
+       nil,
+       nil,
        (206...207),
        ArrayNode(208...212)(
          [IntegerNode(208...209)(), IntegerNode(211...212)()],

--- a/test/yarp/snapshots/arrays.txt
+++ b/test/yarp/snapshots/arrays.txt
@@ -317,56 +317,58 @@ ProgramNode(0...511)(
        "[]="
      ),
      MultiWriteNode(191...212)(
-       [CallNode(191...197)(
-          CallNode(191...194)(
+       MultiTargetNode(191...205)(
+         [CallNode(191...197)(
+            CallNode(191...194)(
+              nil,
+              nil,
+              (191...194),
+              nil,
+              nil,
+              nil,
+              nil,
+              2,
+              "foo"
+            ),
             nil,
+            (194...197),
+            (194...195),
+            ArgumentsNode(195...196)([IntegerNode(195...196)()]),
+            (196...197),
             nil,
-            (191...194),
-            nil,
-            nil,
-            nil,
-            nil,
-            2,
-            "foo"
+            0,
+            "[]="
           ),
-          nil,
-          (194...197),
-          (194...195),
-          ArgumentsNode(195...196)([IntegerNode(195...196)()]),
-          (196...197),
-          nil,
-          0,
-          "[]="
-        ),
-        CallNode(199...205)(
-          CallNode(199...202)(
+          CallNode(199...205)(
+            CallNode(199...202)(
+              nil,
+              nil,
+              (199...202),
+              nil,
+              nil,
+              nil,
+              nil,
+              2,
+              "bar"
+            ),
             nil,
+            (202...205),
+            (202...203),
+            ArgumentsNode(203...204)([IntegerNode(203...204)()]),
+            (204...205),
             nil,
-            (199...202),
-            nil,
-            nil,
-            nil,
-            nil,
-            2,
-            "bar"
-          ),
-          nil,
-          (202...205),
-          (202...203),
-          ArgumentsNode(203...204)([IntegerNode(203...204)()]),
-          (204...205),
-          nil,
-          0,
-          "[]="
-        )],
+            0,
+            "[]="
+          )],
+         nil,
+         nil
+       ),
        (206...207),
        ArrayNode(208...212)(
          [IntegerNode(208...209)(), IntegerNode(211...212)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      CallNode(214...233)(
        CallNode(214...217)(

--- a/test/yarp/snapshots/for.txt
+++ b/test/yarp/snapshots/for.txt
@@ -2,10 +2,8 @@ ProgramNode(0...143)(
   [:i, :j, :k],
   StatementsNode(0...143)(
     [ForNode(0...20)(
-       MultiWriteNode(4...5)(
+       MultiTargetNode(4...5)(
          [LocalVariableTargetNode(4...5)(:i, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -22,10 +20,8 @@ ProgramNode(0...143)(
        (17...20)
      ),
      ForNode(22...44)(
-       MultiWriteNode(26...27)(
+       MultiTargetNode(26...27)(
          [LocalVariableTargetNode(26...27)(:i, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -42,11 +38,9 @@ ProgramNode(0...143)(
        (41...44)
      ),
      ForNode(46...68)(
-       MultiWriteNode(50...53)(
+       MultiTargetNode(50...53)(
          [LocalVariableTargetNode(50...51)(:i, 0),
           LocalVariableTargetNode(52...53)(:j, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -63,12 +57,10 @@ ProgramNode(0...143)(
        (65...68)
      ),
      ForNode(70...94)(
-       MultiWriteNode(74...79)(
+       MultiTargetNode(74...79)(
          [LocalVariableTargetNode(74...75)(:i, 0),
           LocalVariableTargetNode(76...77)(:j, 0),
           LocalVariableTargetNode(78...79)(:k, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -85,10 +77,8 @@ ProgramNode(0...143)(
        (91...94)
      ),
      ForNode(96...119)(
-       MultiWriteNode(100...101)(
+       MultiTargetNode(100...101)(
          [LocalVariableTargetNode(100...101)(:i, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -105,10 +95,8 @@ ProgramNode(0...143)(
        (116...119)
      ),
      ForNode(121...143)(
-       MultiWriteNode(125...126)(
+       MultiTargetNode(125...126)(
          [LocalVariableTargetNode(125...126)(:i, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),

--- a/test/yarp/snapshots/method_calls.txt
+++ b/test/yarp/snapshots/method_calls.txt
@@ -348,56 +348,58 @@ ProgramNode(0...1237)(
        "b"
      ),
      MultiWriteNode(181...204)(
-       [CallNode(181...188)(
-          CallNode(181...184)(
+       MultiTargetNode(181...197)(
+         [CallNode(181...188)(
+            CallNode(181...184)(
+              nil,
+              nil,
+              (181...184),
+              nil,
+              nil,
+              nil,
+              nil,
+              2,
+              "foo"
+            ),
+            (184...185),
+            (185...188),
             nil,
             nil,
-            (181...184),
             nil,
             nil,
-            nil,
-            nil,
-            2,
-            "foo"
+            0,
+            "foo="
           ),
-          (184...185),
-          (185...188),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "foo="
-        ),
-        CallNode(190...197)(
-          CallNode(190...193)(
+          CallNode(190...197)(
+            CallNode(190...193)(
+              nil,
+              nil,
+              (190...193),
+              nil,
+              nil,
+              nil,
+              nil,
+              2,
+              "bar"
+            ),
+            (193...194),
+            (194...197),
             nil,
             nil,
-            (190...193),
             nil,
             nil,
-            nil,
-            nil,
-            2,
-            "bar"
-          ),
-          (193...194),
-          (194...197),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "bar="
-        )],
+            0,
+            "bar="
+          )],
+         nil,
+         nil
+       ),
        (198...199),
        ArrayNode(200...204)(
          [IntegerNode(200...201)(), IntegerNode(203...204)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      CallNode(206...210)(
        CallNode(206...207)(nil, nil, (206...207), nil, nil, nil, nil, 2, "a"),

--- a/test/yarp/snapshots/method_calls.txt
+++ b/test/yarp/snapshots/method_calls.txt
@@ -348,52 +348,50 @@ ProgramNode(0...1237)(
        "b"
      ),
      MultiWriteNode(181...204)(
-       MultiTargetNode(181...197)(
-         [CallNode(181...188)(
-            CallNode(181...184)(
-              nil,
-              nil,
-              (181...184),
-              nil,
-              nil,
-              nil,
-              nil,
-              2,
-              "foo"
-            ),
-            (184...185),
-            (185...188),
+       [CallNode(181...188)(
+          CallNode(181...184)(
+            nil,
+            nil,
+            (181...184),
             nil,
             nil,
             nil,
             nil,
-            0,
-            "foo="
+            2,
+            "foo"
           ),
-          CallNode(190...197)(
-            CallNode(190...193)(
-              nil,
-              nil,
-              (190...193),
-              nil,
-              nil,
-              nil,
-              nil,
-              2,
-              "bar"
-            ),
-            (193...194),
-            (194...197),
+          (184...185),
+          (185...188),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "foo="
+        ),
+        CallNode(190...197)(
+          CallNode(190...193)(
+            nil,
+            nil,
+            (190...193),
             nil,
             nil,
             nil,
             nil,
-            0,
-            "bar="
-          )],
-         nil,
-         nil
-       ),
+            2,
+            "bar"
+          ),
+          (193...194),
+          (194...197),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "bar="
+        )],
+       nil,
+       nil,
        (198...199),
        ArrayNode(200...204)(
          [IntegerNode(200...201)(), IntegerNode(203...204)()],

--- a/test/yarp/snapshots/seattlerb/masgn_anon_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_anon_splat_arg.txt
@@ -2,12 +2,10 @@ ProgramNode(0...8)(
   [:a],
   StatementsNode(0...8)(
     [MultiWriteNode(0...8)(
-       MultiTargetNode(0...4)(
-         [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
-          LocalVariableTargetNode(3...4)(:a, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+        LocalVariableTargetNode(3...4)(:a, 0)],
+       nil,
+       nil,
        (5...6),
        CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "b")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_anon_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_anon_splat_arg.txt
@@ -2,18 +2,14 @@ ProgramNode(0...8)(
   [:a],
   StatementsNode(0...8)(
     [MultiWriteNode(0...8)(
-       [MultiWriteNode(0...1)(
-          [SplatNode(0...1)((0...1), nil)],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(3...4)(:a, 0)],
+       MultiTargetNode(0...4)(
+         [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+          LocalVariableTargetNode(3...4)(:a, 0)],
+         nil,
+         nil
+       ),
        (5...6),
-       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "b"),
-       nil,
-       nil
+       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "b")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_arg_colon_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_colon_arg.txt
@@ -2,22 +2,24 @@ ProgramNode(0...11)(
   [:a],
   StatementsNode(0...11)(
     [MultiWriteNode(0...11)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        CallNode(3...7)(
-          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-          (4...6),
-          (6...7),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "c="
-        )],
+       MultiTargetNode(0...7)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          CallNode(3...7)(
+            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+            (4...6),
+            (6...7),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "c="
+          )],
+         nil,
+         nil
+       ),
        (8...9),
-       CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "d"),
-       nil,
-       nil
+       CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "d")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_arg_colon_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_colon_arg.txt
@@ -2,22 +2,20 @@ ProgramNode(0...11)(
   [:a],
   StatementsNode(0...11)(
     [MultiWriteNode(0...11)(
-       MultiTargetNode(0...7)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          CallNode(3...7)(
-            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-            (4...6),
-            (6...7),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "c="
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        CallNode(3...7)(
+          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+          (4...6),
+          (6...7),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "c="
+        )],
+       nil,
+       nil,
        (8...9),
        CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "d")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_arg_ident.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_ident.txt
@@ -2,22 +2,20 @@ ProgramNode(0...10)(
   [:a],
   StatementsNode(0...10)(
     [MultiWriteNode(0...10)(
-       MultiTargetNode(0...6)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          CallNode(3...6)(
-            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-            (4...5),
-            (5...6),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "C="
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        CallNode(3...6)(
+          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+          (4...5),
+          (5...6),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "C="
+        )],
+       nil,
+       nil,
        (7...8),
        CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "d")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_arg_ident.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_ident.txt
@@ -2,22 +2,24 @@ ProgramNode(0...10)(
   [:a],
   StatementsNode(0...10)(
     [MultiWriteNode(0...10)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        CallNode(3...6)(
-          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-          (4...5),
-          (5...6),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "C="
-        )],
+       MultiTargetNode(0...6)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          CallNode(3...6)(
+            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+            (4...5),
+            (5...6),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "C="
+          )],
+         nil,
+         nil
+       ),
        (7...8),
-       CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "d"),
-       nil,
-       nil
+       CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "d")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_arg_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_splat_arg.txt
@@ -2,13 +2,11 @@ ProgramNode(0...12)(
   [:a, :b, :c],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       MultiTargetNode(0...8)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          SplatNode(3...5)((3...4), LocalVariableTargetNode(4...5)(:b, 0)),
-          LocalVariableTargetNode(7...8)(:c, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        SplatNode(3...5)((3...4), LocalVariableTargetNode(4...5)(:b, 0)),
+        LocalVariableTargetNode(7...8)(:c, 0)],
+       nil,
+       nil,
        (9...10),
        CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_arg_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_arg_splat_arg.txt
@@ -2,13 +2,15 @@ ProgramNode(0...12)(
   [:a, :b, :c],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        SplatNode(3...5)((3...4), LocalVariableTargetNode(4...5)(:b, 0)),
-        LocalVariableTargetNode(7...8)(:c, 0)],
+       MultiTargetNode(0...8)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          SplatNode(3...5)((3...4), LocalVariableTargetNode(4...5)(:b, 0)),
+          LocalVariableTargetNode(7...8)(:c, 0)],
+         nil,
+         nil
+       ),
        (9...10),
-       CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d"),
-       nil,
-       nil
+       CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_colon2.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_colon2.txt
@@ -2,16 +2,14 @@ ProgramNode(0...14)(
   [:a],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       MultiTargetNode(0...7)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          ConstantPathTargetNode(3...7)(
-            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-            ConstantReadNode(6...7)(:C),
-            (4...6)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        ConstantPathTargetNode(3...7)(
+          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+          ConstantReadNode(6...7)(:C),
+          (4...6)
+        )],
+       nil,
+       nil,
        (8...9),
        ArrayNode(10...14)(
          [IntegerNode(10...11)(), IntegerNode(13...14)()],

--- a/test/yarp/snapshots/seattlerb/masgn_colon2.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_colon2.txt
@@ -2,20 +2,22 @@ ProgramNode(0...14)(
   [:a],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        ConstantPathTargetNode(3...7)(
-          CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
-          ConstantReadNode(6...7)(:C),
-          (4...6)
-        )],
+       MultiTargetNode(0...7)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          ConstantPathTargetNode(3...7)(
+            CallNode(3...4)(nil, nil, (3...4), nil, nil, nil, nil, 2, "b"),
+            ConstantReadNode(6...7)(:C),
+            (4...6)
+          )],
+         nil,
+         nil
+       ),
        (8...9),
        ArrayNode(10...14)(
          [IntegerNode(10...11)(), IntegerNode(13...14)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_colon3.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_colon3.txt
@@ -2,20 +2,18 @@ ProgramNode(0...15)(
   [],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       MultiTargetNode(0...8)(
-         [ConstantPathTargetNode(0...3)(
-            nil,
-            ConstantReadNode(2...3)(:A),
-            (0...2)
-          ),
-          ConstantPathTargetNode(5...8)(
-            nil,
-            ConstantReadNode(7...8)(:B),
-            (5...7)
-          )],
-         nil,
-         nil
-       ),
+       [ConstantPathTargetNode(0...3)(
+          nil,
+          ConstantReadNode(2...3)(:A),
+          (0...2)
+        ),
+        ConstantPathTargetNode(5...8)(
+          nil,
+          ConstantReadNode(7...8)(:B),
+          (5...7)
+        )],
+       nil,
+       nil,
        (9...10),
        ArrayNode(11...15)(
          [IntegerNode(11...12)(), IntegerNode(14...15)()],

--- a/test/yarp/snapshots/seattlerb/masgn_colon3.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_colon3.txt
@@ -2,24 +2,26 @@ ProgramNode(0...15)(
   [],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       [ConstantPathTargetNode(0...3)(
-          nil,
-          ConstantReadNode(2...3)(:A),
-          (0...2)
-        ),
-        ConstantPathTargetNode(5...8)(
-          nil,
-          ConstantReadNode(7...8)(:B),
-          (5...7)
-        )],
+       MultiTargetNode(0...8)(
+         [ConstantPathTargetNode(0...3)(
+            nil,
+            ConstantReadNode(2...3)(:A),
+            (0...2)
+          ),
+          ConstantPathTargetNode(5...8)(
+            nil,
+            ConstantReadNode(7...8)(:B),
+            (5...7)
+          )],
+         nil,
+         nil
+       ),
        (9...10),
        ArrayNode(11...15)(
          [IntegerNode(11...12)(), IntegerNode(14...15)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_command_call.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_command_call.txt
@@ -2,12 +2,9 @@ ProgramNode(0...10)(
   [:a],
   StatementsNode(0...10)(
     [MultiWriteNode(0...10)(
-       MultiTargetNode(0...2)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          SplatNode(1...2)((1...2), nil)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0), SplatNode(1...2)((1...2), nil)],
+       nil,
+       nil,
        (3...4),
        CallNode(5...10)(
          CallNode(5...6)(nil, nil, (5...6), nil, nil, nil, nil, 2, "b"),

--- a/test/yarp/snapshots/seattlerb/masgn_command_call.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_command_call.txt
@@ -2,7 +2,12 @@ ProgramNode(0...10)(
   [:a],
   StatementsNode(0...10)(
     [MultiWriteNode(0...10)(
-       [LocalVariableTargetNode(0...1)(:a, 0), SplatNode(1...2)((1...2), nil)],
+       MultiTargetNode(0...2)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          SplatNode(1...2)((1...2), nil)],
+         nil,
+         nil
+       ),
        (3...4),
        CallNode(5...10)(
          CallNode(5...6)(nil, nil, (5...6), nil, nil, nil, nil, 2, "b"),
@@ -14,9 +19,7 @@ ProgramNode(0...10)(
          nil,
          0,
          "c"
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_double_paren.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_double_paren.txt
@@ -2,16 +2,14 @@ ProgramNode(1...9)(
   [:a, :b],
   StatementsNode(1...9)(
     [MultiWriteNode(1...9)(
-       MultiTargetNode(1...6)(
-         [MultiTargetNode(1...6)(
-            [LocalVariableTargetNode(2...3)(:a, 0),
-             LocalVariableTargetNode(4...5)(:b, 0)],
-            (1...2),
-            (5...6)
-          )],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(1...6)(
+          [LocalVariableTargetNode(2...3)(:a, 0),
+           LocalVariableTargetNode(4...5)(:b, 0)],
+          (1...2),
+          (5...6)
+        )],
+       nil,
+       nil,
        (7...8),
        CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_double_paren.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_double_paren.txt
@@ -1,19 +1,19 @@
-ProgramNode(0...9)(
+ProgramNode(1...9)(
   [:a, :b],
-  StatementsNode(0...9)(
-    [MultiWriteNode(0...9)(
-       [MultiWriteNode(1...6)(
-          [LocalVariableTargetNode(2...3)(:a, 0),
-           LocalVariableTargetNode(4...5)(:b, 0)],
-          nil,
-          nil,
-          (1...2),
-          (5...6)
-        )],
+  StatementsNode(1...9)(
+    [MultiWriteNode(1...9)(
+       MultiTargetNode(1...6)(
+         [MultiTargetNode(1...6)(
+            [LocalVariableTargetNode(2...3)(:a, 0),
+             LocalVariableTargetNode(4...5)(:b, 0)],
+            (1...2),
+            (5...6)
+          )],
+         nil,
+         nil
+       ),
        (7...8),
-       CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c"),
-       (0...1),
-       (6...7)
+       CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_lhs_splat.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_lhs_splat.txt
@@ -2,15 +2,17 @@ ProgramNode(0...12)(
   [:a],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+       MultiTargetNode(0...2)(
+         [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+         nil,
+         nil
+       ),
        (3...4),
        ArrayNode(5...12)(
          [IntegerNode(5...6)(), IntegerNode(8...9)(), IntegerNode(11...12)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_lhs_splat.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_lhs_splat.txt
@@ -2,11 +2,9 @@ ProgramNode(0...12)(
   [:a],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       MultiTargetNode(0...2)(
-         [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
-         nil,
-         nil
-       ),
+       [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+       nil,
+       nil,
        (3...4),
        ArrayNode(5...12)(
          [IntegerNode(5...6)(), IntegerNode(8...9)(), IntegerNode(11...12)()],

--- a/test/yarp/snapshots/seattlerb/masgn_paren.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_paren.txt
@@ -2,12 +2,10 @@ ProgramNode(0...12)(
   [:a, :b],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       MultiTargetNode(0...6)(
-         [LocalVariableTargetNode(1...2)(:a, 0),
-          LocalVariableTargetNode(4...5)(:b, 0)],
-         (0...1),
-         (5...6)
-       ),
+       [LocalVariableTargetNode(1...2)(:a, 0),
+        LocalVariableTargetNode(4...5)(:b, 0)],
+       (0...1),
+       (5...6),
        (7...8),
        CallNode(9...12)(
          CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "c"),

--- a/test/yarp/snapshots/seattlerb/masgn_paren.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_paren.txt
@@ -2,8 +2,12 @@ ProgramNode(0...12)(
   [:a, :b],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       [LocalVariableTargetNode(1...2)(:a, 0),
-        LocalVariableTargetNode(4...5)(:b, 0)],
+       MultiTargetNode(0...6)(
+         [LocalVariableTargetNode(1...2)(:a, 0),
+          LocalVariableTargetNode(4...5)(:b, 0)],
+         (0...1),
+         (5...6)
+       ),
        (7...8),
        CallNode(9...12)(
          CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "c"),
@@ -15,9 +19,7 @@ ProgramNode(0...12)(
          nil,
          0,
          "d"
-       ),
-       (0...1),
-       (5...6)
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_splat_arg.txt
@@ -2,16 +2,14 @@ ProgramNode(0...9)(
   [:a, :b],
   StatementsNode(0...9)(
     [MultiWriteNode(0...9)(
-       MultiTargetNode(0...5)(
-         [MultiTargetNode(0...2)(
-            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
-            nil,
-            nil
-          ),
-          LocalVariableTargetNode(4...5)(:b, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(0...2)(
+          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+          nil,
+          nil
+        ),
+        LocalVariableTargetNode(4...5)(:b, 0)],
+       nil,
+       nil,
        (6...7),
        CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_splat_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_splat_arg.txt
@@ -2,18 +2,18 @@ ProgramNode(0...9)(
   [:a, :b],
   StatementsNode(0...9)(
     [MultiWriteNode(0...9)(
-       [MultiWriteNode(0...2)(
-          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(4...5)(:b, 0)],
+       MultiTargetNode(0...5)(
+         [MultiTargetNode(0...2)(
+            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+            nil,
+            nil
+          ),
+          LocalVariableTargetNode(4...5)(:b, 0)],
+         nil,
+         nil
+       ),
        (6...7),
-       CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c"),
-       nil,
-       nil
+       CallNode(8...9)(nil, nil, (8...9), nil, nil, nil, nil, 2, "c")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_splat_arg_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_splat_arg_arg.txt
@@ -2,19 +2,19 @@ ProgramNode(0...12)(
   [:a, :b, :c],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       [MultiWriteNode(0...2)(
-          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(4...5)(:b, 0),
-        LocalVariableTargetNode(7...8)(:c, 0)],
+       MultiTargetNode(0...8)(
+         [MultiTargetNode(0...2)(
+            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+            nil,
+            nil
+          ),
+          LocalVariableTargetNode(4...5)(:b, 0),
+          LocalVariableTargetNode(7...8)(:c, 0)],
+         nil,
+         nil
+       ),
        (9...10),
-       CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d"),
-       nil,
-       nil
+       CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_splat_arg_arg.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_splat_arg_arg.txt
@@ -2,17 +2,15 @@ ProgramNode(0...12)(
   [:a, :b, :c],
   StatementsNode(0...12)(
     [MultiWriteNode(0...12)(
-       MultiTargetNode(0...8)(
-         [MultiTargetNode(0...2)(
-            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
-            nil,
-            nil
-          ),
-          LocalVariableTargetNode(4...5)(:b, 0),
-          LocalVariableTargetNode(7...8)(:c, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(0...2)(
+          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:a, 0))],
+          nil,
+          nil
+        ),
+        LocalVariableTargetNode(4...5)(:b, 0),
+        LocalVariableTargetNode(7...8)(:c, 0)],
+       nil,
+       nil,
        (9...10),
        CallNode(11...12)(nil, nil, (11...12), nil, nil, nil, nil, 2, "d")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_star.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_star.txt
@@ -2,11 +2,9 @@ ProgramNode(0...5)(
   [],
   StatementsNode(0...5)(
     [MultiWriteNode(0...5)(
-       [SplatNode(0...1)((0...1), nil)],
+       MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
        (2...3),
-       IntegerNode(4...5)(),
-       nil,
-       nil
+       IntegerNode(4...5)()
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/masgn_star.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_star.txt
@@ -2,7 +2,9 @@ ProgramNode(0...5)(
   [],
   StatementsNode(0...5)(
     [MultiWriteNode(0...5)(
-       MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+       [SplatNode(0...1)((0...1), nil)],
+       nil,
+       nil,
        (2...3),
        IntegerNode(4...5)()
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_var_star_var.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_var_star_var.txt
@@ -2,13 +2,11 @@ ProgramNode(0...11)(
   [:a, :b],
   StatementsNode(0...11)(
     [MultiWriteNode(0...11)(
-       MultiTargetNode(0...7)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          SplatNode(3...4)((3...4), nil),
-          LocalVariableTargetNode(6...7)(:b, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        SplatNode(3...4)((3...4), nil),
+        LocalVariableTargetNode(6...7)(:b, 0)],
+       nil,
+       nil,
        (8...9),
        CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "c")
      )]

--- a/test/yarp/snapshots/seattlerb/masgn_var_star_var.txt
+++ b/test/yarp/snapshots/seattlerb/masgn_var_star_var.txt
@@ -2,13 +2,15 @@ ProgramNode(0...11)(
   [:a, :b],
   StatementsNode(0...11)(
     [MultiWriteNode(0...11)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        SplatNode(3...4)((3...4), nil),
-        LocalVariableTargetNode(6...7)(:b, 0)],
+       MultiTargetNode(0...7)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          SplatNode(3...4)((3...4), nil),
+          LocalVariableTargetNode(6...7)(:b, 0)],
+         nil,
+         nil
+       ),
        (8...9),
-       CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "c"),
-       nil,
-       nil
+       CallNode(10...11)(nil, nil, (10...11), nil, nil, nil, nil, 2, "c")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_back_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_back_anonsplat.txt
@@ -2,14 +2,16 @@ ProgramNode(0...14)(
   [:a, :b, :c],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0),
-        LocalVariableTargetNode(6...7)(:c, 0),
-        SplatNode(9...10)((9...10), nil)],
+       MultiTargetNode(0...10)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0),
+          LocalVariableTargetNode(6...7)(:c, 0),
+          SplatNode(9...10)((9...10), nil)],
+         nil,
+         nil
+       ),
        (11...12),
-       CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_back_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_back_anonsplat.txt
@@ -2,14 +2,12 @@ ProgramNode(0...14)(
   [:a, :b, :c],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       MultiTargetNode(0...10)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0),
-          LocalVariableTargetNode(6...7)(:c, 0),
-          SplatNode(9...10)((9...10), nil)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0),
+        LocalVariableTargetNode(6...7)(:c, 0),
+        SplatNode(9...10)((9...10), nil)],
+       nil,
+       nil,
        (11...12),
        CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_back_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_back_splat.txt
@@ -2,17 +2,12 @@ ProgramNode(0...15)(
   [:a, :b, :c, :s],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       MultiTargetNode(0...11)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0),
-          LocalVariableTargetNode(6...7)(:c, 0),
-          SplatNode(9...11)(
-            (9...10),
-            LocalVariableTargetNode(10...11)(:s, 0)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0),
+        LocalVariableTargetNode(6...7)(:c, 0),
+        SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0))],
+       nil,
+       nil,
        (12...13),
        CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_back_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_back_splat.txt
@@ -2,14 +2,19 @@ ProgramNode(0...15)(
   [:a, :b, :c, :s],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0),
-        LocalVariableTargetNode(6...7)(:c, 0),
-        SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0))],
+       MultiTargetNode(0...11)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0),
+          LocalVariableTargetNode(6...7)(:c, 0),
+          SplatNode(9...11)(
+            (9...10),
+            LocalVariableTargetNode(10...11)(:s, 0)
+          )],
+         nil,
+         nil
+       ),
        (12...13),
-       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_front_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_front_anonsplat.txt
@@ -2,20 +2,16 @@ ProgramNode(0...14)(
   [:x, :y, :z],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       [MultiWriteNode(0...1)(
-          [SplatNode(0...1)((0...1), nil)],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(3...4)(:x, 0),
-        LocalVariableTargetNode(6...7)(:y, 0),
-        LocalVariableTargetNode(9...10)(:z, 0)],
+       MultiTargetNode(0...10)(
+         [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+          LocalVariableTargetNode(3...4)(:x, 0),
+          LocalVariableTargetNode(6...7)(:y, 0),
+          LocalVariableTargetNode(9...10)(:z, 0)],
+         nil,
+         nil
+       ),
        (11...12),
-       CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_front_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_front_anonsplat.txt
@@ -2,14 +2,12 @@ ProgramNode(0...14)(
   [:x, :y, :z],
   StatementsNode(0...14)(
     [MultiWriteNode(0...14)(
-       MultiTargetNode(0...10)(
-         [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
-          LocalVariableTargetNode(3...4)(:x, 0),
-          LocalVariableTargetNode(6...7)(:y, 0),
-          LocalVariableTargetNode(9...10)(:z, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+        LocalVariableTargetNode(3...4)(:x, 0),
+        LocalVariableTargetNode(6...7)(:y, 0),
+        LocalVariableTargetNode(9...10)(:z, 0)],
+       nil,
+       nil,
        (11...12),
        CallNode(13...14)(nil, nil, (13...14), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_front_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_front_splat.txt
@@ -2,18 +2,16 @@ ProgramNode(0...15)(
   [:s, :x, :y, :z],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       MultiTargetNode(0...11)(
-         [MultiTargetNode(0...2)(
-            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:s, 0))],
-            nil,
-            nil
-          ),
-          LocalVariableTargetNode(4...5)(:x, 0),
-          LocalVariableTargetNode(7...8)(:y, 0),
-          LocalVariableTargetNode(10...11)(:z, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(0...2)(
+          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:s, 0))],
+          nil,
+          nil
+        ),
+        LocalVariableTargetNode(4...5)(:x, 0),
+        LocalVariableTargetNode(7...8)(:y, 0),
+        LocalVariableTargetNode(10...11)(:z, 0)],
+       nil,
+       nil,
        (12...13),
        CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_front_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_front_splat.txt
@@ -2,20 +2,20 @@ ProgramNode(0...15)(
   [:s, :x, :y, :z],
   StatementsNode(0...15)(
     [MultiWriteNode(0...15)(
-       [MultiWriteNode(0...2)(
-          [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:s, 0))],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(4...5)(:x, 0),
-        LocalVariableTargetNode(7...8)(:y, 0),
-        LocalVariableTargetNode(10...11)(:z, 0)],
+       MultiTargetNode(0...11)(
+         [MultiTargetNode(0...2)(
+            [SplatNode(0...2)((0...1), LocalVariableTargetNode(1...2)(:s, 0))],
+            nil,
+            nil
+          ),
+          LocalVariableTargetNode(4...5)(:x, 0),
+          LocalVariableTargetNode(7...8)(:y, 0),
+          LocalVariableTargetNode(10...11)(:z, 0)],
+         nil,
+         nil
+       ),
        (12...13),
-       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(14...15)(nil, nil, (14...15), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_mid_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_mid_anonsplat.txt
@@ -2,17 +2,15 @@ ProgramNode(0...23)(
   [:a, :b, :c, :x, :y, :z],
   StatementsNode(0...23)(
     [MultiWriteNode(0...23)(
-       MultiTargetNode(0...19)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0),
-          LocalVariableTargetNode(6...7)(:c, 0),
-          SplatNode(9...10)((9...10), nil),
-          LocalVariableTargetNode(12...13)(:x, 0),
-          LocalVariableTargetNode(15...16)(:y, 0),
-          LocalVariableTargetNode(18...19)(:z, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0),
+        LocalVariableTargetNode(6...7)(:c, 0),
+        SplatNode(9...10)((9...10), nil),
+        LocalVariableTargetNode(12...13)(:x, 0),
+        LocalVariableTargetNode(15...16)(:y, 0),
+        LocalVariableTargetNode(18...19)(:z, 0)],
+       nil,
+       nil,
        (20...21),
        CallNode(22...23)(nil, nil, (22...23), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_mid_anonsplat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_mid_anonsplat.txt
@@ -2,17 +2,19 @@ ProgramNode(0...23)(
   [:a, :b, :c, :x, :y, :z],
   StatementsNode(0...23)(
     [MultiWriteNode(0...23)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0),
-        LocalVariableTargetNode(6...7)(:c, 0),
-        SplatNode(9...10)((9...10), nil),
-        LocalVariableTargetNode(12...13)(:x, 0),
-        LocalVariableTargetNode(15...16)(:y, 0),
-        LocalVariableTargetNode(18...19)(:z, 0)],
+       MultiTargetNode(0...19)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0),
+          LocalVariableTargetNode(6...7)(:c, 0),
+          SplatNode(9...10)((9...10), nil),
+          LocalVariableTargetNode(12...13)(:x, 0),
+          LocalVariableTargetNode(15...16)(:y, 0),
+          LocalVariableTargetNode(18...19)(:z, 0)],
+         nil,
+         nil
+       ),
        (20...21),
-       CallNode(22...23)(nil, nil, (22...23), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(22...23)(nil, nil, (22...23), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_mid_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_mid_splat.txt
@@ -2,17 +2,15 @@ ProgramNode(0...24)(
   [:a, :b, :c, :s, :x, :y, :z],
   StatementsNode(0...24)(
     [MultiWriteNode(0...24)(
-       MultiTargetNode(0...20)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0),
-          LocalVariableTargetNode(6...7)(:c, 0),
-          SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0)),
-          LocalVariableTargetNode(13...14)(:x, 0),
-          LocalVariableTargetNode(16...17)(:y, 0),
-          LocalVariableTargetNode(19...20)(:z, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0),
+        LocalVariableTargetNode(6...7)(:c, 0),
+        SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0)),
+        LocalVariableTargetNode(13...14)(:x, 0),
+        LocalVariableTargetNode(16...17)(:y, 0),
+        LocalVariableTargetNode(19...20)(:z, 0)],
+       nil,
+       nil,
        (21...22),
        CallNode(23...24)(nil, nil, (23...24), nil, nil, nil, nil, 2, "f")
      )]

--- a/test/yarp/snapshots/seattlerb/mlhs_mid_splat.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_mid_splat.txt
@@ -2,17 +2,19 @@ ProgramNode(0...24)(
   [:a, :b, :c, :s, :x, :y, :z],
   StatementsNode(0...24)(
     [MultiWriteNode(0...24)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0),
-        LocalVariableTargetNode(6...7)(:c, 0),
-        SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0)),
-        LocalVariableTargetNode(13...14)(:x, 0),
-        LocalVariableTargetNode(16...17)(:y, 0),
-        LocalVariableTargetNode(19...20)(:z, 0)],
+       MultiTargetNode(0...20)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0),
+          LocalVariableTargetNode(6...7)(:c, 0),
+          SplatNode(9...11)((9...10), LocalVariableTargetNode(10...11)(:s, 0)),
+          LocalVariableTargetNode(13...14)(:x, 0),
+          LocalVariableTargetNode(16...17)(:y, 0),
+          LocalVariableTargetNode(19...20)(:z, 0)],
+         nil,
+         nil
+       ),
        (21...22),
-       CallNode(23...24)(nil, nil, (23...24), nil, nil, nil, nil, 2, "f"),
-       nil,
-       nil
+       CallNode(23...24)(nil, nil, (23...24), nil, nil, nil, nil, 2, "f")
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_rescue.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_rescue.txt
@@ -2,16 +2,18 @@ ProgramNode(0...18)(
   [:a, :b],
   StatementsNode(0...18)(
     [MultiWriteNode(0...18)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0)],
+       MultiTargetNode(0...4)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0)],
+         nil,
+         nil
+       ),
        (5...6),
        RescueModifierNode(7...18)(
          CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "f"),
          (9...15),
          IntegerNode(16...18)()
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/seattlerb/mlhs_rescue.txt
+++ b/test/yarp/snapshots/seattlerb/mlhs_rescue.txt
@@ -2,12 +2,10 @@ ProgramNode(0...18)(
   [:a, :b],
   StatementsNode(0...18)(
     [MultiWriteNode(0...18)(
-       MultiTargetNode(0...4)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0)],
+       nil,
+       nil,
        (5...6),
        RescueModifierNode(7...18)(
          CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "f"),

--- a/test/yarp/snapshots/seattlerb/parse_line_to_ary.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_to_ary.txt
@@ -2,12 +2,14 @@ ProgramNode(0...10)(
   [:a, :b],
   StatementsNode(0...10)(
     [MultiWriteNode(0...8)(
-       [LocalVariableTargetNode(0...1)(:a, 0),
-        LocalVariableTargetNode(3...4)(:b, 0)],
+       MultiTargetNode(0...4)(
+         [LocalVariableTargetNode(0...1)(:a, 0),
+          LocalVariableTargetNode(3...4)(:b, 0)],
+         nil,
+         nil
+       ),
        (5...6),
-       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "c"),
-       nil,
-       nil
+       CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "c")
      ),
      CallNode(9...10)(nil, nil, (9...10), nil, nil, nil, nil, 2, "d")]
   )

--- a/test/yarp/snapshots/seattlerb/parse_line_to_ary.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_to_ary.txt
@@ -2,12 +2,10 @@ ProgramNode(0...10)(
   [:a, :b],
   StatementsNode(0...10)(
     [MultiWriteNode(0...8)(
-       MultiTargetNode(0...4)(
-         [LocalVariableTargetNode(0...1)(:a, 0),
-          LocalVariableTargetNode(3...4)(:b, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...1)(:a, 0),
+        LocalVariableTargetNode(3...4)(:b, 0)],
+       nil,
+       nil,
        (5...6),
        CallNode(7...8)(nil, nil, (7...8), nil, nil, nil, nil, 2, "c")
      ),

--- a/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
@@ -8,90 +8,102 @@ ProgramNode(0...704)(
        (3...4)
      ),
      MultiWriteNode(7...24)(
-       [GlobalVariableTargetNode(8...10)(:$a),
-        GlobalVariableTargetNode(12...14)(:$b)],
+       MultiTargetNode(7...15)(
+         [GlobalVariableTargetNode(8...10)(:$a),
+          GlobalVariableTargetNode(12...14)(:$b)],
+         (7...8),
+         (14...15)
+       ),
        (16...17),
        ArrayNode(18...24)(
          [IntegerNode(19...20)(), IntegerNode(22...23)()],
          (18...19),
          (23...24)
-       ),
-       (7...8),
-       (14...15)
+       )
      ),
      MultiWriteNode(25...38)(
-       [MultiWriteNode(26...30)(
-          [LocalVariableTargetNode(27...28)(:a, 0),
-           SplatNode(28...29)((28...29), nil)],
-          nil,
-          nil,
-          (26...27),
-          (29...30)
-        ),
-        LocalVariableTargetNode(32...33)(:b, 0)],
+       MultiTargetNode(25...34)(
+         [MultiTargetNode(26...30)(
+            [LocalVariableTargetNode(27...28)(:a, 0),
+             SplatNode(28...29)((28...29), nil)],
+            (26...27),
+            (29...30)
+          ),
+          LocalVariableTargetNode(32...33)(:b, 0)],
+         (25...26),
+         (33...34)
+       ),
        (35...36),
-       IntegerNode(37...38)(),
-       (25...26),
-       (33...34)
+       IntegerNode(37...38)()
      ),
      MultiWriteNode(39...48)(
-       [SplatNode(40...42)(
-          (40...41),
-          LocalVariableTargetNode(41...42)(:a, 0)
-        )],
+       MultiTargetNode(39...43)(
+         [SplatNode(40...42)(
+            (40...41),
+            LocalVariableTargetNode(41...42)(:a, 0)
+          )],
+         (39...40),
+         (42...43)
+       ),
        (44...45),
-       ArrayNode(46...48)([], (46...47), (47...48)),
-       (39...40),
-       (42...43)
+       ArrayNode(46...48)([], (46...47), (47...48))
      ),
      MultiWriteNode(49...64)(
-       [SplatNode(50...54)(
-          (50...51),
-          LocalVariableTargetNode(51...54)(:foo, 0)
-        )],
+       MultiTargetNode(49...55)(
+         [SplatNode(50...54)(
+            (50...51),
+            LocalVariableTargetNode(51...54)(:foo, 0)
+          )],
+         (49...50),
+         (54...55)
+       ),
        (56...57),
        ArrayNode(58...64)(
          [IntegerNode(59...60)(), IntegerNode(62...63)()],
          (58...59),
          (63...64)
-       ),
-       (49...50),
-       (54...55)
+       )
      ),
      MultiWriteNode(65...84)(
-       [ClassVariableTargetNode(66...69)(:@@a),
-        ClassVariableTargetNode(71...74)(:@@b)],
+       MultiTargetNode(65...75)(
+         [ClassVariableTargetNode(66...69)(:@@a),
+          ClassVariableTargetNode(71...74)(:@@b)],
+         (65...66),
+         (74...75)
+       ),
        (76...77),
        ArrayNode(78...84)(
          [IntegerNode(79...80)(), IntegerNode(82...83)()],
          (78...79),
          (83...84)
-       ),
-       (65...66),
-       (74...75)
+       )
      ),
      MultiWriteNode(85...102)(
-       [InstanceVariableTargetNode(86...88)(:@a),
-        InstanceVariableTargetNode(90...92)(:@b)],
+       MultiTargetNode(85...93)(
+         [InstanceVariableTargetNode(86...88)(:@a),
+          InstanceVariableTargetNode(90...92)(:@b)],
+         (85...86),
+         (92...93)
+       ),
        (94...95),
        ArrayNode(96...102)(
          [IntegerNode(97...98)(), IntegerNode(100...101)()],
          (96...97),
          (101...102)
-       ),
-       (85...86),
-       (92...93)
+       )
      ),
      MultiWriteNode(103...128)(
-       [LocalVariableTargetNode(104...105)(:a, 0),
-        MultiWriteNode(107...113)(
-          [LocalVariableTargetNode(108...109)(:b, 0),
-           LocalVariableTargetNode(111...112)(:c, 0)],
-          nil,
-          nil,
-          (107...108),
-          (112...113)
-        )],
+       MultiTargetNode(103...114)(
+         [LocalVariableTargetNode(104...105)(:a, 0),
+          MultiTargetNode(107...113)(
+            [LocalVariableTargetNode(108...109)(:b, 0),
+             LocalVariableTargetNode(111...112)(:c, 0)],
+            (107...108),
+            (112...113)
+          )],
+         (103...104),
+         (113...114)
+       ),
        (115...116),
        ArrayNode(117...128)(
          [IntegerNode(118...119)(),
@@ -102,185 +114,201 @@ ProgramNode(0...704)(
           )],
          (117...118),
          (127...128)
-       ),
-       (103...104),
-       (113...114)
+       )
      ),
      MultiWriteNode(129...144)(
-       [LocalVariableTargetNode(130...131)(:a, 0),
-        SplatNode(133...134)((133...134), nil)],
+       MultiTargetNode(129...135)(
+         [LocalVariableTargetNode(130...131)(:a, 0),
+          SplatNode(133...134)((133...134), nil)],
+         (129...130),
+         (134...135)
+       ),
        (136...137),
        ArrayNode(138...144)(
          [IntegerNode(139...140)(), IntegerNode(142...143)()],
          (138...139),
          (143...144)
-       ),
-       (129...130),
-       (134...135)
+       )
      ),
      MultiWriteNode(145...163)(
-       [LocalVariableTargetNode(146...147)(:a, 0),
-        SplatNode(149...153)(
-          (149...150),
-          LocalVariableTargetNode(150...153)(:foo, 0)
-        )],
+       MultiTargetNode(145...154)(
+         [LocalVariableTargetNode(146...147)(:a, 0),
+          SplatNode(149...153)(
+            (149...150),
+            LocalVariableTargetNode(150...153)(:foo, 0)
+          )],
+         (145...146),
+         (153...154)
+       ),
        (155...156),
        ArrayNode(157...163)(
          [IntegerNode(158...159)(), IntegerNode(161...162)()],
          (157...158),
          (162...163)
-       ),
-       (145...146),
-       (153...154)
+       )
      ),
      MultiWriteNode(164...179)(
-       [LocalVariableTargetNode(165...166)(:a, 0),
-        LocalVariableTargetNode(168...169)(:b, 0)],
+       MultiTargetNode(164...170)(
+         [LocalVariableTargetNode(165...166)(:a, 0),
+          LocalVariableTargetNode(168...169)(:b, 0)],
+         (164...165),
+         (169...170)
+       ),
        (171...172),
        ArrayNode(173...179)(
          [IntegerNode(174...175)(), IntegerNode(177...178)()],
          (173...174),
          (178...179)
-       ),
-       (164...165),
-       (169...170)
+       )
      ),
      MultiWriteNode(180...192)(
-       [LocalVariableTargetNode(181...182)(:a, 0),
-        LocalVariableTargetNode(184...185)(:b, 0)],
+       MultiTargetNode(180...186)(
+         [LocalVariableTargetNode(181...182)(:a, 0),
+          LocalVariableTargetNode(184...185)(:b, 0)],
+         (180...181),
+         (185...186)
+       ),
        (187...188),
-       LocalVariableReadNode(189...192)(:foo, 0),
-       (180...181),
-       (185...186)
+       LocalVariableReadNode(189...192)(:foo, 0)
      ),
      MultiWriteNode(193...203)(
-       [LocalVariableTargetNode(194...195)(:a, 0),
-        SplatNode(195...196)((195...196), nil)],
+       MultiTargetNode(193...197)(
+         [LocalVariableTargetNode(194...195)(:a, 0),
+          SplatNode(195...196)((195...196), nil)],
+         (193...194),
+         (196...197)
+       ),
        (198...199),
-       LocalVariableReadNode(200...203)(:foo, 0),
-       (193...194),
-       (196...197)
+       LocalVariableReadNode(200...203)(:foo, 0)
      ),
      MultiWriteNode(204...227)(
-       [CallNode(205...210)(
-          LocalVariableReadNode(205...206)(:a, 0),
-          (206...207),
-          (207...210),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "foo="
-        ),
-        CallNode(212...217)(
-          LocalVariableReadNode(212...213)(:a, 0),
-          (213...214),
-          (214...217),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "bar="
-        )],
-       (219...220),
-       ArrayNode(221...227)(
-         [IntegerNode(222...223)(), IntegerNode(225...226)()],
-         (221...222),
-         (226...227)
-       ),
-       (204...205),
-       (217...218)
-     ),
-     MultiWriteNode(228...252)(
-       [CallNode(229...236)(
-          LocalVariableReadNode(229...230)(:a, 0),
-          nil,
-          (230...236),
-          (230...231),
-          ArgumentsNode(231...235)(
-            [SplatNode(231...235)(
-               (231...232),
-               LocalVariableReadNode(232...235)(:foo, 0)
-             )]
-          ),
-          (235...236),
-          nil,
-          0,
-          "[]="
-        ),
-        CallNode(238...242)(
-          LocalVariableReadNode(238...239)(:a, 0),
-          nil,
-          (239...242),
-          (239...240),
-          ArgumentsNode(240...241)([IntegerNode(240...241)()]),
-          (241...242),
-          nil,
-          0,
-          "[]="
-        )],
-       (244...245),
-       ArrayNode(246...252)(
-         [IntegerNode(247...248)(), IntegerNode(250...251)()],
-         (246...247),
-         (251...252)
-       ),
-       (228...229),
-       (242...243)
-     ),
-     MultiWriteNode(253...274)(
-       [CallNode(254...258)(
-          LocalVariableReadNode(254...255)(:a, 0),
-          nil,
-          (255...258),
-          (255...256),
-          ArgumentsNode(256...257)([IntegerNode(256...257)()]),
-          (257...258),
-          nil,
-          0,
-          "[]="
-        ),
-        CallNode(260...264)(
-          LocalVariableReadNode(260...261)(:a, 0),
-          nil,
-          (261...264),
-          (261...262),
-          ArgumentsNode(262...263)([IntegerNode(262...263)()]),
-          (263...264),
-          nil,
-          0,
-          "[]="
-        )],
-       (266...267),
-       ArrayNode(268...274)(
-         [IntegerNode(269...270)(), IntegerNode(272...273)()],
-         (268...269),
-         (273...274)
-       ),
-       (253...254),
-       (264...265)
-     ),
-     MultiWriteNode(275...287)(
-       [SplatNode(276...282)(
-          (276...277),
-          CallNode(277...282)(
-            LocalVariableReadNode(277...278)(:c, 0),
-            (278...279),
-            (279...282),
+       MultiTargetNode(204...218)(
+         [CallNode(205...210)(
+            LocalVariableReadNode(205...206)(:a, 0),
+            (206...207),
+            (207...210),
             nil,
             nil,
             nil,
             nil,
             0,
             "foo="
-          )
-        )],
+          ),
+          CallNode(212...217)(
+            LocalVariableReadNode(212...213)(:a, 0),
+            (213...214),
+            (214...217),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "bar="
+          )],
+         (204...205),
+         (217...218)
+       ),
+       (219...220),
+       ArrayNode(221...227)(
+         [IntegerNode(222...223)(), IntegerNode(225...226)()],
+         (221...222),
+         (226...227)
+       )
+     ),
+     MultiWriteNode(228...252)(
+       MultiTargetNode(228...243)(
+         [CallNode(229...236)(
+            LocalVariableReadNode(229...230)(:a, 0),
+            nil,
+            (230...236),
+            (230...231),
+            ArgumentsNode(231...235)(
+              [SplatNode(231...235)(
+                 (231...232),
+                 LocalVariableReadNode(232...235)(:foo, 0)
+               )]
+            ),
+            (235...236),
+            nil,
+            0,
+            "[]="
+          ),
+          CallNode(238...242)(
+            LocalVariableReadNode(238...239)(:a, 0),
+            nil,
+            (239...242),
+            (239...240),
+            ArgumentsNode(240...241)([IntegerNode(240...241)()]),
+            (241...242),
+            nil,
+            0,
+            "[]="
+          )],
+         (228...229),
+         (242...243)
+       ),
+       (244...245),
+       ArrayNode(246...252)(
+         [IntegerNode(247...248)(), IntegerNode(250...251)()],
+         (246...247),
+         (251...252)
+       )
+     ),
+     MultiWriteNode(253...274)(
+       MultiTargetNode(253...265)(
+         [CallNode(254...258)(
+            LocalVariableReadNode(254...255)(:a, 0),
+            nil,
+            (255...258),
+            (255...256),
+            ArgumentsNode(256...257)([IntegerNode(256...257)()]),
+            (257...258),
+            nil,
+            0,
+            "[]="
+          ),
+          CallNode(260...264)(
+            LocalVariableReadNode(260...261)(:a, 0),
+            nil,
+            (261...264),
+            (261...262),
+            ArgumentsNode(262...263)([IntegerNode(262...263)()]),
+            (263...264),
+            nil,
+            0,
+            "[]="
+          )],
+         (253...254),
+         (264...265)
+       ),
+       (266...267),
+       ArrayNode(268...274)(
+         [IntegerNode(269...270)(), IntegerNode(272...273)()],
+         (268...269),
+         (273...274)
+       )
+     ),
+     MultiWriteNode(275...287)(
+       MultiTargetNode(275...283)(
+         [SplatNode(276...282)(
+            (276...277),
+            CallNode(277...282)(
+              LocalVariableReadNode(277...278)(:c, 0),
+              (278...279),
+              (279...282),
+              nil,
+              nil,
+              nil,
+              nil,
+              0,
+              "foo="
+            )
+          )],
+         (275...276),
+         (282...283)
+       ),
        (284...285),
-       IntegerNode(286...287)(),
-       (275...276),
-       (282...283)
+       IntegerNode(286...287)()
      ),
      ConstantPathWriteNode(288...301)(
        ConstantPathNode(288...293)(
@@ -333,12 +361,14 @@ ProgramNode(0...704)(
        ParenthesesNode(355...367)(
          StatementsNode(356...366)(
            [MultiWriteNode(356...366)(
-              [LocalVariableTargetNode(357...358)(:b, 0),
-               LocalVariableTargetNode(360...361)(:c, 0)],
+              MultiTargetNode(356...362)(
+                [LocalVariableTargetNode(357...358)(:b, 0),
+                 LocalVariableTargetNode(360...361)(:c, 0)],
+                (356...357),
+                (361...362)
+              ),
               (363...364),
-              IntegerNode(365...366)(),
-              (356...357),
-              (361...362)
+              IntegerNode(365...366)()
             )]
          ),
          (355...356),

--- a/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
@@ -8,12 +8,10 @@ ProgramNode(0...704)(
        (3...4)
      ),
      MultiWriteNode(7...24)(
-       MultiTargetNode(7...15)(
-         [GlobalVariableTargetNode(8...10)(:$a),
-          GlobalVariableTargetNode(12...14)(:$b)],
-         (7...8),
-         (14...15)
-       ),
+       [GlobalVariableTargetNode(8...10)(:$a),
+        GlobalVariableTargetNode(12...14)(:$b)],
+       (7...8),
+       (14...15),
        (16...17),
        ArrayNode(18...24)(
          [IntegerNode(19...20)(), IntegerNode(22...23)()],
@@ -22,41 +20,35 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(25...38)(
-       MultiTargetNode(25...34)(
-         [MultiTargetNode(26...30)(
-            [LocalVariableTargetNode(27...28)(:a, 0),
-             SplatNode(28...29)((28...29), nil)],
-            (26...27),
-            (29...30)
-          ),
-          LocalVariableTargetNode(32...33)(:b, 0)],
-         (25...26),
-         (33...34)
-       ),
+       [MultiTargetNode(26...30)(
+          [LocalVariableTargetNode(27...28)(:a, 0),
+           SplatNode(28...29)((28...29), nil)],
+          (26...27),
+          (29...30)
+        ),
+        LocalVariableTargetNode(32...33)(:b, 0)],
+       (25...26),
+       (33...34),
        (35...36),
        IntegerNode(37...38)()
      ),
      MultiWriteNode(39...48)(
-       MultiTargetNode(39...43)(
-         [SplatNode(40...42)(
-            (40...41),
-            LocalVariableTargetNode(41...42)(:a, 0)
-          )],
-         (39...40),
-         (42...43)
-       ),
+       [SplatNode(40...42)(
+          (40...41),
+          LocalVariableTargetNode(41...42)(:a, 0)
+        )],
+       (39...40),
+       (42...43),
        (44...45),
        ArrayNode(46...48)([], (46...47), (47...48))
      ),
      MultiWriteNode(49...64)(
-       MultiTargetNode(49...55)(
-         [SplatNode(50...54)(
-            (50...51),
-            LocalVariableTargetNode(51...54)(:foo, 0)
-          )],
-         (49...50),
-         (54...55)
-       ),
+       [SplatNode(50...54)(
+          (50...51),
+          LocalVariableTargetNode(51...54)(:foo, 0)
+        )],
+       (49...50),
+       (54...55),
        (56...57),
        ArrayNode(58...64)(
          [IntegerNode(59...60)(), IntegerNode(62...63)()],
@@ -65,12 +57,10 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(65...84)(
-       MultiTargetNode(65...75)(
-         [ClassVariableTargetNode(66...69)(:@@a),
-          ClassVariableTargetNode(71...74)(:@@b)],
-         (65...66),
-         (74...75)
-       ),
+       [ClassVariableTargetNode(66...69)(:@@a),
+        ClassVariableTargetNode(71...74)(:@@b)],
+       (65...66),
+       (74...75),
        (76...77),
        ArrayNode(78...84)(
          [IntegerNode(79...80)(), IntegerNode(82...83)()],
@@ -79,12 +69,10 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(85...102)(
-       MultiTargetNode(85...93)(
-         [InstanceVariableTargetNode(86...88)(:@a),
-          InstanceVariableTargetNode(90...92)(:@b)],
-         (85...86),
-         (92...93)
-       ),
+       [InstanceVariableTargetNode(86...88)(:@a),
+        InstanceVariableTargetNode(90...92)(:@b)],
+       (85...86),
+       (92...93),
        (94...95),
        ArrayNode(96...102)(
          [IntegerNode(97...98)(), IntegerNode(100...101)()],
@@ -93,17 +81,15 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(103...128)(
-       MultiTargetNode(103...114)(
-         [LocalVariableTargetNode(104...105)(:a, 0),
-          MultiTargetNode(107...113)(
-            [LocalVariableTargetNode(108...109)(:b, 0),
-             LocalVariableTargetNode(111...112)(:c, 0)],
-            (107...108),
-            (112...113)
-          )],
-         (103...104),
-         (113...114)
-       ),
+       [LocalVariableTargetNode(104...105)(:a, 0),
+        MultiTargetNode(107...113)(
+          [LocalVariableTargetNode(108...109)(:b, 0),
+           LocalVariableTargetNode(111...112)(:c, 0)],
+          (107...108),
+          (112...113)
+        )],
+       (103...104),
+       (113...114),
        (115...116),
        ArrayNode(117...128)(
          [IntegerNode(118...119)(),
@@ -117,12 +103,10 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(129...144)(
-       MultiTargetNode(129...135)(
-         [LocalVariableTargetNode(130...131)(:a, 0),
-          SplatNode(133...134)((133...134), nil)],
-         (129...130),
-         (134...135)
-       ),
+       [LocalVariableTargetNode(130...131)(:a, 0),
+        SplatNode(133...134)((133...134), nil)],
+       (129...130),
+       (134...135),
        (136...137),
        ArrayNode(138...144)(
          [IntegerNode(139...140)(), IntegerNode(142...143)()],
@@ -131,15 +115,13 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(145...163)(
-       MultiTargetNode(145...154)(
-         [LocalVariableTargetNode(146...147)(:a, 0),
-          SplatNode(149...153)(
-            (149...150),
-            LocalVariableTargetNode(150...153)(:foo, 0)
-          )],
-         (145...146),
-         (153...154)
-       ),
+       [LocalVariableTargetNode(146...147)(:a, 0),
+        SplatNode(149...153)(
+          (149...150),
+          LocalVariableTargetNode(150...153)(:foo, 0)
+        )],
+       (145...146),
+       (153...154),
        (155...156),
        ArrayNode(157...163)(
          [IntegerNode(158...159)(), IntegerNode(161...162)()],
@@ -148,12 +130,10 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(164...179)(
-       MultiTargetNode(164...170)(
-         [LocalVariableTargetNode(165...166)(:a, 0),
-          LocalVariableTargetNode(168...169)(:b, 0)],
-         (164...165),
-         (169...170)
-       ),
+       [LocalVariableTargetNode(165...166)(:a, 0),
+        LocalVariableTargetNode(168...169)(:b, 0)],
+       (164...165),
+       (169...170),
        (171...172),
        ArrayNode(173...179)(
          [IntegerNode(174...175)(), IntegerNode(177...178)()],
@@ -162,52 +142,46 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(180...192)(
-       MultiTargetNode(180...186)(
-         [LocalVariableTargetNode(181...182)(:a, 0),
-          LocalVariableTargetNode(184...185)(:b, 0)],
-         (180...181),
-         (185...186)
-       ),
+       [LocalVariableTargetNode(181...182)(:a, 0),
+        LocalVariableTargetNode(184...185)(:b, 0)],
+       (180...181),
+       (185...186),
        (187...188),
        LocalVariableReadNode(189...192)(:foo, 0)
      ),
      MultiWriteNode(193...203)(
-       MultiTargetNode(193...197)(
-         [LocalVariableTargetNode(194...195)(:a, 0),
-          SplatNode(195...196)((195...196), nil)],
-         (193...194),
-         (196...197)
-       ),
+       [LocalVariableTargetNode(194...195)(:a, 0),
+        SplatNode(195...196)((195...196), nil)],
+       (193...194),
+       (196...197),
        (198...199),
        LocalVariableReadNode(200...203)(:foo, 0)
      ),
      MultiWriteNode(204...227)(
-       MultiTargetNode(204...218)(
-         [CallNode(205...210)(
-            LocalVariableReadNode(205...206)(:a, 0),
-            (206...207),
-            (207...210),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "foo="
-          ),
-          CallNode(212...217)(
-            LocalVariableReadNode(212...213)(:a, 0),
-            (213...214),
-            (214...217),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "bar="
-          )],
-         (204...205),
-         (217...218)
-       ),
+       [CallNode(205...210)(
+          LocalVariableReadNode(205...206)(:a, 0),
+          (206...207),
+          (207...210),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "foo="
+        ),
+        CallNode(212...217)(
+          LocalVariableReadNode(212...213)(:a, 0),
+          (213...214),
+          (214...217),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "bar="
+        )],
+       (204...205),
+       (217...218),
        (219...220),
        ArrayNode(221...227)(
          [IntegerNode(222...223)(), IntegerNode(225...226)()],
@@ -216,37 +190,35 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(228...252)(
-       MultiTargetNode(228...243)(
-         [CallNode(229...236)(
-            LocalVariableReadNode(229...230)(:a, 0),
-            nil,
-            (230...236),
-            (230...231),
-            ArgumentsNode(231...235)(
-              [SplatNode(231...235)(
-                 (231...232),
-                 LocalVariableReadNode(232...235)(:foo, 0)
-               )]
-            ),
-            (235...236),
-            nil,
-            0,
-            "[]="
+       [CallNode(229...236)(
+          LocalVariableReadNode(229...230)(:a, 0),
+          nil,
+          (230...236),
+          (230...231),
+          ArgumentsNode(231...235)(
+            [SplatNode(231...235)(
+               (231...232),
+               LocalVariableReadNode(232...235)(:foo, 0)
+             )]
           ),
-          CallNode(238...242)(
-            LocalVariableReadNode(238...239)(:a, 0),
-            nil,
-            (239...242),
-            (239...240),
-            ArgumentsNode(240...241)([IntegerNode(240...241)()]),
-            (241...242),
-            nil,
-            0,
-            "[]="
-          )],
-         (228...229),
-         (242...243)
-       ),
+          (235...236),
+          nil,
+          0,
+          "[]="
+        ),
+        CallNode(238...242)(
+          LocalVariableReadNode(238...239)(:a, 0),
+          nil,
+          (239...242),
+          (239...240),
+          ArgumentsNode(240...241)([IntegerNode(240...241)()]),
+          (241...242),
+          nil,
+          0,
+          "[]="
+        )],
+       (228...229),
+       (242...243),
        (244...245),
        ArrayNode(246...252)(
          [IntegerNode(247...248)(), IntegerNode(250...251)()],
@@ -255,32 +227,30 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(253...274)(
-       MultiTargetNode(253...265)(
-         [CallNode(254...258)(
-            LocalVariableReadNode(254...255)(:a, 0),
-            nil,
-            (255...258),
-            (255...256),
-            ArgumentsNode(256...257)([IntegerNode(256...257)()]),
-            (257...258),
-            nil,
-            0,
-            "[]="
-          ),
-          CallNode(260...264)(
-            LocalVariableReadNode(260...261)(:a, 0),
-            nil,
-            (261...264),
-            (261...262),
-            ArgumentsNode(262...263)([IntegerNode(262...263)()]),
-            (263...264),
-            nil,
-            0,
-            "[]="
-          )],
-         (253...254),
-         (264...265)
-       ),
+       [CallNode(254...258)(
+          LocalVariableReadNode(254...255)(:a, 0),
+          nil,
+          (255...258),
+          (255...256),
+          ArgumentsNode(256...257)([IntegerNode(256...257)()]),
+          (257...258),
+          nil,
+          0,
+          "[]="
+        ),
+        CallNode(260...264)(
+          LocalVariableReadNode(260...261)(:a, 0),
+          nil,
+          (261...264),
+          (261...262),
+          ArgumentsNode(262...263)([IntegerNode(262...263)()]),
+          (263...264),
+          nil,
+          0,
+          "[]="
+        )],
+       (253...254),
+       (264...265),
        (266...267),
        ArrayNode(268...274)(
          [IntegerNode(269...270)(), IntegerNode(272...273)()],
@@ -289,24 +259,22 @@ ProgramNode(0...704)(
        )
      ),
      MultiWriteNode(275...287)(
-       MultiTargetNode(275...283)(
-         [SplatNode(276...282)(
-            (276...277),
-            CallNode(277...282)(
-              LocalVariableReadNode(277...278)(:c, 0),
-              (278...279),
-              (279...282),
-              nil,
-              nil,
-              nil,
-              nil,
-              0,
-              "foo="
-            )
-          )],
-         (275...276),
-         (282...283)
-       ),
+       [SplatNode(276...282)(
+          (276...277),
+          CallNode(277...282)(
+            LocalVariableReadNode(277...278)(:c, 0),
+            (278...279),
+            (279...282),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "foo="
+          )
+        )],
+       (275...276),
+       (282...283),
        (284...285),
        IntegerNode(286...287)()
      ),
@@ -361,12 +329,10 @@ ProgramNode(0...704)(
        ParenthesesNode(355...367)(
          StatementsNode(356...366)(
            [MultiWriteNode(356...366)(
-              MultiTargetNode(356...362)(
-                [LocalVariableTargetNode(357...358)(:b, 0),
-                 LocalVariableTargetNode(360...361)(:c, 0)],
-                (356...357),
-                (361...362)
-              ),
+              [LocalVariableTargetNode(357...358)(:b, 0),
+               LocalVariableTargetNode(360...361)(:c, 0)],
+              (356...357),
+              (361...362),
               (363...364),
               IntegerNode(365...366)()
             )]

--- a/test/yarp/snapshots/unparser/corpus/literal/defined.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/defined.txt
@@ -18,12 +18,10 @@ ProgramNode(0...56)(
        ParenthesesNode(38...55)(
          StatementsNode(39...54)(
            [MultiWriteNode(39...54)(
-              MultiTargetNode(39...45)(
-                [LocalVariableTargetNode(40...41)(:a, 0),
-                 LocalVariableTargetNode(43...44)(:b, 0)],
-                (39...40),
-                (44...45)
-              ),
+              [LocalVariableTargetNode(40...41)(:a, 0),
+               LocalVariableTargetNode(43...44)(:b, 0)],
+              (39...40),
+              (44...45),
               (46...47),
               ArrayNode(48...54)(
                 [IntegerNode(49...50)(), IntegerNode(52...53)()],

--- a/test/yarp/snapshots/unparser/corpus/literal/defined.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/defined.txt
@@ -18,16 +18,18 @@ ProgramNode(0...56)(
        ParenthesesNode(38...55)(
          StatementsNode(39...54)(
            [MultiWriteNode(39...54)(
-              [LocalVariableTargetNode(40...41)(:a, 0),
-               LocalVariableTargetNode(43...44)(:b, 0)],
+              MultiTargetNode(39...45)(
+                [LocalVariableTargetNode(40...41)(:a, 0),
+                 LocalVariableTargetNode(43...44)(:b, 0)],
+                (39...40),
+                (44...45)
+              ),
               (46...47),
               ArrayNode(48...54)(
                 [IntegerNode(49...50)(), IntegerNode(52...53)()],
                 (48...49),
                 (53...54)
-              ),
-              (39...40),
-              (44...45)
+              )
             )]
          ),
          (38...39),

--- a/test/yarp/snapshots/unparser/corpus/literal/for.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/for.txt
@@ -8,10 +8,8 @@ ProgramNode(0...119)(
        (3...4),
        ArgumentsNode(4...29)(
          [ForNode(4...29)(
-            MultiWriteNode(8...9)(
+            MultiTargetNode(8...9)(
               [LocalVariableTargetNode(8...9)(:a, 0)],
-              nil,
-              nil,
               nil,
               nil
             ),
@@ -51,10 +49,8 @@ ProgramNode(0...119)(
        "bar"
      ),
      ForNode(31...56)(
-       MultiWriteNode(35...36)(
+       MultiTargetNode(35...36)(
          [LocalVariableTargetNode(35...36)(:a, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -68,14 +64,12 @@ ProgramNode(0...119)(
        (53...56)
      ),
      ForNode(57...88)(
-       MultiWriteNode(61...68)(
+       MultiTargetNode(61...68)(
          [LocalVariableTargetNode(62...63)(:a, 0),
           SplatNode(65...67)(
             (65...66),
             LocalVariableTargetNode(66...67)(:b, 0)
           )],
-         nil,
-         nil,
          (61...62),
          (67...68)
        ),
@@ -89,11 +83,9 @@ ProgramNode(0...119)(
        (85...88)
      ),
      ForNode(89...119)(
-       MultiWriteNode(93...99)(
+       MultiTargetNode(93...99)(
          [LocalVariableTargetNode(94...95)(:a, 0),
           LocalVariableTargetNode(97...98)(:b, 0)],
-         nil,
-         nil,
          (93...94),
          (98...99)
        ),

--- a/test/yarp/snapshots/unparser/corpus/literal/send.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/send.txt
@@ -12,8 +12,12 @@ ProgramNode(0...999)(
             ParenthesesNode(19...31)(
               StatementsNode(20...30)(
                 [MultiWriteNode(20...30)(
-                   [LocalVariableTargetNode(21...22)(:a, 0),
-                    LocalVariableTargetNode(24...25)(:_, 0)],
+                   MultiTargetNode(20...26)(
+                     [LocalVariableTargetNode(21...22)(:a, 0),
+                      LocalVariableTargetNode(24...25)(:_, 0)],
+                     (20...21),
+                     (25...26)
+                   ),
                    (27...28),
                    CallNode(29...30)(
                      nil,
@@ -25,9 +29,7 @@ ProgramNode(0...999)(
                      nil,
                      2,
                      "b"
-                   ),
-                   (20...21),
-                   (25...26)
+                   )
                  )]
               ),
               (19...20),

--- a/test/yarp/snapshots/unparser/corpus/literal/send.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/send.txt
@@ -12,12 +12,10 @@ ProgramNode(0...999)(
             ParenthesesNode(19...31)(
               StatementsNode(20...30)(
                 [MultiWriteNode(20...30)(
-                   MultiTargetNode(20...26)(
-                     [LocalVariableTargetNode(21...22)(:a, 0),
-                      LocalVariableTargetNode(24...25)(:_, 0)],
-                     (20...21),
-                     (25...26)
-                   ),
+                   [LocalVariableTargetNode(21...22)(:a, 0),
+                    LocalVariableTargetNode(24...25)(:_, 0)],
+                   (20...21),
+                   (25...26),
                    (27...28),
                    CallNode(29...30)(
                      nil,

--- a/test/yarp/snapshots/variables.txt
+++ b/test/yarp/snapshots/variables.txt
@@ -9,12 +9,14 @@ ProgramNode(0...293)(
        (13...14)
      ),
      MultiWriteNode(18...34)(
-       [ClassVariableTargetNode(18...23)(:@@foo),
-        ClassVariableTargetNode(25...30)(:@@bar)],
+       MultiTargetNode(18...30)(
+         [ClassVariableTargetNode(18...23)(:@@foo),
+          ClassVariableTargetNode(25...30)(:@@bar)],
+         nil,
+         nil
+       ),
        (31...32),
-       IntegerNode(33...34)(),
-       nil,
-       nil
+       IntegerNode(33...34)()
      ),
      ClassVariableWriteNode(36...48)(
        :@@foo,
@@ -49,12 +51,14 @@ ProgramNode(0...293)(
        (89...90)
      ),
      MultiWriteNode(94...108)(
-       [GlobalVariableTargetNode(94...98)(:$foo),
-        GlobalVariableTargetNode(100...104)(:$bar)],
+       MultiTargetNode(94...104)(
+         [GlobalVariableTargetNode(94...98)(:$foo),
+          GlobalVariableTargetNode(100...104)(:$bar)],
+         nil,
+         nil
+       ),
        (105...106),
-       IntegerNode(107...108)(),
-       nil,
-       nil
+       IntegerNode(107...108)()
      ),
      GlobalVariableWriteNode(110...121)(
        :$foo,
@@ -67,12 +71,14 @@ ProgramNode(0...293)(
        (115...116)
      ),
      MultiWriteNode(123...137)(
-       [InstanceVariableTargetNode(123...127)(:@foo),
-        InstanceVariableTargetNode(129...133)(:@bar)],
+       MultiTargetNode(123...133)(
+         [InstanceVariableTargetNode(123...127)(:@foo),
+          InstanceVariableTargetNode(129...133)(:@bar)],
+         nil,
+         nil
+       ),
        (134...135),
-       IntegerNode(136...137)(),
-       nil,
-       nil
+       IntegerNode(136...137)()
      ),
      InstanceVariableWriteNode(139...150)(
        :@foo,
@@ -114,54 +120,62 @@ ProgramNode(0...293)(
        (177...178)
      ),
      MultiWriteNode(185...198)(
-       [LocalVariableTargetNode(185...188)(:foo, 0),
-        SplatNode(190...191)((190...191), nil)],
+       MultiTargetNode(185...191)(
+         [LocalVariableTargetNode(185...188)(:foo, 0),
+          SplatNode(190...191)((190...191), nil)],
+         nil,
+         nil
+       ),
        (192...193),
        ArrayNode(194...198)(
          [IntegerNode(194...195)(), IntegerNode(197...198)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      MultiWriteNode(200...211)(
-       [LocalVariableTargetNode(200...203)(:foo, 0),
-        SplatNode(203...204)((203...204), nil)],
+       MultiTargetNode(200...204)(
+         [LocalVariableTargetNode(200...203)(:foo, 0),
+          SplatNode(203...204)((203...204), nil)],
+         nil,
+         nil
+       ),
        (205...206),
        ArrayNode(207...211)(
          [IntegerNode(207...208)(), IntegerNode(210...211)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      MultiWriteNode(213...229)(
-       [LocalVariableTargetNode(213...216)(:foo, 0),
-        SplatNode(218...222)(
-          (218...219),
-          LocalVariableTargetNode(219...222)(:bar, 0)
-        )],
+       MultiTargetNode(213...222)(
+         [LocalVariableTargetNode(213...216)(:foo, 0),
+          SplatNode(218...222)(
+            (218...219),
+            LocalVariableTargetNode(219...222)(:bar, 0)
+          )],
+         nil,
+         nil
+       ),
        (223...224),
        ArrayNode(225...229)(
          [IntegerNode(225...226)(), IntegerNode(228...229)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      MultiWriteNode(231...258)(
-       [LocalVariableTargetNode(231...234)(:foo, 0),
-        MultiWriteNode(236...246)(
-          [LocalVariableTargetNode(237...240)(:bar, 0),
-           LocalVariableTargetNode(242...245)(:baz, 0)],
-          nil,
-          nil,
-          (236...237),
-          (245...246)
-        )],
+       MultiTargetNode(231...246)(
+         [LocalVariableTargetNode(231...234)(:foo, 0),
+          MultiTargetNode(236...246)(
+            [LocalVariableTargetNode(237...240)(:bar, 0),
+             LocalVariableTargetNode(242...245)(:baz, 0)],
+            (236...237),
+            (245...246)
+          )],
+         nil,
+         nil
+       ),
        (247...248),
        ArrayNode(249...258)(
          [IntegerNode(249...250)(),
@@ -172,9 +186,7 @@ ProgramNode(0...293)(
           )],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      LocalVariableWriteNode(260...270)(
        :foo,

--- a/test/yarp/snapshots/variables.txt
+++ b/test/yarp/snapshots/variables.txt
@@ -9,12 +9,10 @@ ProgramNode(0...293)(
        (13...14)
      ),
      MultiWriteNode(18...34)(
-       MultiTargetNode(18...30)(
-         [ClassVariableTargetNode(18...23)(:@@foo),
-          ClassVariableTargetNode(25...30)(:@@bar)],
-         nil,
-         nil
-       ),
+       [ClassVariableTargetNode(18...23)(:@@foo),
+        ClassVariableTargetNode(25...30)(:@@bar)],
+       nil,
+       nil,
        (31...32),
        IntegerNode(33...34)()
      ),
@@ -51,12 +49,10 @@ ProgramNode(0...293)(
        (89...90)
      ),
      MultiWriteNode(94...108)(
-       MultiTargetNode(94...104)(
-         [GlobalVariableTargetNode(94...98)(:$foo),
-          GlobalVariableTargetNode(100...104)(:$bar)],
-         nil,
-         nil
-       ),
+       [GlobalVariableTargetNode(94...98)(:$foo),
+        GlobalVariableTargetNode(100...104)(:$bar)],
+       nil,
+       nil,
        (105...106),
        IntegerNode(107...108)()
      ),
@@ -71,12 +67,10 @@ ProgramNode(0...293)(
        (115...116)
      ),
      MultiWriteNode(123...137)(
-       MultiTargetNode(123...133)(
-         [InstanceVariableTargetNode(123...127)(:@foo),
-          InstanceVariableTargetNode(129...133)(:@bar)],
-         nil,
-         nil
-       ),
+       [InstanceVariableTargetNode(123...127)(:@foo),
+        InstanceVariableTargetNode(129...133)(:@bar)],
+       nil,
+       nil,
        (134...135),
        IntegerNode(136...137)()
      ),
@@ -120,12 +114,10 @@ ProgramNode(0...293)(
        (177...178)
      ),
      MultiWriteNode(185...198)(
-       MultiTargetNode(185...191)(
-         [LocalVariableTargetNode(185...188)(:foo, 0),
-          SplatNode(190...191)((190...191), nil)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(185...188)(:foo, 0),
+        SplatNode(190...191)((190...191), nil)],
+       nil,
+       nil,
        (192...193),
        ArrayNode(194...198)(
          [IntegerNode(194...195)(), IntegerNode(197...198)()],
@@ -134,12 +126,10 @@ ProgramNode(0...293)(
        )
      ),
      MultiWriteNode(200...211)(
-       MultiTargetNode(200...204)(
-         [LocalVariableTargetNode(200...203)(:foo, 0),
-          SplatNode(203...204)((203...204), nil)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(200...203)(:foo, 0),
+        SplatNode(203...204)((203...204), nil)],
+       nil,
+       nil,
        (205...206),
        ArrayNode(207...211)(
          [IntegerNode(207...208)(), IntegerNode(210...211)()],
@@ -148,15 +138,13 @@ ProgramNode(0...293)(
        )
      ),
      MultiWriteNode(213...229)(
-       MultiTargetNode(213...222)(
-         [LocalVariableTargetNode(213...216)(:foo, 0),
-          SplatNode(218...222)(
-            (218...219),
-            LocalVariableTargetNode(219...222)(:bar, 0)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(213...216)(:foo, 0),
+        SplatNode(218...222)(
+          (218...219),
+          LocalVariableTargetNode(219...222)(:bar, 0)
+        )],
+       nil,
+       nil,
        (223...224),
        ArrayNode(225...229)(
          [IntegerNode(225...226)(), IntegerNode(228...229)()],
@@ -165,17 +153,15 @@ ProgramNode(0...293)(
        )
      ),
      MultiWriteNode(231...258)(
-       MultiTargetNode(231...246)(
-         [LocalVariableTargetNode(231...234)(:foo, 0),
-          MultiTargetNode(236...246)(
-            [LocalVariableTargetNode(237...240)(:bar, 0),
-             LocalVariableTargetNode(242...245)(:baz, 0)],
-            (236...237),
-            (245...246)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(231...234)(:foo, 0),
+        MultiTargetNode(236...246)(
+          [LocalVariableTargetNode(237...240)(:bar, 0),
+           LocalVariableTargetNode(242...245)(:baz, 0)],
+          (236...237),
+          (245...246)
+        )],
+       nil,
+       nil,
        (247...248),
        ArrayNode(249...258)(
          [IntegerNode(249...250)(),

--- a/test/yarp/snapshots/whitequark/and_or_masgn.txt
+++ b/test/yarp/snapshots/whitequark/and_or_masgn.txt
@@ -6,12 +6,10 @@ ProgramNode(0...40)(
        ParenthesesNode(7...19)(
          StatementsNode(8...18)(
            [MultiWriteNode(8...18)(
-              MultiTargetNode(8...12)(
-                [LocalVariableTargetNode(8...9)(:a, 0),
-                 LocalVariableTargetNode(11...12)(:b, 0)],
-                nil,
-                nil
-              ),
+              [LocalVariableTargetNode(8...9)(:a, 0),
+               LocalVariableTargetNode(11...12)(:b, 0)],
+              nil,
+              nil,
               (13...14),
               CallNode(15...18)(
                 nil,
@@ -36,12 +34,10 @@ ProgramNode(0...40)(
        ParenthesesNode(28...40)(
          StatementsNode(29...39)(
            [MultiWriteNode(29...39)(
-              MultiTargetNode(29...33)(
-                [LocalVariableTargetNode(29...30)(:a, 0),
-                 LocalVariableTargetNode(32...33)(:b, 0)],
-                nil,
-                nil
-              ),
+              [LocalVariableTargetNode(29...30)(:a, 0),
+               LocalVariableTargetNode(32...33)(:b, 0)],
+              nil,
+              nil,
               (34...35),
               CallNode(36...39)(
                 nil,

--- a/test/yarp/snapshots/whitequark/and_or_masgn.txt
+++ b/test/yarp/snapshots/whitequark/and_or_masgn.txt
@@ -6,8 +6,12 @@ ProgramNode(0...40)(
        ParenthesesNode(7...19)(
          StatementsNode(8...18)(
            [MultiWriteNode(8...18)(
-              [LocalVariableTargetNode(8...9)(:a, 0),
-               LocalVariableTargetNode(11...12)(:b, 0)],
+              MultiTargetNode(8...12)(
+                [LocalVariableTargetNode(8...9)(:a, 0),
+                 LocalVariableTargetNode(11...12)(:b, 0)],
+                nil,
+                nil
+              ),
               (13...14),
               CallNode(15...18)(
                 nil,
@@ -19,9 +23,7 @@ ProgramNode(0...40)(
                 nil,
                 2,
                 "bar"
-              ),
-              nil,
-              nil
+              )
             )]
          ),
          (7...8),
@@ -34,8 +36,12 @@ ProgramNode(0...40)(
        ParenthesesNode(28...40)(
          StatementsNode(29...39)(
            [MultiWriteNode(29...39)(
-              [LocalVariableTargetNode(29...30)(:a, 0),
-               LocalVariableTargetNode(32...33)(:b, 0)],
+              MultiTargetNode(29...33)(
+                [LocalVariableTargetNode(29...30)(:a, 0),
+                 LocalVariableTargetNode(32...33)(:b, 0)],
+                nil,
+                nil
+              ),
               (34...35),
               CallNode(36...39)(
                 nil,
@@ -47,9 +53,7 @@ ProgramNode(0...40)(
                 nil,
                 2,
                 "bar"
-              ),
-              nil,
-              nil
+              )
             )]
          ),
          (28...29),

--- a/test/yarp/snapshots/whitequark/cond_begin_masgn.txt
+++ b/test/yarp/snapshots/whitequark/cond_begin_masgn.txt
@@ -7,12 +7,10 @@ ProgramNode(0...25)(
          StatementsNode(4...19)(
            [CallNode(4...7)(nil, nil, (4...7), nil, nil, nil, nil, 2, "bar"),
             MultiWriteNode(9...19)(
-              MultiTargetNode(9...13)(
-                [LocalVariableTargetNode(9...10)(:a, 0),
-                 LocalVariableTargetNode(12...13)(:b, 0)],
-                nil,
-                nil
-              ),
+              [LocalVariableTargetNode(9...10)(:a, 0),
+               LocalVariableTargetNode(12...13)(:b, 0)],
+              nil,
+              nil,
               (14...15),
               CallNode(16...19)(
                 nil,

--- a/test/yarp/snapshots/whitequark/cond_begin_masgn.txt
+++ b/test/yarp/snapshots/whitequark/cond_begin_masgn.txt
@@ -7,8 +7,12 @@ ProgramNode(0...25)(
          StatementsNode(4...19)(
            [CallNode(4...7)(nil, nil, (4...7), nil, nil, nil, nil, 2, "bar"),
             MultiWriteNode(9...19)(
-              [LocalVariableTargetNode(9...10)(:a, 0),
-               LocalVariableTargetNode(12...13)(:b, 0)],
+              MultiTargetNode(9...13)(
+                [LocalVariableTargetNode(9...10)(:a, 0),
+                 LocalVariableTargetNode(12...13)(:b, 0)],
+                nil,
+                nil
+              ),
               (14...15),
               CallNode(16...19)(
                 nil,
@@ -20,9 +24,7 @@ ProgramNode(0...25)(
                 nil,
                 2,
                 "foo"
-              ),
-              nil,
-              nil
+              )
             )]
          ),
          (3...4),

--- a/test/yarp/snapshots/whitequark/for.txt
+++ b/test/yarp/snapshots/whitequark/for.txt
@@ -2,10 +2,8 @@ ProgramNode(0...48)(
   [:a],
   StatementsNode(0...48)(
     [ForNode(0...24)(
-       MultiWriteNode(4...5)(
+       MultiTargetNode(4...5)(
          [LocalVariableTargetNode(4...5)(:a, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),
@@ -29,10 +27,8 @@ ProgramNode(0...48)(
        (21...24)
      ),
      ForNode(26...48)(
-       MultiWriteNode(30...31)(
+       MultiTargetNode(30...31)(
          [LocalVariableTargetNode(30...31)(:a, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),

--- a/test/yarp/snapshots/whitequark/for_mlhs.txt
+++ b/test/yarp/snapshots/whitequark/for_mlhs.txt
@@ -2,11 +2,9 @@ ProgramNode(0...28)(
   [:a, :b],
   StatementsNode(0...28)(
     [ForNode(0...28)(
-       MultiWriteNode(4...8)(
+       MultiTargetNode(4...8)(
          [LocalVariableTargetNode(4...5)(:a, 0),
           LocalVariableTargetNode(7...8)(:b, 0)],
-         nil,
-         nil,
          nil,
          nil
        ),

--- a/test/yarp/snapshots/whitequark/if_masgn__24.txt
+++ b/test/yarp/snapshots/whitequark/if_masgn__24.txt
@@ -6,12 +6,10 @@ ProgramNode(0...20)(
        ParenthesesNode(3...15)(
          StatementsNode(4...14)(
            [MultiWriteNode(4...14)(
-              MultiTargetNode(4...8)(
-                [LocalVariableTargetNode(4...5)(:a, 0),
-                 LocalVariableTargetNode(7...8)(:b, 0)],
-                nil,
-                nil
-              ),
+              [LocalVariableTargetNode(4...5)(:a, 0),
+               LocalVariableTargetNode(7...8)(:b, 0)],
+              nil,
+              nil,
               (9...10),
               CallNode(11...14)(
                 nil,

--- a/test/yarp/snapshots/whitequark/if_masgn__24.txt
+++ b/test/yarp/snapshots/whitequark/if_masgn__24.txt
@@ -6,8 +6,12 @@ ProgramNode(0...20)(
        ParenthesesNode(3...15)(
          StatementsNode(4...14)(
            [MultiWriteNode(4...14)(
-              [LocalVariableTargetNode(4...5)(:a, 0),
-               LocalVariableTargetNode(7...8)(:b, 0)],
+              MultiTargetNode(4...8)(
+                [LocalVariableTargetNode(4...5)(:a, 0),
+                 LocalVariableTargetNode(7...8)(:b, 0)],
+                nil,
+                nil
+              ),
               (9...10),
               CallNode(11...14)(
                 nil,
@@ -19,9 +23,7 @@ ProgramNode(0...20)(
                 nil,
                 2,
                 "foo"
-              ),
-              nil,
-              nil
+              )
             )]
          ),
          (3...4),

--- a/test/yarp/snapshots/whitequark/masgn.txt
+++ b/test/yarp/snapshots/whitequark/masgn.txt
@@ -2,12 +2,10 @@ ProgramNode(0...56)(
   [:foo, :bar, :baz],
   StatementsNode(0...56)(
     [MultiWriteNode(0...17)(
-       MultiTargetNode(0...10)(
-         [LocalVariableTargetNode(1...4)(:foo, 0),
-          LocalVariableTargetNode(6...9)(:bar, 0)],
-         (0...1),
-         (9...10)
-       ),
+       [LocalVariableTargetNode(1...4)(:foo, 0),
+        LocalVariableTargetNode(6...9)(:bar, 0)],
+       (0...1),
+       (9...10),
        (11...12),
        ArrayNode(13...17)(
          [IntegerNode(13...14)(), IntegerNode(16...17)()],
@@ -16,12 +14,10 @@ ProgramNode(0...56)(
        )
      ),
      MultiWriteNode(19...34)(
-       MultiTargetNode(19...27)(
-         [LocalVariableTargetNode(19...22)(:foo, 0),
-          LocalVariableTargetNode(24...27)(:bar, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(19...22)(:foo, 0),
+        LocalVariableTargetNode(24...27)(:bar, 0)],
+       nil,
+       nil,
        (28...29),
        ArrayNode(30...34)(
          [IntegerNode(30...31)(), IntegerNode(33...34)()],
@@ -30,13 +26,11 @@ ProgramNode(0...56)(
        )
      ),
      MultiWriteNode(36...56)(
-       MultiTargetNode(36...49)(
-         [LocalVariableTargetNode(36...39)(:foo, 0),
-          LocalVariableTargetNode(41...44)(:bar, 0),
-          LocalVariableTargetNode(46...49)(:baz, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(36...39)(:foo, 0),
+        LocalVariableTargetNode(41...44)(:bar, 0),
+        LocalVariableTargetNode(46...49)(:baz, 0)],
+       nil,
+       nil,
        (50...51),
        ArrayNode(52...56)(
          [IntegerNode(52...53)(), IntegerNode(55...56)()],

--- a/test/yarp/snapshots/whitequark/masgn.txt
+++ b/test/yarp/snapshots/whitequark/masgn.txt
@@ -2,41 +2,47 @@ ProgramNode(0...56)(
   [:foo, :bar, :baz],
   StatementsNode(0...56)(
     [MultiWriteNode(0...17)(
-       [LocalVariableTargetNode(1...4)(:foo, 0),
-        LocalVariableTargetNode(6...9)(:bar, 0)],
+       MultiTargetNode(0...10)(
+         [LocalVariableTargetNode(1...4)(:foo, 0),
+          LocalVariableTargetNode(6...9)(:bar, 0)],
+         (0...1),
+         (9...10)
+       ),
        (11...12),
        ArrayNode(13...17)(
          [IntegerNode(13...14)(), IntegerNode(16...17)()],
          nil,
          nil
-       ),
-       (0...1),
-       (9...10)
+       )
      ),
      MultiWriteNode(19...34)(
-       [LocalVariableTargetNode(19...22)(:foo, 0),
-        LocalVariableTargetNode(24...27)(:bar, 0)],
+       MultiTargetNode(19...27)(
+         [LocalVariableTargetNode(19...22)(:foo, 0),
+          LocalVariableTargetNode(24...27)(:bar, 0)],
+         nil,
+         nil
+       ),
        (28...29),
        ArrayNode(30...34)(
          [IntegerNode(30...31)(), IntegerNode(33...34)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      MultiWriteNode(36...56)(
-       [LocalVariableTargetNode(36...39)(:foo, 0),
-        LocalVariableTargetNode(41...44)(:bar, 0),
-        LocalVariableTargetNode(46...49)(:baz, 0)],
+       MultiTargetNode(36...49)(
+         [LocalVariableTargetNode(36...39)(:foo, 0),
+          LocalVariableTargetNode(41...44)(:bar, 0),
+          LocalVariableTargetNode(46...49)(:baz, 0)],
+         nil,
+         nil
+       ),
        (50...51),
        ArrayNode(52...56)(
          [IntegerNode(52...53)(), IntegerNode(55...56)()],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_attr.txt
+++ b/test/yarp/snapshots/whitequark/masgn_attr.txt
@@ -2,74 +2,68 @@ ProgramNode(0...63)(
   [:foo],
   StatementsNode(0...63)(
     [MultiWriteNode(0...17)(
-       MultiTargetNode(0...11)(
-         [CallNode(0...6)(
-            SelfNode(0...4)(),
-            (4...5),
-            (5...6),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "A="
-          ),
-          LocalVariableTargetNode(8...11)(:foo, 0)],
-         nil,
-         nil
-       ),
+       [CallNode(0...6)(
+          SelfNode(0...4)(),
+          (4...5),
+          (5...6),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "A="
+        ),
+        LocalVariableTargetNode(8...11)(:foo, 0)],
+       nil,
+       nil,
        (12...13),
        LocalVariableReadNode(14...17)(:foo, 0)
      ),
      MultiWriteNode(19...43)(
-       MultiTargetNode(19...37)(
-         [CallNode(19...25)(
-            SelfNode(19...23)(),
-            (23...24),
-            (24...25),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "a="
+       [CallNode(19...25)(
+          SelfNode(19...23)(),
+          (23...24),
+          (24...25),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "a="
+        ),
+        CallNode(27...37)(
+          SelfNode(27...31)(),
+          nil,
+          (31...37),
+          (31...32),
+          ArgumentsNode(32...36)(
+            [IntegerNode(32...33)(), IntegerNode(35...36)()]
           ),
-          CallNode(27...37)(
-            SelfNode(27...31)(),
-            nil,
-            (31...37),
-            (31...32),
-            ArgumentsNode(32...36)(
-              [IntegerNode(32...33)(), IntegerNode(35...36)()]
-            ),
-            (36...37),
-            nil,
-            0,
-            "[]="
-          )],
-         nil,
-         nil
-       ),
+          (36...37),
+          nil,
+          0,
+          "[]="
+        )],
+       nil,
+       nil,
        (38...39),
        LocalVariableReadNode(40...43)(:foo, 0)
      ),
      MultiWriteNode(45...63)(
-       MultiTargetNode(45...57)(
-         [CallNode(45...52)(
-            SelfNode(45...49)(),
-            (49...51),
-            (51...52),
-            nil,
-            nil,
-            nil,
-            nil,
-            0,
-            "a="
-          ),
-          LocalVariableTargetNode(54...57)(:foo, 0)],
-         nil,
-         nil
-       ),
+       [CallNode(45...52)(
+          SelfNode(45...49)(),
+          (49...51),
+          (51...52),
+          nil,
+          nil,
+          nil,
+          nil,
+          0,
+          "a="
+        ),
+        LocalVariableTargetNode(54...57)(:foo, 0)],
+       nil,
+       nil,
        (58...59),
        LocalVariableReadNode(60...63)(:foo, 0)
      )]

--- a/test/yarp/snapshots/whitequark/masgn_attr.txt
+++ b/test/yarp/snapshots/whitequark/masgn_attr.txt
@@ -2,70 +2,76 @@ ProgramNode(0...63)(
   [:foo],
   StatementsNode(0...63)(
     [MultiWriteNode(0...17)(
-       [CallNode(0...6)(
-          SelfNode(0...4)(),
-          (4...5),
-          (5...6),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "A="
-        ),
-        LocalVariableTargetNode(8...11)(:foo, 0)],
+       MultiTargetNode(0...11)(
+         [CallNode(0...6)(
+            SelfNode(0...4)(),
+            (4...5),
+            (5...6),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "A="
+          ),
+          LocalVariableTargetNode(8...11)(:foo, 0)],
+         nil,
+         nil
+       ),
        (12...13),
-       LocalVariableReadNode(14...17)(:foo, 0),
-       nil,
-       nil
+       LocalVariableReadNode(14...17)(:foo, 0)
      ),
      MultiWriteNode(19...43)(
-       [CallNode(19...25)(
-          SelfNode(19...23)(),
-          (23...24),
-          (24...25),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "a="
-        ),
-        CallNode(27...37)(
-          SelfNode(27...31)(),
-          nil,
-          (31...37),
-          (31...32),
-          ArgumentsNode(32...36)(
-            [IntegerNode(32...33)(), IntegerNode(35...36)()]
+       MultiTargetNode(19...37)(
+         [CallNode(19...25)(
+            SelfNode(19...23)(),
+            (23...24),
+            (24...25),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "a="
           ),
-          (36...37),
-          nil,
-          0,
-          "[]="
-        )],
+          CallNode(27...37)(
+            SelfNode(27...31)(),
+            nil,
+            (31...37),
+            (31...32),
+            ArgumentsNode(32...36)(
+              [IntegerNode(32...33)(), IntegerNode(35...36)()]
+            ),
+            (36...37),
+            nil,
+            0,
+            "[]="
+          )],
+         nil,
+         nil
+       ),
        (38...39),
-       LocalVariableReadNode(40...43)(:foo, 0),
-       nil,
-       nil
+       LocalVariableReadNode(40...43)(:foo, 0)
      ),
      MultiWriteNode(45...63)(
-       [CallNode(45...52)(
-          SelfNode(45...49)(),
-          (49...51),
-          (51...52),
-          nil,
-          nil,
-          nil,
-          nil,
-          0,
-          "a="
-        ),
-        LocalVariableTargetNode(54...57)(:foo, 0)],
+       MultiTargetNode(45...57)(
+         [CallNode(45...52)(
+            SelfNode(45...49)(),
+            (49...51),
+            (51...52),
+            nil,
+            nil,
+            nil,
+            nil,
+            0,
+            "a="
+          ),
+          LocalVariableTargetNode(54...57)(:foo, 0)],
+         nil,
+         nil
+       ),
        (58...59),
-       LocalVariableReadNode(60...63)(:foo, 0),
-       nil,
-       nil
+       LocalVariableReadNode(60...63)(:foo, 0)
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_cmd.txt
+++ b/test/yarp/snapshots/whitequark/masgn_cmd.txt
@@ -2,12 +2,10 @@ ProgramNode(0...16)(
   [:foo, :bar],
   StatementsNode(0...16)(
     [MultiWriteNode(0...16)(
-       MultiTargetNode(0...8)(
-         [LocalVariableTargetNode(0...3)(:foo, 0),
-          LocalVariableTargetNode(5...8)(:bar, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...3)(:foo, 0),
+        LocalVariableTargetNode(5...8)(:bar, 0)],
+       nil,
+       nil,
        (9...10),
        CallNode(11...16)(
          nil,

--- a/test/yarp/snapshots/whitequark/masgn_cmd.txt
+++ b/test/yarp/snapshots/whitequark/masgn_cmd.txt
@@ -2,8 +2,12 @@ ProgramNode(0...16)(
   [:foo, :bar],
   StatementsNode(0...16)(
     [MultiWriteNode(0...16)(
-       [LocalVariableTargetNode(0...3)(:foo, 0),
-        LocalVariableTargetNode(5...8)(:bar, 0)],
+       MultiTargetNode(0...8)(
+         [LocalVariableTargetNode(0...3)(:foo, 0),
+          LocalVariableTargetNode(5...8)(:bar, 0)],
+         nil,
+         nil
+       ),
        (9...10),
        CallNode(11...16)(
          nil,
@@ -15,9 +19,7 @@ ProgramNode(0...16)(
          nil,
          0,
          "m"
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_const.txt
+++ b/test/yarp/snapshots/whitequark/masgn_const.txt
@@ -2,28 +2,32 @@ ProgramNode(0...34)(
   [:foo],
   StatementsNode(0...34)(
     [MultiWriteNode(0...14)(
-       [ConstantPathTargetNode(0...3)(
-          nil,
-          ConstantReadNode(2...3)(:A),
-          (0...2)
-        ),
-        LocalVariableTargetNode(5...8)(:foo, 0)],
+       MultiTargetNode(0...8)(
+         [ConstantPathTargetNode(0...3)(
+            nil,
+            ConstantReadNode(2...3)(:A),
+            (0...2)
+          ),
+          LocalVariableTargetNode(5...8)(:foo, 0)],
+         nil,
+         nil
+       ),
        (9...10),
-       LocalVariableReadNode(11...14)(:foo, 0),
-       nil,
-       nil
+       LocalVariableReadNode(11...14)(:foo, 0)
      ),
      MultiWriteNode(16...34)(
-       [ConstantPathTargetNode(16...23)(
-          SelfNode(16...20)(),
-          ConstantReadNode(22...23)(:A),
-          (20...22)
-        ),
-        LocalVariableTargetNode(25...28)(:foo, 0)],
+       MultiTargetNode(16...28)(
+         [ConstantPathTargetNode(16...23)(
+            SelfNode(16...20)(),
+            ConstantReadNode(22...23)(:A),
+            (20...22)
+          ),
+          LocalVariableTargetNode(25...28)(:foo, 0)],
+         nil,
+         nil
+       ),
        (29...30),
-       LocalVariableReadNode(31...34)(:foo, 0),
-       nil,
-       nil
+       LocalVariableReadNode(31...34)(:foo, 0)
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_const.txt
+++ b/test/yarp/snapshots/whitequark/masgn_const.txt
@@ -2,30 +2,26 @@ ProgramNode(0...34)(
   [:foo],
   StatementsNode(0...34)(
     [MultiWriteNode(0...14)(
-       MultiTargetNode(0...8)(
-         [ConstantPathTargetNode(0...3)(
-            nil,
-            ConstantReadNode(2...3)(:A),
-            (0...2)
-          ),
-          LocalVariableTargetNode(5...8)(:foo, 0)],
-         nil,
-         nil
-       ),
+       [ConstantPathTargetNode(0...3)(
+          nil,
+          ConstantReadNode(2...3)(:A),
+          (0...2)
+        ),
+        LocalVariableTargetNode(5...8)(:foo, 0)],
+       nil,
+       nil,
        (9...10),
        LocalVariableReadNode(11...14)(:foo, 0)
      ),
      MultiWriteNode(16...34)(
-       MultiTargetNode(16...28)(
-         [ConstantPathTargetNode(16...23)(
-            SelfNode(16...20)(),
-            ConstantReadNode(22...23)(:A),
-            (20...22)
-          ),
-          LocalVariableTargetNode(25...28)(:foo, 0)],
-         nil,
-         nil
-       ),
+       [ConstantPathTargetNode(16...23)(
+          SelfNode(16...20)(),
+          ConstantReadNode(22...23)(:A),
+          (20...22)
+        ),
+        LocalVariableTargetNode(25...28)(:foo, 0)],
+       nil,
+       nil,
        (29...30),
        LocalVariableReadNode(31...34)(:foo, 0)
      )]

--- a/test/yarp/snapshots/whitequark/masgn_nested.txt
+++ b/test/yarp/snapshots/whitequark/masgn_nested.txt
@@ -1,34 +1,34 @@
-ProgramNode(0...30)(
+ProgramNode(1...30)(
   [:b, :a, :c],
-  StatementsNode(0...30)(
-    [MultiWriteNode(0...13)(
-       [MultiWriteNode(1...6)(
-          [LocalVariableTargetNode(2...3)(:b, 0),
-           SplatNode(3...4)((3...4), nil)],
-          nil,
-          nil,
-          (1...2),
-          (5...6)
-        )],
+  StatementsNode(1...30)(
+    [MultiWriteNode(1...13)(
+       MultiTargetNode(1...6)(
+         [MultiTargetNode(1...6)(
+            [LocalVariableTargetNode(2...3)(:b, 0),
+             SplatNode(3...4)((3...4), nil)],
+            (1...2),
+            (5...6)
+          )],
+         nil,
+         nil
+       ),
        (8...9),
-       CallNode(10...13)(nil, nil, (10...13), nil, nil, nil, nil, 2, "foo"),
-       (0...1),
-       (6...7)
+       CallNode(10...13)(nil, nil, (10...13), nil, nil, nil, nil, 2, "foo")
      ),
      MultiWriteNode(15...30)(
-       [LocalVariableTargetNode(15...16)(:a, 0),
-        MultiWriteNode(18...24)(
-          [LocalVariableTargetNode(19...20)(:b, 0),
-           LocalVariableTargetNode(22...23)(:c, 0)],
-          nil,
-          nil,
-          (18...19),
-          (23...24)
-        )],
+       MultiTargetNode(15...24)(
+         [LocalVariableTargetNode(15...16)(:a, 0),
+          MultiTargetNode(18...24)(
+            [LocalVariableTargetNode(19...20)(:b, 0),
+             LocalVariableTargetNode(22...23)(:c, 0)],
+            (18...19),
+            (23...24)
+          )],
+         nil,
+         nil
+       ),
        (25...26),
-       CallNode(27...30)(nil, nil, (27...30), nil, nil, nil, nil, 2, "foo"),
-       nil,
-       nil
+       CallNode(27...30)(nil, nil, (27...30), nil, nil, nil, nil, 2, "foo")
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_nested.txt
+++ b/test/yarp/snapshots/whitequark/masgn_nested.txt
@@ -2,31 +2,27 @@ ProgramNode(1...30)(
   [:b, :a, :c],
   StatementsNode(1...30)(
     [MultiWriteNode(1...13)(
-       MultiTargetNode(1...6)(
-         [MultiTargetNode(1...6)(
-            [LocalVariableTargetNode(2...3)(:b, 0),
-             SplatNode(3...4)((3...4), nil)],
-            (1...2),
-            (5...6)
-          )],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(1...6)(
+          [LocalVariableTargetNode(2...3)(:b, 0),
+           SplatNode(3...4)((3...4), nil)],
+          (1...2),
+          (5...6)
+        )],
+       nil,
+       nil,
        (8...9),
        CallNode(10...13)(nil, nil, (10...13), nil, nil, nil, nil, 2, "foo")
      ),
      MultiWriteNode(15...30)(
-       MultiTargetNode(15...24)(
-         [LocalVariableTargetNode(15...16)(:a, 0),
-          MultiTargetNode(18...24)(
-            [LocalVariableTargetNode(19...20)(:b, 0),
-             LocalVariableTargetNode(22...23)(:c, 0)],
-            (18...19),
-            (23...24)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(15...16)(:a, 0),
+        MultiTargetNode(18...24)(
+          [LocalVariableTargetNode(19...20)(:b, 0),
+           LocalVariableTargetNode(22...23)(:c, 0)],
+          (18...19),
+          (23...24)
+        )],
+       nil,
+       nil,
        (25...26),
        CallNode(27...30)(nil, nil, (27...30), nil, nil, nil, nil, 2, "foo")
      )]

--- a/test/yarp/snapshots/whitequark/masgn_splat.txt
+++ b/test/yarp/snapshots/whitequark/masgn_splat.txt
@@ -2,57 +2,61 @@ ProgramNode(0...139)(
   [:c, :d, :b, :a],
   StatementsNode(0...139)(
     [MultiWriteNode(0...7)(
-       [SplatNode(0...1)((0...1), nil)],
+       MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
        (2...3),
-       CallNode(4...7)(nil, nil, (4...7), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(4...7)(nil, nil, (4...7), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(9...22)(
-       [MultiWriteNode(9...10)(
-          [SplatNode(9...10)((9...10), nil)],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(12...13)(:c, 0),
-        LocalVariableTargetNode(15...16)(:d, 0)],
+       MultiTargetNode(9...16)(
+         [MultiTargetNode(9...10)(
+            [SplatNode(9...10)((9...10), nil)],
+            nil,
+            nil
+          ),
+          LocalVariableTargetNode(12...13)(:c, 0),
+          LocalVariableTargetNode(15...16)(:d, 0)],
+         nil,
+         nil
+       ),
        (17...18),
-       CallNode(19...22)(nil, nil, (19...22), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(19...22)(nil, nil, (19...22), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(24...32)(
-       [SplatNode(24...26)(
-          (24...25),
-          LocalVariableTargetNode(25...26)(:b, 0)
-        )],
+       MultiTargetNode(24...26)(
+         [SplatNode(24...26)(
+            (24...25),
+            LocalVariableTargetNode(25...26)(:b, 0)
+          )],
+         nil,
+         nil
+       ),
        (27...28),
-       CallNode(29...32)(nil, nil, (29...32), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(29...32)(nil, nil, (29...32), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(34...45)(
-       [MultiWriteNode(34...36)(
-          [SplatNode(34...36)(
-             (34...35),
-             LocalVariableTargetNode(35...36)(:b, 0)
-           )],
-          nil,
-          nil,
-          nil,
-          nil
-        ),
-        LocalVariableTargetNode(38...39)(:c, 0)],
+       MultiTargetNode(34...39)(
+         [MultiTargetNode(34...36)(
+            [SplatNode(34...36)(
+               (34...35),
+               LocalVariableTargetNode(35...36)(:b, 0)
+             )],
+            nil,
+            nil
+          ),
+          LocalVariableTargetNode(38...39)(:c, 0)],
+         nil,
+         nil
+       ),
        (40...41),
-       CallNode(42...45)(nil, nil, (42...45), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(42...45)(nil, nil, (42...45), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(47...65)(
-       [InstanceVariableTargetNode(47...51)(:@foo),
-        ClassVariableTargetNode(53...58)(:@@bar)],
+       MultiTargetNode(47...58)(
+         [InstanceVariableTargetNode(47...51)(:@foo),
+          ClassVariableTargetNode(53...58)(:@@bar)],
+         nil,
+         nil
+       ),
        (59...60),
        ArrayNode(61...65)(
          [SplatNode(61...65)(
@@ -71,73 +75,63 @@ ProgramNode(0...139)(
           )],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      ),
      MultiWriteNode(67...77)(
-       [LocalVariableTargetNode(67...68)(:a, 0),
-        SplatNode(70...71)((70...71), nil)],
+       MultiTargetNode(67...71)(
+         [LocalVariableTargetNode(67...68)(:a, 0),
+          SplatNode(70...71)((70...71), nil)],
+         nil,
+         nil
+       ),
        (72...73),
-       CallNode(74...77)(nil, nil, (74...77), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(74...77)(nil, nil, (74...77), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(79...92)(
-       [LocalVariableTargetNode(79...80)(:a, 0),
-        SplatNode(82...83)((82...83), nil),
-        LocalVariableTargetNode(85...86)(:c, 0)],
+       MultiTargetNode(79...86)(
+         [LocalVariableTargetNode(79...80)(:a, 0),
+          SplatNode(82...83)((82...83), nil),
+          LocalVariableTargetNode(85...86)(:c, 0)],
+         nil,
+         nil
+       ),
        (87...88),
-       CallNode(89...92)(nil, nil, (89...92), nil, nil, nil, nil, 2, "bar"),
-       nil,
-       nil
+       CallNode(89...92)(nil, nil, (89...92), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(94...105)(
-       [LocalVariableTargetNode(94...95)(:a, 0),
-        SplatNode(97...99)(
-          (97...98),
-          LocalVariableTargetNode(98...99)(:b, 0)
-        )],
-       (100...101),
-       CallNode(102...105)(
+       MultiTargetNode(94...99)(
+         [LocalVariableTargetNode(94...95)(:a, 0),
+          SplatNode(97...99)(
+            (97...98),
+            LocalVariableTargetNode(98...99)(:b, 0)
+          )],
          nil,
-         nil,
-         (102...105),
-         nil,
-         nil,
-         nil,
-         nil,
-         2,
-         "bar"
+         nil
        ),
-       nil,
-       nil
+       (100...101),
+       CallNode(102...105)(nil, nil, (102...105), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(107...121)(
-       [LocalVariableTargetNode(107...108)(:a, 0),
-        SplatNode(110...112)(
-          (110...111),
-          LocalVariableTargetNode(111...112)(:b, 0)
-        ),
-        LocalVariableTargetNode(114...115)(:c, 0)],
-       (116...117),
-       CallNode(118...121)(
+       MultiTargetNode(107...115)(
+         [LocalVariableTargetNode(107...108)(:a, 0),
+          SplatNode(110...112)(
+            (110...111),
+            LocalVariableTargetNode(111...112)(:b, 0)
+          ),
+          LocalVariableTargetNode(114...115)(:c, 0)],
          nil,
-         nil,
-         (118...121),
-         nil,
-         nil,
-         nil,
-         nil,
-         2,
-         "bar"
+         nil
        ),
-       nil,
-       nil
+       (116...117),
+       CallNode(118...121)(nil, nil, (118...121), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(123...139)(
-       [LocalVariableTargetNode(123...124)(:a, 0),
-        LocalVariableTargetNode(126...127)(:b, 0)],
+       MultiTargetNode(123...127)(
+         [LocalVariableTargetNode(123...124)(:a, 0),
+          LocalVariableTargetNode(126...127)(:b, 0)],
+         nil,
+         nil
+       ),
        (128...129),
        ArrayNode(130...139)(
          [SplatNode(130...134)(
@@ -167,9 +161,7 @@ ProgramNode(0...139)(
           )],
          nil,
          nil
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )

--- a/test/yarp/snapshots/whitequark/masgn_splat.txt
+++ b/test/yarp/snapshots/whitequark/masgn_splat.txt
@@ -2,61 +2,51 @@ ProgramNode(0...139)(
   [:c, :d, :b, :a],
   StatementsNode(0...139)(
     [MultiWriteNode(0...7)(
-       MultiTargetNode(0...1)([SplatNode(0...1)((0...1), nil)], nil, nil),
+       [SplatNode(0...1)((0...1), nil)],
+       nil,
+       nil,
        (2...3),
        CallNode(4...7)(nil, nil, (4...7), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(9...22)(
-       MultiTargetNode(9...16)(
-         [MultiTargetNode(9...10)(
-            [SplatNode(9...10)((9...10), nil)],
-            nil,
-            nil
-          ),
-          LocalVariableTargetNode(12...13)(:c, 0),
-          LocalVariableTargetNode(15...16)(:d, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(9...10)([SplatNode(9...10)((9...10), nil)], nil, nil),
+        LocalVariableTargetNode(12...13)(:c, 0),
+        LocalVariableTargetNode(15...16)(:d, 0)],
+       nil,
+       nil,
        (17...18),
        CallNode(19...22)(nil, nil, (19...22), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(24...32)(
-       MultiTargetNode(24...26)(
-         [SplatNode(24...26)(
-            (24...25),
-            LocalVariableTargetNode(25...26)(:b, 0)
-          )],
-         nil,
-         nil
-       ),
+       [SplatNode(24...26)(
+          (24...25),
+          LocalVariableTargetNode(25...26)(:b, 0)
+        )],
+       nil,
+       nil,
        (27...28),
        CallNode(29...32)(nil, nil, (29...32), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(34...45)(
-       MultiTargetNode(34...39)(
-         [MultiTargetNode(34...36)(
-            [SplatNode(34...36)(
-               (34...35),
-               LocalVariableTargetNode(35...36)(:b, 0)
-             )],
-            nil,
-            nil
-          ),
-          LocalVariableTargetNode(38...39)(:c, 0)],
-         nil,
-         nil
-       ),
+       [MultiTargetNode(34...36)(
+          [SplatNode(34...36)(
+             (34...35),
+             LocalVariableTargetNode(35...36)(:b, 0)
+           )],
+          nil,
+          nil
+        ),
+        LocalVariableTargetNode(38...39)(:c, 0)],
+       nil,
+       nil,
        (40...41),
        CallNode(42...45)(nil, nil, (42...45), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(47...65)(
-       MultiTargetNode(47...58)(
-         [InstanceVariableTargetNode(47...51)(:@foo),
-          ClassVariableTargetNode(53...58)(:@@bar)],
-         nil,
-         nil
-       ),
+       [InstanceVariableTargetNode(47...51)(:@foo),
+        ClassVariableTargetNode(53...58)(:@@bar)],
+       nil,
+       nil,
        (59...60),
        ArrayNode(61...65)(
          [SplatNode(61...65)(
@@ -78,60 +68,50 @@ ProgramNode(0...139)(
        )
      ),
      MultiWriteNode(67...77)(
-       MultiTargetNode(67...71)(
-         [LocalVariableTargetNode(67...68)(:a, 0),
-          SplatNode(70...71)((70...71), nil)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(67...68)(:a, 0),
+        SplatNode(70...71)((70...71), nil)],
+       nil,
+       nil,
        (72...73),
        CallNode(74...77)(nil, nil, (74...77), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(79...92)(
-       MultiTargetNode(79...86)(
-         [LocalVariableTargetNode(79...80)(:a, 0),
-          SplatNode(82...83)((82...83), nil),
-          LocalVariableTargetNode(85...86)(:c, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(79...80)(:a, 0),
+        SplatNode(82...83)((82...83), nil),
+        LocalVariableTargetNode(85...86)(:c, 0)],
+       nil,
+       nil,
        (87...88),
        CallNode(89...92)(nil, nil, (89...92), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(94...105)(
-       MultiTargetNode(94...99)(
-         [LocalVariableTargetNode(94...95)(:a, 0),
-          SplatNode(97...99)(
-            (97...98),
-            LocalVariableTargetNode(98...99)(:b, 0)
-          )],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(94...95)(:a, 0),
+        SplatNode(97...99)(
+          (97...98),
+          LocalVariableTargetNode(98...99)(:b, 0)
+        )],
+       nil,
+       nil,
        (100...101),
        CallNode(102...105)(nil, nil, (102...105), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(107...121)(
-       MultiTargetNode(107...115)(
-         [LocalVariableTargetNode(107...108)(:a, 0),
-          SplatNode(110...112)(
-            (110...111),
-            LocalVariableTargetNode(111...112)(:b, 0)
-          ),
-          LocalVariableTargetNode(114...115)(:c, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(107...108)(:a, 0),
+        SplatNode(110...112)(
+          (110...111),
+          LocalVariableTargetNode(111...112)(:b, 0)
+        ),
+        LocalVariableTargetNode(114...115)(:c, 0)],
+       nil,
+       nil,
        (116...117),
        CallNode(118...121)(nil, nil, (118...121), nil, nil, nil, nil, 2, "bar")
      ),
      MultiWriteNode(123...139)(
-       MultiTargetNode(123...127)(
-         [LocalVariableTargetNode(123...124)(:a, 0),
-          LocalVariableTargetNode(126...127)(:b, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(123...124)(:a, 0),
+        LocalVariableTargetNode(126...127)(:b, 0)],
+       nil,
+       nil,
        (128...129),
        ArrayNode(130...139)(
          [SplatNode(130...134)(

--- a/test/yarp/snapshots/whitequark/not_masgn__24.txt
+++ b/test/yarp/snapshots/whitequark/not_masgn__24.txt
@@ -5,8 +5,12 @@ ProgramNode(0...13)(
        ParenthesesNode(1...13)(
          StatementsNode(2...12)(
            [MultiWriteNode(2...12)(
-              [LocalVariableTargetNode(2...3)(:a, 0),
-               LocalVariableTargetNode(5...6)(:b, 0)],
+              MultiTargetNode(2...6)(
+                [LocalVariableTargetNode(2...3)(:a, 0),
+                 LocalVariableTargetNode(5...6)(:b, 0)],
+                nil,
+                nil
+              ),
               (7...8),
               CallNode(9...12)(
                 nil,
@@ -18,9 +22,7 @@ ProgramNode(0...13)(
                 nil,
                 2,
                 "foo"
-              ),
-              nil,
-              nil
+              )
             )]
          ),
          (1...2),

--- a/test/yarp/snapshots/whitequark/not_masgn__24.txt
+++ b/test/yarp/snapshots/whitequark/not_masgn__24.txt
@@ -5,12 +5,10 @@ ProgramNode(0...13)(
        ParenthesesNode(1...13)(
          StatementsNode(2...12)(
            [MultiWriteNode(2...12)(
-              MultiTargetNode(2...6)(
-                [LocalVariableTargetNode(2...3)(:a, 0),
-                 LocalVariableTargetNode(5...6)(:b, 0)],
-                nil,
-                nil
-              ),
+              [LocalVariableTargetNode(2...3)(:a, 0),
+               LocalVariableTargetNode(5...6)(:b, 0)],
+              nil,
+              nil,
               (7...8),
               CallNode(9...12)(
                 nil,

--- a/test/yarp/snapshots/whitequark/rescue_mod_masgn.txt
+++ b/test/yarp/snapshots/whitequark/rescue_mod_masgn.txt
@@ -2,12 +2,10 @@ ProgramNode(0...29)(
   [:foo, :bar],
   StatementsNode(0...29)(
     [MultiWriteNode(0...29)(
-       MultiTargetNode(0...8)(
-         [LocalVariableTargetNode(0...3)(:foo, 0),
-          LocalVariableTargetNode(5...8)(:bar, 0)],
-         nil,
-         nil
-       ),
+       [LocalVariableTargetNode(0...3)(:foo, 0),
+        LocalVariableTargetNode(5...8)(:bar, 0)],
+       nil,
+       nil,
        (9...10),
        RescueModifierNode(11...29)(
          CallNode(11...15)(nil, nil, (11...15), nil, nil, nil, nil, 2, "meth"),

--- a/test/yarp/snapshots/whitequark/rescue_mod_masgn.txt
+++ b/test/yarp/snapshots/whitequark/rescue_mod_masgn.txt
@@ -2,8 +2,12 @@ ProgramNode(0...29)(
   [:foo, :bar],
   StatementsNode(0...29)(
     [MultiWriteNode(0...29)(
-       [LocalVariableTargetNode(0...3)(:foo, 0),
-        LocalVariableTargetNode(5...8)(:bar, 0)],
+       MultiTargetNode(0...8)(
+         [LocalVariableTargetNode(0...3)(:foo, 0),
+          LocalVariableTargetNode(5...8)(:bar, 0)],
+         nil,
+         nil
+       ),
        (9...10),
        RescueModifierNode(11...29)(
          CallNode(11...15)(nil, nil, (11...15), nil, nil, nil, nil, 2, "meth"),
@@ -13,9 +17,7 @@ ProgramNode(0...29)(
            (23...24),
            (28...29)
          )
-       ),
-       nil,
-       nil
+       )
      )]
   )
 )


### PR DESCRIPTION
This commit introduces a multi target node, which is used in two places.

Previously `for foo, bar in baz do end` contains a `MultiWriteNode` with a value and operator that were always null. This wasted memory and space in the serialization. These are now `MultiTargetNode` nodes.

Previously, `foo, (bar, baz) = qux` would have a child `MultiWriteNode` with a value and operator that were always null. This is now a `MultiTargetNode`.

Fixes #1383