### PR TITLE
Mark flags as private

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -389,30 +389,6 @@ module YARP
     end
   end
 
-  class FloatNode < Node
-    def value
-      Float(slice)
-    end
-  end
-
-  class ImaginaryNode < Node
-    def value
-      Complex(0, numeric.value)
-    end
-  end
-
-  class IntegerNode < Node
-    def value
-      Integer(slice)
-    end
-  end
-
-  class RationalNode < Node
-    def value
-      Rational(slice.chomp("r"))
-    end
-  end
-
   # Load the serialized AST using the source as a reference into a tree.
   def self.load(source, serialized)
     Serialize.load(source, serialized)
@@ -598,4 +574,58 @@ if RUBY_ENGINE == "ruby" and !ENV["YARP_FFI_BACKEND"]
   require "yarp/yarp"
 else
   require_relative "yarp/ffi"
+end
+
+# Reopening the YARP module after yarp/node is required so that constant
+# reflection APIs will find the constants defined in the node file before these.
+# This block is meant to contain extra APIs we define on YARP nodes that aren't
+# templated and are meant as convenience methods.
+module YARP
+  class FloatNode < Node
+    # Returns the value of the node as a Ruby Float.
+    def value
+      Float(slice)
+    end
+  end
+
+  class ImaginaryNode < Node
+    # Returns the value of the node as a Ruby Complex.
+    def value
+      Complex(0, numeric.value)
+    end
+  end
+
+  class IntegerNode < Node
+    # Returns the value of the node as a Ruby Integer.
+    def value
+      Integer(slice)
+    end
+  end
+
+  class InterpolatedRegularExpressionNode < Node
+    # Returns a numeric value that represents the flags that were used to create
+    # the regular expression. This mirrors the Regexp#options method in Ruby.
+    # Note that this is effectively masking only the three common flags that are
+    # used in Ruby, and does not include the full set of flags like encoding.
+    def options
+      flags & 0b111
+    end
+  end
+
+  class RationalNode < Node
+    # Returns the value of the node as a Ruby Rational.
+    def value
+      Rational(slice.chomp("r"))
+    end
+  end
+
+  class RegularExpressionNode < Node
+    # Returns a numeric value that represents the flags that were used to create
+    # the regular expression. This mirrors the Regexp#options method in Ruby.
+    # Note that this is effectively masking only the three common flags that are
+    # used in Ruby, and does not include the full set of flags like encoding.
+    def options
+      flags & 0b111
+    end
+  end
 end

--- a/templates/lib/yarp/node.rb.erb
+++ b/templates/lib/yarp/node.rb.erb
@@ -3,7 +3,7 @@ module YARP
   <%= "#{node.comment.split("\n").map { |line| line.empty? ? "#" : "# #{line}" }.join("\n  ")}\n  " if node.comment %>class <%= node.name -%> < Node
     <%- node.fields.each do |field| -%>
     # attr_reader <%= field.name %>: <%= field.rbs_class %>
-    attr_reader :<%= field.name %>
+    <%= "private " if field.is_a?(YARP::FlagsField) %>attr_reader :<%= field.name %>
 
     <%- end -%>
     # def initialize: (<%= (node.fields.map { |field| "#{field.name}: #{field.rbs_class}" } + ["location: Location"]).join(", ") %>) -> void

--- a/test/yarp/regexp_test.rb
+++ b/test/yarp/regexp_test.rb
@@ -197,20 +197,20 @@ module YARP
     ##############################################################################
 
     def test_flag_ignorecase
-      assert_equal(Regexp::IGNORECASE, flags("i"))
+      assert_equal(Regexp::IGNORECASE, options("i"))
     end
 
     def test_flag_extended
-      assert_equal(Regexp::EXTENDED, flags("x"))
+      assert_equal(Regexp::EXTENDED, options("x"))
     end
 
     def test_flag_multiline
-      assert_equal(Regexp::MULTILINE, flags("m"))
+      assert_equal(Regexp::MULTILINE, options("m"))
     end
 
     def test_flag_combined
       value = Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED
-      assert_equal(value, flags("mix"))
+      assert_equal(value, options("mix"))
     end
 
     private
@@ -219,8 +219,19 @@ module YARP
       Debug.named_captures(source)
     end
 
-    def flags(str)
-      YARP.parse("/foo/#{str}").value.child_nodes.first.child_nodes.first.flags
+    def options(flags)
+      options =
+        ["/foo/#{flags}", "/foo\#{1}/#{flags}"].map do |source|
+          YARP.parse(source).value.statements.body.first.options
+        end
+
+      # Check that we get the same set of options from both regular expressions
+      # and interpolated regular expressions.
+      assert_equal(1, options.uniq.length)
+
+      # Return the options from the first regular expression since we know they
+      # are the same.
+      options.first
     end
   end
 end


### PR DESCRIPTION
The flags integer is an implementation detail. We want people to use the query methods to access the individual fields so we are freed from having to maintain a specific order. As such, this commit changes the Ruby API to mark all flags fields as private attr_readers.

The only one that has a clear use case is returning the set of options given to regular expressions, to mirror the Regexp#options API. So, to support this use case, this commit introduces RegularExpressionNode#options and InterpolatedRegularExpressionNode#options. These APIs provide back the same integer so that they can be used interchangeably.