### PR TITLE
Introduce MatchLastLineNode and InterpolatedMatchLastLineNode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1488,6 +1488,25 @@ nodes:
 
           1
           ^
+  - name: InterpolatedMatchLastLineNode
+    fields:
+      - name: opening_loc
+        type: location
+      - name: parts
+        type: node[]
+      - name: closing_loc
+        type: location
+      - name: flags
+        type: flags
+        kind: RegularExpressionFlags
+    newline: parts
+    comment: |
+      Represents a regular expression literal that contains interpolation that
+      is being used in the predicate of a conditional to implicitly match
+      against the last line read by an IO object.
+
+          if /foo #{bar} baz/ then end
+             ^^^^^^^^^^^^^^^^
   - name: InterpolatedRegularExpressionNode
     fields:
       - name: opening_loc
@@ -1702,6 +1721,26 @@ nodes:
 
           foo = 1
           ^^^^^^^
+  - name: MatchLastLineNode
+    fields:
+      - name: opening_loc
+        type: location
+      - name: content_loc
+        type: location
+      - name: closing_loc
+        type: location
+      - name: unescaped
+        type: string
+      - name: flags
+        type: flags
+        kind: RegularExpressionFlags
+    comment: |
+      Represents a regular expression literal used in the predicate of a
+      conditional to implicitly match against the last line read by an IO
+      object.
+
+          if /foo/i then end
+             ^^^^^^
   - name: MatchPredicateNode
     fields:
       - name: value

--- a/test/yarp/location_test.rb
+++ b/test/yarp/location_test.rb
@@ -450,6 +450,10 @@ module YARP
       assert_location(IntegerNode, "0o1_000")
     end
 
+    def test_InterpolatedMatchLastLineNode
+      assert_location(InterpolatedMatchLastLineNode, "if /foo \#{bar}/ then end", 3...15, &:predicate)
+    end
+
     def test_InterpolatedRegularExpressionNode
       assert_location(InterpolatedRegularExpressionNode, "/\#{foo}/")
     end
@@ -523,6 +527,10 @@ module YARP
 
     def test_LocalVariableWriteNode
       assert_location(LocalVariableWriteNode, "foo = bar")
+    end
+
+    def test_MatchLastLineNode
+      assert_location(MatchLastLineNode, "if /foo/ then end", 3...8, &:predicate)
     end
 
     def test_MatchPredicateNode

--- a/test/yarp/snapshots/unparser/corpus/literal/if.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/if.txt
@@ -6,7 +6,7 @@
         ├── @ IfNode (location: (0...18))
         │   ├── if_keyword_loc: (0...2) = "if"
         │   ├── predicate:
-        │   │   @ RegularExpressionNode (location: (3...8))
+        │   │   @ MatchLastLineNode (location: (3...8))
         │   │   ├── opening_loc: (3...4) = "/"
         │   │   ├── content_loc: (4...7) = "foo"
         │   │   ├── closing_loc: (7...8) = "/"

--- a/test/yarp/snapshots/whitequark/cond_match_current_line.txt
+++ b/test/yarp/snapshots/whitequark/cond_match_current_line.txt
@@ -5,7 +5,7 @@
     └── body: (length: 2)
         ├── @ CallNode (location: (0...6))
         │   ├── receiver:
-        │   │   @ RegularExpressionNode (location: (1...6))
+        │   │   @ MatchLastLineNode (location: (1...6))
         │   │   ├── opening_loc: (1...2) = "/"
         │   │   ├── content_loc: (2...5) = "wat"
         │   │   ├── closing_loc: (5...6) = "/"
@@ -22,7 +22,7 @@
         └── @ IfNode (location: (8...21))
             ├── if_keyword_loc: (8...10) = "if"
             ├── predicate:
-            │   @ RegularExpressionNode (location: (11...16))
+            │   @ MatchLastLineNode (location: (11...16))
             │   ├── opening_loc: (11...12) = "/"
             │   ├── content_loc: (12...15) = "wat"
             │   ├── closing_loc: (15...16) = "/"


### PR DESCRIPTION
These are replacements for regular expressions when they are used alone as the predicate of a conditional. That's because they are significantly different from a regular expression because they are not evaluated for truthyness, but instead evaluated as a match against the last line read by an IO object.