### PR TITLE
Split AliasNode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -360,7 +360,7 @@ flags:
       - name: ONCE
         comment: "o - only interpolates values into the regular expression once"
 nodes:
-  - name: AliasNode
+  - name: AliasGlobalVariableNode
     fields:
       - name: new_name
         type: node
@@ -369,7 +369,20 @@ nodes:
       - name: keyword_loc
         type: location
     comment: |
-      Represents the use of the `alias` keyword.
+      Represents the use of the `alias` keyword to alias a global variable.
+
+          alias $foo $bar
+          ^^^^^^^^^^^^^^^
+  - name: AliasMethodNode
+    fields:
+      - name: new_name
+        type: node
+      - name: old_name
+        type: node
+      - name: keyword_loc
+        type: location
+    comment: |
+      Represents the use of the `alias` keyword to alias a method.
 
           alias foo bar
           ^^^^^^^^^^^^^

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -28,6 +28,10 @@
 #include <strings.h>
 #endif
 
+// These aliases are for migration purposes.
+#define YP_ALIAS_NODE YP_ALIAS_METHOD_NODE
+#define yp_alias_node_t yp_alias_method_node_t
+
 void yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
 
 void yp_print_node(yp_parser_t *parser, yp_node_t *node);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -711,15 +711,37 @@ yp_missing_node_create(yp_parser_t *parser, const uint8_t *start, const uint8_t 
     return node;
 }
 
-// Allocate and initialize a new alias node.
-static yp_alias_node_t *
-yp_alias_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *new_name, yp_node_t *old_name) {
+// Allocate and initialize a new AliasGlobalVariableNode node.
+static yp_alias_global_variable_node_t *
+yp_alias_global_variable_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *new_name, yp_node_t *old_name) {
     assert(keyword->type == YP_TOKEN_KEYWORD_ALIAS);
-    yp_alias_node_t *node = YP_ALLOC_NODE(parser, yp_alias_node_t);
+    yp_alias_global_variable_node_t *node = YP_ALLOC_NODE(parser, yp_alias_global_variable_node_t);
 
-    *node = (yp_alias_node_t) {
+    *node = (yp_alias_global_variable_node_t) {
         {
-            .type = YP_ALIAS_NODE,
+            .type = YP_ALIAS_GLOBAL_VARIABLE_NODE,
+            .location = {
+                .start = keyword->start,
+                .end = old_name->location.end
+            },
+        },
+        .new_name = new_name,
+        .old_name = old_name,
+        .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword)
+    };
+
+    return node;
+}
+
+// Allocate and initialize a new AliasMethodNode node.
+static yp_alias_method_node_t *
+yp_alias_method_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *new_name, yp_node_t *old_name) {
+    assert(keyword->type == YP_TOKEN_KEYWORD_ALIAS);
+    yp_alias_method_node_t *node = YP_ALLOC_NODE(parser, yp_alias_method_node_t);
+
+    *node = (yp_alias_method_node_t) {
+        {
+            .type = YP_ALIAS_METHOD_NODE,
             .location = {
                 .start = keyword->start,
                 .end = old_name->location.end
@@ -11301,13 +11323,6 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *old_name = parse_alias_argument(parser, false);
 
             switch (YP_NODE_TYPE(new_name)) {
-                case YP_SYMBOL_NODE:
-                case YP_INTERPOLATED_SYMBOL_NODE: {
-                    if (!YP_NODE_TYPE_P(old_name, YP_SYMBOL_NODE) && !YP_NODE_TYPE_P(old_name, YP_INTERPOLATED_SYMBOL_NODE)) {
-                        yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, YP_ERR_ALIAS_ARGUMENT);
-                    }
-                    break;
-                }
                 case YP_BACK_REFERENCE_READ_NODE:
                 case YP_NUMBERED_REFERENCE_READ_NODE:
                 case YP_GLOBAL_VARIABLE_READ_NODE: {
@@ -11318,13 +11333,19 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     } else {
                         yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, YP_ERR_ALIAS_ARGUMENT);
                     }
-                    break;
-                }
-                default:
-                    break;
-            }
 
-            return (yp_node_t *) yp_alias_node_create(parser, &keyword, new_name, old_name);
+                    return (yp_node_t *) yp_alias_global_variable_node_create(parser, &keyword, new_name, old_name);
+                }
+                case YP_SYMBOL_NODE:
+                case YP_INTERPOLATED_SYMBOL_NODE: {
+                    if (!YP_NODE_TYPE_P(old_name, YP_SYMBOL_NODE) && !YP_NODE_TYPE_P(old_name, YP_INTERPOLATED_SYMBOL_NODE)) {
+                        yp_diagnostic_list_append(&parser->error_list, old_name->location.start, old_name->location.end, YP_ERR_ALIAS_ARGUMENT);
+                    }
+                }
+                /* fallthrough */
+                default:
+                    return (yp_node_t *) yp_alias_method_node_create(parser, &keyword, new_name, old_name);
+            }
         }
         case YP_TOKEN_KEYWORD_CASE: {
             parser_lex(parser);

--- a/test/yarp/location_test.rb
+++ b/test/yarp/location_test.rb
@@ -4,8 +4,12 @@ require_relative "test_helper"
 
 module YARP
   class LocationTest < TestCase
-    def test_AliasNode
-      assert_location(AliasNode, "alias foo bar")
+    def test_AliasGlobalVariableNode
+      assert_location(AliasGlobalVariableNode, "alias $foo $bar")
+    end
+
+    def test_AliasMethodNode
+      assert_location(AliasMethodNode, "alias foo bar")
     end
 
     def test_AlternationPatternNode

--- a/test/yarp/snapshots/alias.txt
+++ b/test/yarp/snapshots/alias.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...199))
     └── body: (length: 12)
-        ├── @ AliasNode (location: (0...15))
+        ├── @ AliasMethodNode (location: (0...15))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (6...10))
         │   │   ├── opening_loc: (6...7) = ":"
@@ -17,7 +17,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "bar"
         │   └── keyword_loc: (0...5) = "alias"
-        ├── @ AliasNode (location: (17...38))
+        ├── @ AliasMethodNode (location: (17...38))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (23...30))
         │   │   ├── opening_loc: (23...26) = "%s["
@@ -31,7 +31,7 @@
         │   │   ├── closing_loc: (37...38) = "]"
         │   │   └── unescaped: "def"
         │   └── keyword_loc: (17...22) = "alias"
-        ├── @ AliasNode (location: (40...59))
+        ├── @ AliasMethodNode (location: (40...59))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (46...52))
         │   │   ├── opening_loc: (46...48) = ":'"
@@ -45,7 +45,7 @@
         │   │   ├── closing_loc: (58...59) = "'"
         │   │   └── unescaped: "def"
         │   └── keyword_loc: (40...45) = "alias"
-        ├── @ AliasNode (location: (61...84))
+        ├── @ AliasMethodNode (location: (61...84))
         │   ├── new_name:
         │   │   @ InterpolatedSymbolNode (location: (67...77))
         │   │   ├── opening_loc: (67...69) = ":\""
@@ -70,14 +70,14 @@
         │   │   ├── closing_loc: (83...84) = "'"
         │   │   └── unescaped: "def"
         │   └── keyword_loc: (61...66) = "alias"
-        ├── @ AliasNode (location: (86...97))
+        ├── @ AliasGlobalVariableNode (location: (86...97))
         │   ├── new_name:
         │   │   @ GlobalVariableReadNode (location: (92...94))
         │   │   └── name: :$a
         │   ├── old_name:
         │   │   @ BackReferenceReadNode (location: (95...97))
         │   └── keyword_loc: (86...91) = "alias"
-        ├── @ AliasNode (location: (99...112))
+        ├── @ AliasMethodNode (location: (99...112))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (105...108))
         │   │   ├── opening_loc: ∅
@@ -91,7 +91,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "bar"
         │   └── keyword_loc: (99...104) = "alias"
-        ├── @ AliasNode (location: (114...129))
+        ├── @ AliasGlobalVariableNode (location: (114...129))
         │   ├── new_name:
         │   │   @ GlobalVariableReadNode (location: (120...124))
         │   │   └── name: :$foo
@@ -99,7 +99,7 @@
         │   │   @ GlobalVariableReadNode (location: (125...129))
         │   │   └── name: :$bar
         │   └── keyword_loc: (114...119) = "alias"
-        ├── @ AliasNode (location: (131...143))
+        ├── @ AliasMethodNode (location: (131...143))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (137...140))
         │   │   ├── opening_loc: ∅
@@ -113,7 +113,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "if"
         │   └── keyword_loc: (131...136) = "alias"
-        ├── @ AliasNode (location: (145...158))
+        ├── @ AliasMethodNode (location: (145...158))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (151...154))
         │   │   ├── opening_loc: ∅
@@ -127,7 +127,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "<=>"
         │   └── keyword_loc: (145...150) = "alias"
-        ├── @ AliasNode (location: (160...175))
+        ├── @ AliasMethodNode (location: (160...175))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (166...169))
         │   │   ├── opening_loc: (166...167) = ":"
@@ -141,7 +141,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "eql?"
         │   └── keyword_loc: (160...165) = "alias"
-        ├── @ AliasNode (location: (177...186))
+        ├── @ AliasMethodNode (location: (177...186))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (183...184))
         │   │   ├── opening_loc: ∅
@@ -155,7 +155,7 @@
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "B"
         │   └── keyword_loc: (177...182) = "alias"
-        └── @ AliasNode (location: (188...199))
+        └── @ AliasMethodNode (location: (188...199))
             ├── new_name:
             │   @ SymbolNode (location: (194...196))
             │   ├── opening_loc: (194...195) = ":"

--- a/test/yarp/snapshots/seattlerb/alias_gvar_backref.txt
+++ b/test/yarp/snapshots/seattlerb/alias_gvar_backref.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...15))
     └── body: (length: 1)
-        └── @ AliasNode (location: (0...15))
+        └── @ AliasGlobalVariableNode (location: (0...15))
             ├── new_name:
             │   @ GlobalVariableReadNode (location: (6...12))
             │   └── name: :$MATCH

--- a/test/yarp/snapshots/seattlerb/alias_resword.txt
+++ b/test/yarp/snapshots/seattlerb/alias_resword.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...12))
     └── body: (length: 1)
-        └── @ AliasNode (location: (0...12))
+        └── @ AliasMethodNode (location: (0...12))
             ├── new_name:
             │   @ SymbolNode (location: (6...8))
             │   ├── opening_loc: ∅

--- a/test/yarp/snapshots/seattlerb/dsym_to_sym.txt
+++ b/test/yarp/snapshots/seattlerb/dsym_to_sym.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...32))
     └── body: (length: 2)
-        ├── @ AliasNode (location: (0...17))
+        ├── @ AliasMethodNode (location: (0...17))
         │   ├── new_name:
         │   │   @ SymbolNode (location: (6...11))
         │   │   ├── opening_loc: (6...8) = ":\""
@@ -17,7 +17,7 @@
         │   │   ├── closing_loc: (16...17) = "\""
         │   │   └── unescaped: ">>"
         │   └── keyword_loc: (0...5) = "alias"
-        └── @ AliasNode (location: (19...32))
+        └── @ AliasMethodNode (location: (19...32))
             ├── new_name:
             │   @ SymbolNode (location: (25...28))
             │   ├── opening_loc: (25...26) = ":"

--- a/test/yarp/snapshots/unparser/corpus/literal/alias.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/alias.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...31))
     └── body: (length: 2)
-        ├── @ AliasNode (location: (0...15))
+        ├── @ AliasGlobalVariableNode (location: (0...15))
         │   ├── new_name:
         │   │   @ GlobalVariableReadNode (location: (6...10))
         │   │   └── name: :$foo
@@ -11,7 +11,7 @@
         │   │   @ GlobalVariableReadNode (location: (11...15))
         │   │   └── name: :$bar
         │   └── keyword_loc: (0...5) = "alias"
-        └── @ AliasNode (location: (16...31))
+        └── @ AliasMethodNode (location: (16...31))
             ├── new_name:
             │   @ SymbolNode (location: (22...26))
             │   ├── opening_loc: (22...23) = ":"

--- a/test/yarp/snapshots/whitequark/alias.txt
+++ b/test/yarp/snapshots/whitequark/alias.txt
@@ -3,7 +3,7 @@
 └── statements:
     @ StatementsNode (location: (0...14))
     └── body: (length: 1)
-        └── @ AliasNode (location: (0...14))
+        └── @ AliasMethodNode (location: (0...14))
             ├── new_name:
             │   @ SymbolNode (location: (6...10))
             │   ├── opening_loc: (6...7) = ":"

--- a/test/yarp/snapshots/whitequark/alias_gvar.txt
+++ b/test/yarp/snapshots/whitequark/alias_gvar.txt
@@ -3,14 +3,14 @@
 └── statements:
     @ StatementsNode (location: (0...24))
     └── body: (length: 2)
-        ├── @ AliasNode (location: (0...11))
+        ├── @ AliasGlobalVariableNode (location: (0...11))
         │   ├── new_name:
         │   │   @ GlobalVariableReadNode (location: (6...8))
         │   │   └── name: :$a
         │   ├── old_name:
         │   │   @ BackReferenceReadNode (location: (9...11))
         │   └── keyword_loc: (0...5) = "alias"
-        └── @ AliasNode (location: (13...24))
+        └── @ AliasGlobalVariableNode (location: (13...24))
             ├── new_name:
             │   @ GlobalVariableReadNode (location: (19...21))
             │   └── name: :$a


### PR DESCRIPTION
Into AliasGlobalVariableNode and AliasMethodNode. These have different enough semantics that we feel comfortable splitting them up.

Fixes https://github.com/ruby/yarp/issues/1432