### PR TITLE
[rust] fix accessing `ConstantId` slices

### DIFF
--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -519,12 +519,21 @@ impl<'pr> ConstantId<'pr> {{
     }}
 
     /// Returns a byte slice for the constant ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the constant ID is not found in the constant pool.
     #[must_use]
     pub fn as_slice(&self) -> &'pr [u8] {{
         unsafe {{
             let pool = &(*self.parser.as_ptr()).constant_pool;
-            let constant = &(*pool.constants.offset(isize::try_from(self.id).expect("id should be in range")));
-            std::slice::from_raw_parts(constant.start, constant.length)
+            for i in 0..pool.capacity {{
+                let constant = &(*pool.constants.add(i));
+                if constant.id() == self.id {{
+                    return std::slice::from_raw_parts(constant.start, constant.length);
+                }}
+            }}
+            panic!("Unable to locate constant id");
         }}
     }}
 }}


### PR DESCRIPTION
When I wrote `ConstantId::as_slice`, I misunderstood how `yp_constant_id_t` works in concert with `yp_constant_pool_t`: it's not a straight index into the pool of constants.

This implementation is, of course, suboptimal in the sense that we're taking what should be a cheap operation and making it linear in the number of constant ids the program contains, but it is at least correct.  I don't have a test for this, as the example that I was seeing this on doesn't fail as a standalone test in the testsuite, for reasons I don't fully understand.

It would not be entirely surprising to me if everybody using the C API gets bitten by this.  Happy to rewrite the constant pool implementation so it works more like one would expect.