### PR TITLE
Frozen string literal comments

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -369,6 +369,10 @@ flags:
         comment: "u - forces the UTF-8 encoding"
       - name: ONCE
         comment: "o - only interpolates values into the regular expression once"
+  - name: StringFlags
+    values:
+      - name: FROZEN
+        comment: "frozen by virtue of a frozen_string_literal comment"
 nodes:
   - name: AliasGlobalVariableNode
     fields:
@@ -2249,6 +2253,9 @@ nodes:
           ^^^^^^^^^^^
   - name: StringNode
     fields:
+      - name: flags
+        type: flags
+        kind: StringFlags
       - name: opening_loc
         type: location?
       - name: content_loc

--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -378,30 +378,30 @@ struct yp_parser {
     yp_node_flags_t integer_base;
 
     // Whether or not we're at the beginning of a command
-    unsigned int command_start : 1;
+    bool command_start;
 
     // Whether or not we're currently recovering from a syntax error
-    unsigned int recovering : 1;
+    bool recovering;
 
     // Whether or not the encoding has been changed by a magic comment. We use
     // this to provide a fast path for the lexer instead of going through the
     // function pointer.
-    unsigned int encoding_changed : 1;
+    bool encoding_changed;
 
     // This flag indicates that we are currently parsing a pattern matching
     // expression and impacts that calculation of newlines.
-    unsigned int pattern_matching_newlines : 1;
+    bool pattern_matching_newlines;
 
     // This flag indicates that we are currently parsing a keyword argument.
-    unsigned int in_keyword_arg : 1;
+    bool in_keyword_arg;
 
     // Whether or not the parser has seen a token that has semantic meaning
     // (i.e., a token that is not a comment or whitespace).
-    unsigned int semantic_token_seen : 1;
+    bool semantic_token_seen;
 
     // Whether or not we have found a frozen_string_literal magic comment with
     // a true value.
-    unsigned int frozen_string_literal : 1;
+    bool frozen_string_literal;
 };
 
 #endif // YARP_PARSER_H

--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -394,6 +394,14 @@ struct yp_parser {
 
     // This flag indicates that we are currently parsing a keyword argument.
     unsigned int in_keyword_arg : 1;
+
+    // Whether or not the parser has seen a token that has semantic meaning
+    // (i.e., a token that is not a comment or whitespace).
+    unsigned int semantic_token_seen : 1;
+
+    // Whether or not we have found a frozen_string_literal magic comment with
+    // a true value.
+    unsigned int frozen_string_literal : 1;
 };
 
 #endif // YARP_PARSER_H

--- a/include/yarp/parser.h
+++ b/include/yarp/parser.h
@@ -291,7 +291,6 @@ typedef struct yp_scope {
 // it's considering.
 struct yp_parser {
     yp_lex_state_t lex_state; // the current state of the lexer
-    bool command_start;       // whether or not we're at the beginning of a command
     int enclosure_nesting;    // tracks the current nesting of (), [], and {}
 
     // Used to temporarily track the nesting of enclosures to determine if a {
@@ -338,16 +337,10 @@ struct yp_parser {
     yp_scope_t *current_scope;          // the current local scope
 
     yp_context_node_t *current_context; // the current parsing context
-    bool recovering; // whether or not we're currently recovering from a syntax error
 
     // The encoding functions for the current file is attached to the parser as
     // it's parsing so that it can change with a magic comment.
     yp_encoding_t encoding;
-
-    // Whether or not the encoding has been changed by a magic comment. We use
-    // this to provide a fast path for the lexer instead of going through the
-    // function pointer.
-    bool encoding_changed;
 
     // When the encoding that is being used to parse the source is changed by
     // YARP, we provide the ability here to call out to a user-defined function.
@@ -367,13 +360,6 @@ struct yp_parser {
     // be called whenever a new token is lexed by the parser.
     yp_lex_callback_t *lex_callback;
 
-    // This flag indicates that we are currently parsing a pattern matching
-    // expression and impacts that calculation of newlines.
-    bool pattern_matching_newlines;
-
-    // This flag indicates that we are currently parsing a keyword argument.
-    bool in_keyword_arg;
-
     // This is the path of the file being parsed
     // We use the filepath when constructing SourceFileNodes
     yp_string_t filepath_string;
@@ -390,6 +376,24 @@ struct yp_parser {
     // communicate this information. So we store it here and pass it through
     // when we find tokens that we need it for.
     yp_node_flags_t integer_base;
+
+    // Whether or not we're at the beginning of a command
+    unsigned int command_start : 1;
+
+    // Whether or not we're currently recovering from a syntax error
+    unsigned int recovering : 1;
+
+    // Whether or not the encoding has been changed by a magic comment. We use
+    // this to provide a fast path for the lexer instead of going through the
+    // function pointer.
+    unsigned int encoding_changed : 1;
+
+    // This flag indicates that we are currently parsing a pattern matching
+    // expression and impacts that calculation of newlines.
+    unsigned int pattern_matching_newlines : 1;
+
+    // This flag indicates that we are currently parsing a keyword argument.
+    unsigned int in_keyword_arg : 1;
 };
 
 #endif // YARP_PARSER_H

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2207,7 +2207,13 @@ static yp_false_node_t *
 yp_false_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD_FALSE);
     yp_false_node_t *node = YP_ALLOC_NODE(parser, yp_false_node_t);
-    *node = (yp_false_node_t) {{ .type = YP_FALSE_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+
+    *node = (yp_false_node_t) {{
+        .type = YP_FALSE_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -2257,7 +2263,13 @@ static yp_float_node_t *
 yp_float_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_FLOAT);
     yp_float_node_t *node = YP_ALLOC_NODE(parser, yp_float_node_t);
-    *node = (yp_float_node_t) {{ .type = YP_FLOAT_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+
+    *node = (yp_float_node_t) {{
+        .type = YP_FLOAT_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -2270,6 +2282,7 @@ yp_float_node_imaginary_create(yp_parser_t *parser, const yp_token_t *token) {
     *node = (yp_imaginary_node_t) {
         {
             .type = YP_IMAGINARY_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_float_node_create(parser, &((yp_token_t) {
@@ -2291,6 +2304,7 @@ yp_float_node_rational_create(yp_parser_t *parser, const yp_token_t *token) {
     *node = (yp_rational_node_t) {
         {
             .type = YP_RATIONAL_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_float_node_create(parser, &((yp_token_t) {
@@ -2312,6 +2326,7 @@ yp_float_node_rational_imaginary_create(yp_parser_t *parser, const yp_token_t *t
     *node = (yp_imaginary_node_t) {
         {
             .type = YP_IMAGINARY_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_float_node_rational_create(parser, &((yp_token_t) {
@@ -2725,7 +2740,7 @@ yp_integer_node_create(yp_parser_t *parser, yp_node_flags_t base, const yp_token
 
     *node = (yp_integer_node_t) {{
         .type = YP_INTEGER_NODE,
-        .flags = base,
+        .flags = base | YP_NODE_FLAG_STATIC_LITERAL,
         .location = YP_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -2741,6 +2756,7 @@ yp_integer_node_imaginary_create(yp_parser_t *parser, yp_node_flags_t base, cons
     *node = (yp_imaginary_node_t) {
         {
             .type = YP_IMAGINARY_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_integer_node_create(parser, base, &((yp_token_t) {
@@ -2762,6 +2778,7 @@ yp_integer_node_rational_create(yp_parser_t *parser, yp_node_flags_t base, const
     *node = (yp_rational_node_t) {
         {
             .type = YP_RATIONAL_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_integer_node_create(parser, base, &((yp_token_t) {
@@ -2783,6 +2800,7 @@ yp_integer_node_rational_imaginary_create(yp_parser_t *parser, yp_node_flags_t b
     *node = (yp_imaginary_node_t) {
         {
             .type = YP_IMAGINARY_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (yp_node_t *) yp_integer_node_rational_create(parser, base, &((yp_token_t) {
@@ -3458,7 +3476,12 @@ yp_nil_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD_NIL);
     yp_nil_node_t *node = YP_ALLOC_NODE(parser, yp_nil_node_t);
 
-    *node = (yp_nil_node_t) {{ .type = YP_NIL_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+    *node = (yp_nil_node_t) {{
+        .type = YP_NIL_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4005,7 +4028,12 @@ yp_self_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD_SELF);
     yp_self_node_t *node = YP_ALLOC_NODE(parser, yp_self_node_t);
 
-    *node = (yp_self_node_t) {{ .type = YP_SELF_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+    *node = (yp_self_node_t) {{
+        .type = YP_SELF_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4039,7 +4067,12 @@ yp_source_encoding_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD___ENCODING__);
     yp_source_encoding_node_t *node = YP_ALLOC_NODE(parser, yp_source_encoding_node_t);
 
-    *node = (yp_source_encoding_node_t) {{ .type = YP_SOURCE_ENCODING_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+    *node = (yp_source_encoding_node_t) {{
+        .type = YP_SOURCE_ENCODING_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4052,6 +4085,7 @@ yp_source_file_node_create(yp_parser_t *parser, const yp_token_t *file_keyword) 
     *node = (yp_source_file_node_t) {
         {
             .type = YP_SOURCE_FILE_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = YP_LOCATION_TOKEN_VALUE(file_keyword),
         },
         .filepath = parser->filepath_string,
@@ -4066,7 +4100,12 @@ yp_source_line_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD___LINE__);
     yp_source_line_node_t *node = YP_ALLOC_NODE(parser, yp_source_line_node_t);
 
-    *node = (yp_source_line_node_t) {{ .type = YP_SOURCE_LINE_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+    *node = (yp_source_line_node_t) {{
+        .type = YP_SOURCE_LINE_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4220,6 +4259,7 @@ yp_symbol_node_create(yp_parser_t *parser, const yp_token_t *opening, const yp_t
     *node = (yp_symbol_node_t) {
         {
             .type = YP_SYMBOL_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = {
                 .start = (opening->type == YP_TOKEN_NOT_PROVIDED ? value->start : opening->start),
                 .end = (closing->type == YP_TOKEN_NOT_PROVIDED ? value->end : closing->end)
@@ -4297,6 +4337,7 @@ yp_string_node_to_symbol_node(yp_parser_t *parser, yp_string_node_t *node, const
     *new_node = (yp_symbol_node_t) {
         {
             .type = YP_SYMBOL_NODE,
+            .flags = YP_NODE_FLAG_STATIC_LITERAL,
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -4346,7 +4387,12 @@ yp_true_node_create(yp_parser_t *parser, const yp_token_t *token) {
     assert(token->type == YP_TOKEN_KEYWORD_TRUE);
     yp_true_node_t *node = YP_ALLOC_NODE(parser, yp_true_node_t);
 
-    *node = (yp_true_node_t) {{ .type = YP_TRUE_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+    *node = (yp_true_node_t) {{
+        .type = YP_TRUE_NODE,
+        .flags = YP_NODE_FLAG_STATIC_LITERAL,
+        .location = YP_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4951,8 +4951,7 @@ parser_lex_encoding_comment_start(yp_parser_t *parser, const uint8_t *cursor, pt
 static void
 parser_lex_encoding_comment(yp_parser_t *parser) {
     const uint8_t *start = parser->current.start + 1;
-    const uint8_t *end = next_newline(start, parser->end - start);
-    if (end == NULL) end = parser->end;
+    const uint8_t *end = parser->current.end;
 
     // These are the patterns we're going to match to find the encoding comment.
     // This is definitely not complete or even really correct.
@@ -5050,6 +5049,38 @@ parser_lex_encoding_comment(yp_parser_t *parser) {
     // case we'll keep using the default encoding but add an error to the
     // parser to indicate an unsuccessful parse.
     yp_diagnostic_list_append(&parser->error_list, encoding_start, encoding_end, YP_ERR_INVALID_ENCODING_MAGIC_COMMENT);
+}
+
+// Check if this is a magic comment that includes the frozen_string_literal
+// pragma. If it does, set that field on the parser.
+static void
+parser_lex_frozen_string_literal_comment(yp_parser_t *parser) {
+    const uint8_t *cursor = parser->current.start + 1;
+    const uint8_t *end = parser->current.end;
+
+    size_t key_length = strlen("frozen_string_literal");
+    if (key_length > (size_t) (end - cursor)) return;
+
+    const uint8_t *cursor_limit = cursor + (end - cursor) - key_length + 1;
+
+    while ((cursor = yp_memchr(cursor, 'f', (size_t) (cursor_limit - cursor), parser->encoding_changed, &parser->encoding)) != NULL) {
+        if (memcmp(cursor, "frozen_string_literal", key_length) == 0) {
+            cursor += yp_strspn_inline_whitespace(cursor + key_length, end - (cursor + key_length));
+
+            if (*cursor == ':' || *cursor == '=') {
+                cursor++;
+                cursor += yp_strspn_inline_whitespace(cursor, end - cursor);
+
+                if (cursor + 4 <= end && yp_strncasecmp(cursor, (const uint8_t *) "true", 4) == 0) {
+                    parser->frozen_string_literal = true;
+                }
+
+                return;
+            }
+        }
+
+        cursor++;
+    }
 }
 
 /******************************************************************************/
@@ -5982,6 +6013,11 @@ parser_lex(yp_parser_t *parser) {
     // already seen a comment.
     bool lexed_comment = false;
 
+    // Here we cache the current value of the semantic token seen flag. This is
+    // used to reset it in case we find a token that shouldn't flip this flag.
+    unsigned int semantic_token_seen = parser->semantic_token_seen;
+    parser->semantic_token_seen = true;
+
     switch (parser->lex_modes.current->mode) {
         case YP_LEX_DEFAULT:
         case YP_LEX_EMBEXPR:
@@ -6083,12 +6119,18 @@ parser_lex(yp_parser_t *parser) {
                         parser_lex_encoding_comment(parser);
                     }
 
+                    if (!semantic_token_seen) {
+                        parser_lex_frozen_string_literal_comment(parser);
+                    }
+
                     lexed_comment = true;
                 }
                 /* fallthrough */
                 case '\r':
                 case '\n': {
+                    parser->semantic_token_seen = semantic_token_seen;
                     size_t eol_length = match_eol_at(parser, parser->current.end - 1);
+
                     if (eol_length) {
                         // The only way you can have carriage returns in this
                         // particular loop is if you have a carriage return
@@ -13934,7 +13976,6 @@ yp_parser_init(yp_parser_t *parser, const uint8_t *source, size_t size, const ch
 
     *parser = (yp_parser_t) {
         .lex_state = YP_LEX_STATE_BEG,
-        .command_start = true,
         .enclosure_nesting = 0,
         .lambda_enclosure_nesting = -1,
         .brace_nesting = 0,
@@ -13956,19 +13997,22 @@ yp_parser_init(yp_parser_t *parser, const uint8_t *source, size_t size, const ch
         .error_list = YP_LIST_EMPTY,
         .current_scope = NULL,
         .current_context = NULL,
-        .recovering = false,
         .encoding = yp_encoding_utf_8,
-        .encoding_changed = false,
         .encoding_changed_callback = NULL,
         .encoding_decode_callback = NULL,
         .encoding_comment_start = source,
         .lex_callback = NULL,
-        .pattern_matching_newlines = false,
-        .in_keyword_arg = false,
         .filepath_string = filepath_string,
         .constant_pool = YP_CONSTANT_POOL_EMPTY,
         .newline_list = YP_NEWLINE_LIST_EMPTY,
-        .integer_base = 0
+        .integer_base = 0,
+        .command_start = true,
+        .recovering = false,
+        .encoding_changed = false,
+        .pattern_matching_newlines = false,
+        .in_keyword_arg = false,
+        .semantic_token_seen = false,
+        .frozen_string_literal = false
     };
 
     yp_accepts_block_stack_push(parser, true);

--- a/templates/include/yarp/ast.h.erb
+++ b/templates/include/yarp/ast.h.erb
@@ -59,6 +59,7 @@ typedef uint16_t yp_node_flags_t;
 // We store the flags enum in every node in the tree. Some flags are common to
 // all nodes (the ones listed below). Others are specific to certain node types.
 static const yp_node_flags_t YP_NODE_FLAG_NEWLINE = 0x1;
+static const yp_node_flags_t YP_NODE_FLAG_STATIC_LITERAL = 0x2;
 
 // For easy access, we define some macros to check node type
 #define YP_NODE_TYPE(node) ((enum yp_node_type)node->type)

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -5,7 +5,7 @@ require "fileutils"
 require "yaml"
 
 module YARP
-  COMMON_FLAGS = 1
+  COMMON_FLAGS = 2
 
   # This represents a field on a node. It contains all of the necessary
   # information to template out the code for that field.

--- a/test/yarp/errors_test.rb
+++ b/test/yarp/errors_test.rb
@@ -601,7 +601,7 @@ module YARP
     end
 
     def test_do_not_allow_multiple_codepoints_in_a_single_character_literal
-      expected = StringNode(Location(), Location(), nil, "\u0001\u0002")
+      expected = StringNode(0, Location(), Location(), nil, "\u0001\u0002")
 
       assert_errors expected, '?\u{0001 0002}', [
         ["Invalid Unicode escape sequence; multiple codepoints are not allowed in a character literal", 9..12]
@@ -615,7 +615,7 @@ module YARP
     end
 
     def test_do_not_allow_more_than_6_hexadecimal_digits_in_u_Unicode_character_notation
-      expected = StringNode(Location(), Location(), Location(), "\u0001")
+      expected = StringNode(0, Location(), Location(), Location(), "\u0001")
 
       assert_errors expected, '"\u{0000001}"', [
         ["Invalid Unicode escape sequence; maximum length is 6 digits", 4..11],
@@ -623,7 +623,7 @@ module YARP
     end
 
     def test_do_not_allow_characters_other_than_0_9_a_f_and_A_F_in_u_Unicode_character_notation
-      expected = StringNode(Location(), Location(), Location(), "\u0000z}")
+      expected = StringNode(0, Location(), Location(), Location(), "\u0000z}")
 
       assert_errors expected, '"\u{000z}"', [
         ["Invalid Unicode escape sequence", 7..7],

--- a/test/yarp/snapshots/alias.txt
+++ b/test/yarp/snapshots/alias.txt
@@ -51,6 +51,7 @@
         │   │   ├── opening_loc: (67...69) = ":\""
         │   │   ├── parts: (length: 2)
         │   │   │   ├── @ StringNode (location: (69...72))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── content_loc: (69...72) = "abc"
         │   │   │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/arrays.txt
+++ b/test/yarp/snapshots/arrays.txt
@@ -745,16 +745,19 @@
         ├── @ ArrayNode (location: (350...367))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (353...356))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (353...356) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ StringNode (location: (357...360))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (357...360) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ StringNode (location: (361...366))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (361...366) = "three"
         │   │       ├── closing_loc: ∅
@@ -788,16 +791,19 @@
         ├── @ ArrayNode (location: (408...425))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (411...414))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (411...414) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ StringNode (location: (415...418))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (415...418) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ StringNode (location: (419...424))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (419...424) = "three"
         │   │       ├── closing_loc: ∅
@@ -831,16 +837,19 @@
         ├── @ ArrayNode (location: (466...483))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (469...472))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (469...472) = "one"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "one"
         │   │   ├── @ StringNode (location: (473...476))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (473...476) = "two"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "two"
         │   │   └── @ StringNode (location: (477...482))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (477...482) = "three"
         │   │       ├── closing_loc: ∅
@@ -855,6 +864,7 @@
         └── @ ArrayNode (location: (504...511))
             ├── elements: (length: 1)
             │   └── @ StringNode (location: (507...510))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (507...510) = "\\C:"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/begin_rescue.txt
+++ b/test/yarp/snapshots/begin_rescue.txt
@@ -408,6 +408,7 @@
         │   │   └── end_keyword_loc: (319...322) = "end"
         │   └── end_keyword_loc: (319...322) = "end"
         ├── @ StringNode (location: (324...330))
+        │   ├── flags: ∅
         │   ├── opening_loc: (324...326) = "%!"
         │   ├── content_loc: (326...329) = "abc"
         │   ├── closing_loc: (329...330) = "!"

--- a/test/yarp/snapshots/dash_heredocs.txt
+++ b/test/yarp/snapshots/dash_heredocs.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...278))
     └── body: (length: 13)
         ├── @ StringNode (location: (0...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...6) = "<<-EOF"
         │   ├── content_loc: (7...11) = "  a\n"
         │   ├── closing_loc: (11...15) = "EOF\n"
@@ -11,6 +12,7 @@
         ├── @ CallNode (location: (16...36))
         │   ├── receiver:
         │   │   @ StringNode (location: (16...24))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (16...24) = "<<-FIRST"
         │   │   ├── content_loc: (37...41) = "  a\n"
         │   │   ├── closing_loc: (41...47) = "FIRST\n"
@@ -22,6 +24,7 @@
         │   │   @ ArgumentsNode (location: (27...36))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (27...36))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (27...36) = "<<-SECOND"
         │   │           ├── content_loc: (47...51) = "  b\n"
         │   │           ├── closing_loc: (51...58) = "SECOND\n"
@@ -34,6 +37,7 @@
         │   ├── opening_loc: (59...67) = "<<-`EOF`"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (68...72))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (68...72) = "  a\n"
         │   │   │   ├── closing_loc: ∅
@@ -55,17 +59,20 @@
         │   │   │   │           └── name: "b"
         │   │   │   └── closing_loc: (75...76) = "}"
         │   │   └── @ StringNode (location: (76...77))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (76...77) = "\n"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "\n"
         │   └── closing_loc: (77...81) = "EOF\n"
         ├── @ StringNode (location: (82...88))
+        │   ├── flags: ∅
         │   ├── opening_loc: (82...88) = "<<-EOF"
         │   ├── content_loc: (98...102) = "  a\n"
         │   ├── closing_loc: (102...106) = "EOF\n"
         │   └── unescaped: "  a\n"
         ├── @ StringNode (location: (107...113))
+        │   ├── flags: ∅
         │   ├── opening_loc: (107...113) = "<<-EOF"
         │   ├── content_loc: (114...122) = "  a\n  b\n"
         │   ├── closing_loc: (122...128) = "  EOF\n"
@@ -74,6 +81,7 @@
         │   ├── opening_loc: (129...137) = "<<-\"EOF\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (138...142))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (138...142) = "  a\n"
         │   │   │   ├── closing_loc: ∅
@@ -95,6 +103,7 @@
         │   │   │   │           └── name: "b"
         │   │   │   └── closing_loc: (145...146) = "}"
         │   │   └── @ StringNode (location: (146...147))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (146...147) = "\n"
         │   │       ├── closing_loc: ∅
@@ -104,6 +113,7 @@
         │   ├── opening_loc: (152...158) = "<<-EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (159...163))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (159...163) = "  a\n"
         │   │   │   ├── closing_loc: ∅
@@ -125,27 +135,32 @@
         │   │   │   │           └── name: "b"
         │   │   │   └── closing_loc: (166...167) = "}"
         │   │   └── @ StringNode (location: (167...168))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (167...168) = "\n"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "\n"
         │   └── closing_loc: (168...172) = "EOF\n"
         ├── @ StringNode (location: (173...179))
+        │   ├── flags: ∅
         │   ├── opening_loc: (173...175) = "%#"
         │   ├── content_loc: (175...178) = "abc"
         │   ├── closing_loc: (178...179) = "#"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (181...187))
+        │   ├── flags: ∅
         │   ├── opening_loc: (181...187) = "<<-EOF"
         │   ├── content_loc: (188...196) = "  a\n  b\n"
         │   ├── closing_loc: (196...200) = "EOF\n"
         │   └── unescaped: "  a\n  b\n"
         ├── @ StringNode (location: (201...206))
+        │   ├── flags: ∅
         │   ├── opening_loc: (201...206) = "<<-''"
         │   ├── content_loc: (207...207) = ""
         │   ├── closing_loc: (207...208) = "\n"
         │   └── unescaped: ""
         ├── @ StringNode (location: (209...217))
+        │   ├── flags: ∅
         │   ├── opening_loc: (209...217) = "<<-'EOF'"
         │   ├── content_loc: (218...227) = "  a \#{1}\n"
         │   ├── closing_loc: (227...231) = "EOF\n"
@@ -153,6 +168,7 @@
         ├── @ CallNode (location: (232...243))
         │   ├── receiver:
         │   │   @ StringNode (location: (232...236))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (232...236) = "<<-A"
         │   │   ├── content_loc: (244...248) = "  a\n"
         │   │   ├── closing_loc: (248...250) = "A\n"
@@ -167,6 +183,7 @@
         │   │           ├── opening_loc: (239...243) = "<<-B"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (250...256))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (250...256) = "  b\n  "
         │   │           │   │   ├── closing_loc: ∅
@@ -180,6 +197,7 @@
         │   │           │   │   │           └── flags: decimal
         │   │           │   │   └── closing_loc: (262...263) = "}"
         │   │           │   └── @ StringNode (location: (263...264))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (263...264) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -192,6 +210,7 @@
         └── @ CallNode (location: (267...278))
             ├── receiver:
             │   @ StringNode (location: (267...271))
+            │   ├── flags: ∅
             │   ├── opening_loc: (267...271) = "<<-A"
             │   ├── content_loc: (279...283) = "  a\n"
             │   ├── closing_loc: (283...285) = "A\n"
@@ -206,6 +225,7 @@
             │           ├── opening_loc: (274...278) = "<<-B"
             │           ├── parts: (length: 3)
             │           │   ├── @ StringNode (location: (285...291))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: ∅
             │           │   │   ├── content_loc: (285...291) = "  b\n  "
             │           │   │   ├── closing_loc: ∅
@@ -219,6 +239,7 @@
             │           │   │   │           └── flags: decimal
             │           │   │   └── closing_loc: (297...298) = "}"
             │           │   └── @ StringNode (location: (298...299))
+            │           │       ├── flags: ∅
             │           │       ├── opening_loc: ∅
             │           │       ├── content_loc: (298...299) = "\n"
             │           │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/dos_endings.txt
+++ b/test/yarp/snapshots/dos_endings.txt
@@ -14,12 +14,14 @@
         │   │       └── @ StringConcatNode (location: (5...24))
         │   │           ├── left:
         │   │           │   @ StringNode (location: (5...9))
+        │   │           │   ├── flags: ∅
         │   │           │   ├── opening_loc: (5...6) = "\""
         │   │           │   ├── content_loc: (6...8) = "hi"
         │   │           │   ├── closing_loc: (8...9) = "\""
         │   │           │   └── unescaped: "hi"
         │   │           └── right:
         │   │               @ StringNode (location: (17...24))
+        │   │               ├── flags: ∅
         │   │               ├── opening_loc: (17...18) = "\""
         │   │               ├── content_loc: (18...23) = "there"
         │   │               ├── closing_loc: (23...24) = "\""
@@ -38,6 +40,7 @@
         │   ├── opening_loc: (28...31) = "%I{"
         │   └── closing_loc: (36...37) = "}"
         ├── @ StringNode (location: (41...45))
+        │   ├── flags: ∅
         │   ├── opening_loc: (41...45) = "<<-E"
         │   ├── content_loc: (47...70) = "    1 \\\r\n    2\r\n    3\r\n"
         │   ├── closing_loc: (70...73) = "E\r\n"
@@ -48,6 +51,7 @@
         │   ├── name_loc: (75...76) = "x"
         │   ├── value:
         │   │   @ StringNode (location: (79...84))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (79...82) = "%\r\n"
         │   │   ├── content_loc: (82...82) = ""
         │   │   ├── closing_loc: (82...84) = "\r\n"
@@ -69,6 +73,7 @@
             │   │       └── @ CallNode (location: (96...107))
             │   │           ├── receiver:
             │   │           │   @ StringNode (location: (96...102))
+            │   │           │   ├── flags: ∅
             │   │           │   ├── opening_loc: (96...102) = "<<~EOF"
             │   │           │   ├── content_loc: (110...121) = "\r\n    baz\r\n"
             │   │           │   ├── closing_loc: (121...128) = "  EOF\r\n"

--- a/test/yarp/snapshots/endless_methods.txt
+++ b/test/yarp/snapshots/endless_methods.txt
@@ -37,6 +37,7 @@
         │   │           │   @ ArgumentsNode (location: (25...27))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (25...27))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (25...26) = "\""
         │   │           │           ├── content_loc: (26...26) = ""
         │   │           │           ├── closing_loc: (26...27) = "\""

--- a/test/yarp/snapshots/heredoc_with_escaped_newline_at_start.txt
+++ b/test/yarp/snapshots/heredoc_with_escaped_newline_at_start.txt
@@ -6,6 +6,7 @@
         ├── @ CallNode (location: (0...25))
         │   ├── receiver:
         │   │   @ StringNode (location: (0...9))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (0...9) = "<<-TARGET"
         │   │   ├── content_loc: (27...27) = ""
         │   │   ├── closing_loc: (27...34) = "TARGET\n"
@@ -23,6 +24,7 @@
         │   │       │   ├── unescaped: "^ {"
         │   │       │   └── flags: ∅
         │   │       └── @ StringNode (location: (23...25))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (23...24) = "'"
         │   │           ├── content_loc: (24...24) = ""
         │   │           ├── closing_loc: (24...25) = "'"
@@ -34,6 +36,7 @@
         └── @ CallNode (location: (37...62))
             ├── receiver:
             │   @ StringNode (location: (37...46))
+            │   ├── flags: ∅
             │   ├── opening_loc: (37...46) = "<<-TARGET"
             │   ├── content_loc: (65...65) = ""
             │   ├── closing_loc: (65...73) = "TARGET\r\n"
@@ -51,6 +54,7 @@
             │       │   ├── unescaped: "^ {"
             │       │   └── flags: ∅
             │       └── @ StringNode (location: (60...62))
+            │           ├── flags: ∅
             │           ├── opening_loc: (60...61) = "'"
             │           ├── content_loc: (61...61) = ""
             │           ├── closing_loc: (61...62) = "'"

--- a/test/yarp/snapshots/heredoc_with_trailing_newline.txt
+++ b/test/yarp/snapshots/heredoc_with_trailing_newline.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...6))
     └── body: (length: 1)
         └── @ StringNode (location: (0...6))
+            ├── flags: ∅
             ├── opening_loc: (0...6) = "<<-END"
             ├── content_loc: (7...7) = ""
             ├── closing_loc: (7...10) = "END"

--- a/test/yarp/snapshots/heredocs_nested.txt
+++ b/test/yarp/snapshots/heredocs_nested.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...7) = "<<~RUBY"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (8...12))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (8...12) = "pre\n"
             │   │   ├── closing_loc: ∅
@@ -17,12 +18,14 @@
             │   │   │   @ StatementsNode (location: (15...21))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (15...21))
+            │   │   │           ├── flags: ∅
             │   │   │           ├── opening_loc: (15...21) = "<<RUBY"
             │   │   │           ├── content_loc: (22...30) = "  hello\n"
             │   │   │           ├── closing_loc: (30...35) = "RUBY\n"
             │   │   │           └── unescaped: "  hello\n"
             │   │   └── closing_loc: (35...36) = "}"
             │   └── @ StringNode (location: (36...42))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (36...42) = "\npost\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/heredocs_with_ignored_newlines.txt
+++ b/test/yarp/snapshots/heredocs_with_ignored_newlines.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...23))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...7))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...7) = "<<-HERE"
         │   ├── content_loc: (9...9) = ""
         │   ├── closing_loc: (9...14) = "HERE\n"
         │   └── unescaped: ""
         └── @ StringNode (location: (15...23))
+            ├── flags: ∅
             ├── opening_loc: (15...23) = "<<~THERE"
             ├── content_loc: (25...100) = "  way over\n  <<HERE\n    not here\n  HERE\n\n  <<~BUT\\\n    but\n  BUT\n    there\n"
             ├── closing_loc: (100...106) = "THERE\n"

--- a/test/yarp/snapshots/heredocs_with_ignored_newlines_and_non_empty.txt
+++ b/test/yarp/snapshots/heredocs_with_ignored_newlines_and_non_empty.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...6))
     └── body: (length: 1)
         └── @ StringNode (location: (0...6))
+            ├── flags: ∅
             ├── opening_loc: (0...6) = "<<-EOE"
             ├── content_loc: (7...23) = " some\n heredocs\n"
             ├── closing_loc: (23...26) = "EOE"

--- a/test/yarp/snapshots/keyword_method_names.txt
+++ b/test/yarp/snapshots/keyword_method_names.txt
@@ -114,11 +114,13 @@
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (110...113) = "end"
         ├── @ StringNode (location: (115...121))
+        │   ├── flags: ∅
         │   ├── opening_loc: (115...117) = "%{"
         │   ├── content_loc: (117...120) = "abc"
         │   ├── closing_loc: (120...121) = "}"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (123...129))
+        │   ├── flags: ∅
         │   ├── opening_loc: (123...125) = "%\""
         │   ├── content_loc: (125...128) = "abc"
         │   ├── closing_loc: (128...129) = "\""

--- a/test/yarp/snapshots/lambda.txt
+++ b/test/yarp/snapshots/lambda.txt
@@ -47,6 +47,7 @@
         │   │   │   │           ├── opening_loc: (22...23) = "\""
         │   │   │   │           ├── parts: (length: 2)
         │   │   │   │           │   ├── @ StringNode (location: (23...24))
+        │   │   │   │           │   │   ├── flags: ∅
         │   │   │   │           │   │   ├── opening_loc: ∅
         │   │   │   │           │   │   ├── content_loc: (23...24) = "b"
         │   │   │   │           │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/method_calls.txt
+++ b/test/yarp/snapshots/method_calls.txt
@@ -22,6 +22,7 @@
         │   │   @ ArgumentsNode (location: (8...14))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (8...14))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (8...10) = "%{"
         │   │           ├── content_loc: (10...13) = "baz"
         │   │           ├── closing_loc: (13...14) = "}"
@@ -1594,6 +1595,7 @@
         │   │           │       │           │   │   @ StatementsNode (location: (881...886))
         │   │           │       │           │   │   └── body: (length: 1)
         │   │           │       │           │   │       └── @ StringNode (location: (881...886))
+        │   │           │       │           │   │           ├── flags: ∅
         │   │           │       │           │   │           ├── opening_loc: (881...882) = "\""
         │   │           │       │           │   │           ├── content_loc: (882...885) = "baz"
         │   │           │       │           │   │           ├── closing_loc: (885...886) = "\""
@@ -2132,6 +2134,7 @@
         │   │       │           │           │   @ StatementsNode (location: (1220...1223))
         │   │       │           │           │   └── body: (length: 1)
         │   │       │           │           │       └── @ StringNode (location: (1220...1223))
+        │   │       │           │           │           ├── flags: ∅
         │   │       │           │           │           ├── opening_loc: (1220...1221) = "\""
         │   │       │           │           │           ├── content_loc: (1221...1222) = " "
         │   │       │           │           │           ├── closing_loc: (1222...1223) = "\""

--- a/test/yarp/snapshots/methods.txt
+++ b/test/yarp/snapshots/methods.txt
@@ -269,6 +269,7 @@
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (216...219) = "end"
         ├── @ StringNode (location: (221...227))
+        │   ├── flags: ∅
         │   ├── opening_loc: (221...223) = "%,"
         │   ├── content_loc: (223...226) = "abc"
         │   ├── closing_loc: (226...227) = ","
@@ -504,6 +505,7 @@
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (386...389) = "end"
         ├── @ StringNode (location: (391...397))
+        │   ├── flags: ∅
         │   ├── opening_loc: (391...393) = "%."
         │   ├── content_loc: (393...396) = "abc"
         │   ├── closing_loc: (396...397) = "."
@@ -1183,6 +1185,7 @@
         │   │           ├── opening_loc: (917...918) = "\""
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (918...921))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (918...921) = "foo"
         │   │           │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/modules.txt
+++ b/test/yarp/snapshots/modules.txt
@@ -26,6 +26,7 @@
         │   ├── opening_loc: (20...23) = "%Q{"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (23...27))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (23...27) = "aaa "
         │   │   │   ├── closing_loc: ∅
@@ -47,6 +48,7 @@
         │   │   │   │           └── name: "bbb"
         │   │   │   └── closing_loc: (32...33) = "}"
         │   │   └── @ StringNode (location: (33...37))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (33...37) = " ccc"
         │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/newline_terminated.txt
+++ b/test/yarp/snapshots/newline_terminated.txt
@@ -4,81 +4,97 @@
     @ StatementsNode (location: (76...212))
     └── body: (length: 17)
         ├── @ StringNode (location: (76...82))
+        │   ├── flags: ∅
         │   ├── opening_loc: (76...78) = "% "
         │   ├── content_loc: (78...81) = "abc"
         │   ├── closing_loc: (81...82) = " "
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (84...90))
+        │   ├── flags: ∅
         │   ├── opening_loc: (84...86) = "%\t"
         │   ├── content_loc: (86...89) = "abc"
         │   ├── closing_loc: (89...90) = "\t"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (92...98))
+        │   ├── flags: ∅
         │   ├── opening_loc: (92...94) = "%\v"
         │   ├── content_loc: (94...97) = "abc"
         │   ├── closing_loc: (97...98) = "\v"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (100...106))
+        │   ├── flags: ∅
         │   ├── opening_loc: (100...102) = "%\r"
         │   ├── content_loc: (102...105) = "abc"
         │   ├── closing_loc: (105...106) = "\r"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (108...114))
+        │   ├── flags: ∅
         │   ├── opening_loc: (108...110) = "%\n"
         │   ├── content_loc: (110...113) = "abc"
         │   ├── closing_loc: (113...114) = "\n"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (116...122))
+        │   ├── flags: ∅
         │   ├── opening_loc: (116...118) = "%\u0000"
         │   ├── content_loc: (118...121) = "abc"
         │   ├── closing_loc: (121...122) = "\u0000"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (124...130))
+        │   ├── flags: ∅
         │   ├── opening_loc: (124...126) = "%\n"
         │   ├── content_loc: (126...129) = "abc"
         │   ├── closing_loc: (129...130) = "\n"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (132...139))
+        │   ├── flags: ∅
         │   ├── opening_loc: (132...134) = "%\n"
         │   ├── content_loc: (134...138) = "\rabc"
         │   ├── closing_loc: (138...139) = "\n"
         │   └── unescaped: "\rabc"
         ├── @ StringNode (location: (142...149))
+        │   ├── flags: ∅
         │   ├── opening_loc: (142...144) = "%\n"
         │   ├── content_loc: (144...148) = "\rabc"
         │   ├── closing_loc: (148...149) = "\n"
         │   └── unescaped: "\rabc"
         ├── @ StringNode (location: (151...157))
+        │   ├── flags: ∅
         │   ├── opening_loc: (151...153) = "%\n"
         │   ├── content_loc: (153...156) = "abc"
         │   ├── closing_loc: (156...157) = "\n"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (159...165))
+        │   ├── flags: ∅
         │   ├── opening_loc: (159...161) = "%\r"
         │   ├── content_loc: (161...164) = "abc"
         │   ├── closing_loc: (164...165) = "\r"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (167...173))
+        │   ├── flags: ∅
         │   ├── opening_loc: (167...169) = "%\n"
         │   ├── content_loc: (169...172) = "abc"
         │   ├── closing_loc: (172...173) = "\n"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (175...181))
+        │   ├── flags: ∅
         │   ├── opening_loc: (175...177) = "%\n"
         │   ├── content_loc: (177...180) = "abc"
         │   ├── closing_loc: (180...181) = "\n"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (182...188))
+        │   ├── flags: ∅
         │   ├── opening_loc: (182...184) = "%\n"
         │   ├── content_loc: (184...187) = "foo"
         │   ├── closing_loc: (187...188) = "\n"
         │   └── unescaped: "foo"
         ├── @ StringNode (location: (189...196))
+        │   ├── flags: ∅
         │   ├── opening_loc: (189...192) = "%q\n"
         │   ├── content_loc: (192...195) = "foo"
         │   ├── closing_loc: (195...196) = "\n"
         │   └── unescaped: "foo"
         ├── @ StringNode (location: (197...204))
+        │   ├── flags: ∅
         │   ├── opening_loc: (197...200) = "%Q\n"
         │   ├── content_loc: (200...203) = "foo"
         │   ├── closing_loc: (203...204) = "\n"

--- a/test/yarp/snapshots/non_alphanumeric_methods.txt
+++ b/test/yarp/snapshots/non_alphanumeric_methods.txt
@@ -109,6 +109,7 @@
         │   ├── equal_loc: ∅
         │   └── end_keyword_loc: (91...94) = "end"
         ├── @ StringNode (location: (96...102))
+        │   ├── flags: ∅
         │   ├── opening_loc: (96...98) = "%|"
         │   ├── content_loc: (98...101) = "abc"
         │   ├── closing_loc: (101...102) = "|"

--- a/test/yarp/snapshots/patterns.txt
+++ b/test/yarp/snapshots/patterns.txt
@@ -264,6 +264,7 @@
         │   │   @ ArrayNode (location: (170...177))
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ StringNode (location: (173...176))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (173...176) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -287,6 +288,7 @@
         │   │   @ ArrayNode (location: (185...192))
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ StringNode (location: (188...191))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (188...191) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -308,6 +310,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (200...207))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (200...203) = "%q["
         │   │   ├── content_loc: (203...206) = "foo"
         │   │   ├── closing_loc: (206...207) = "]"
@@ -327,6 +330,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (215...222))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (215...218) = "%Q["
         │   │   ├── content_loc: (218...221) = "foo"
         │   │   ├── closing_loc: (221...222) = "]"
@@ -346,6 +350,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (230...235))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (230...231) = "\""
         │   │   ├── content_loc: (231...234) = "foo"
         │   │   ├── closing_loc: (234...235) = "\""
@@ -849,6 +854,7 @@
         │   │   │   @ ArrayNode (location: (618...625))
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ StringNode (location: (621...624))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (621...624) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -859,6 +865,7 @@
         │   │   │   @ ArrayNode (location: (629...636))
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ StringNode (location: (632...635))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (632...635) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -886,6 +893,7 @@
         │   │   │   @ ArrayNode (location: (644...651))
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ StringNode (location: (647...650))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (647...650) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -896,6 +904,7 @@
         │   │   │   @ ArrayNode (location: (655...662))
         │   │   │   ├── elements: (length: 1)
         │   │   │   │   └── @ StringNode (location: (658...661))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (658...661) = "foo"
         │   │   │   │       ├── closing_loc: ∅
@@ -921,12 +930,14 @@
         │   │   @ RangeNode (location: (670...688))
         │   │   ├── left:
         │   │   │   @ StringNode (location: (670...677))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (670...673) = "%q["
         │   │   │   ├── content_loc: (673...676) = "foo"
         │   │   │   ├── closing_loc: (676...677) = "]"
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ StringNode (location: (681...688))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (681...684) = "%q["
         │   │   │   ├── content_loc: (684...687) = "foo"
         │   │   │   ├── closing_loc: (687...688) = "]"
@@ -950,12 +961,14 @@
         │   │   @ RangeNode (location: (696...714))
         │   │   ├── left:
         │   │   │   @ StringNode (location: (696...703))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (696...699) = "%Q["
         │   │   │   ├── content_loc: (699...702) = "foo"
         │   │   │   ├── closing_loc: (702...703) = "]"
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ StringNode (location: (707...714))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (707...710) = "%Q["
         │   │   │   ├── content_loc: (710...713) = "foo"
         │   │   │   ├── closing_loc: (713...714) = "]"
@@ -979,12 +992,14 @@
         │   │   @ RangeNode (location: (722...736))
         │   │   ├── left:
         │   │   │   @ StringNode (location: (722...727))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (722...723) = "\""
         │   │   │   ├── content_loc: (723...726) = "foo"
         │   │   │   ├── closing_loc: (726...727) = "\""
         │   │   │   └── unescaped: "foo"
         │   │   ├── right:
         │   │   │   @ StringNode (location: (731...736))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (731...732) = "\""
         │   │   │   ├── content_loc: (732...735) = "foo"
         │   │   │   ├── closing_loc: (735...736) = "\""
@@ -1320,6 +1335,7 @@
         │   │   │   @ CallNode (location: (1030...1043))
         │   │   │   ├── receiver:
         │   │   │   │   @ StringNode (location: (1030...1035))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (1030...1031) = "\""
         │   │   │   │   ├── content_loc: (1031...1034) = "bar"
         │   │   │   │   ├── closing_loc: (1034...1035) = "\""
@@ -1331,6 +1347,7 @@
         │   │   │   │   @ ArgumentsNode (location: (1038...1043))
         │   │   │   │   └── arguments: (length: 1)
         │   │   │   │       └── @ StringNode (location: (1038...1043))
+        │   │   │   │           ├── flags: ∅
         │   │   │   │           ├── opening_loc: (1038...1039) = "\""
         │   │   │   │           ├── content_loc: (1039...1042) = "baz"
         │   │   │   │           ├── closing_loc: (1042...1043) = "\""
@@ -2536,6 +2553,7 @@
         │   │   @ ArrayNode (location: (1818...1825))
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ StringNode (location: (1821...1824))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (1821...1824) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -2559,6 +2577,7 @@
         │   │   @ ArrayNode (location: (1833...1840))
         │   │   ├── elements: (length: 1)
         │   │   │   └── @ StringNode (location: (1836...1839))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (1836...1839) = "foo"
         │   │   │       ├── closing_loc: ∅
@@ -2580,6 +2599,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (1848...1855))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (1848...1851) = "%q["
         │   │   ├── content_loc: (1851...1854) = "foo"
         │   │   ├── closing_loc: (1854...1855) = "]"
@@ -2599,6 +2619,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (1863...1870))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (1863...1866) = "%Q["
         │   │   ├── content_loc: (1866...1869) = "foo"
         │   │   ├── closing_loc: (1869...1870) = "]"
@@ -2618,6 +2639,7 @@
         │   │   └── name: "foo"
         │   ├── pattern:
         │   │   @ StringNode (location: (1878...1883))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (1878...1879) = "\""
         │   │   ├── content_loc: (1879...1882) = "foo"
         │   │   ├── closing_loc: (1882...1883) = "\""
@@ -3109,6 +3131,7 @@
         │   │       │   @ ArrayNode (location: (2374...2381))
         │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ StringNode (location: (2377...2380))
+        │   │       │   │       ├── flags: ∅
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── content_loc: (2377...2380) = "foo"
         │   │       │   │       ├── closing_loc: ∅
@@ -3139,6 +3162,7 @@
         │   │       │   @ ArrayNode (location: (2404...2411))
         │   │       │   ├── elements: (length: 1)
         │   │       │   │   └── @ StringNode (location: (2407...2410))
+        │   │       │   │       ├── flags: ∅
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── content_loc: (2407...2410) = "foo"
         │   │       │   │       ├── closing_loc: ∅
@@ -3167,6 +3191,7 @@
         │   │   └── @ InNode (location: (2431...2446))
         │   │       ├── pattern:
         │   │       │   @ StringNode (location: (2434...2441))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (2434...2437) = "%q["
         │   │       │   ├── content_loc: (2437...2440) = "foo"
         │   │       │   ├── closing_loc: (2440...2441) = "]"
@@ -3193,6 +3218,7 @@
         │   │   └── @ InNode (location: (2461...2476))
         │   │       ├── pattern:
         │   │       │   @ StringNode (location: (2464...2471))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (2464...2467) = "%Q["
         │   │       │   ├── content_loc: (2467...2470) = "foo"
         │   │       │   ├── closing_loc: (2470...2471) = "]"
@@ -3219,6 +3245,7 @@
         │   │   └── @ InNode (location: (2491...2504))
         │   │       ├── pattern:
         │   │       │   @ StringNode (location: (2494...2499))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (2494...2495) = "\""
         │   │       │   ├── content_loc: (2495...2498) = "foo"
         │   │       │   ├── closing_loc: (2498...2499) = "\""
@@ -3923,6 +3950,7 @@
         │   │       │   │       └── @ ArrayNode (location: (3210...3217))
         │   │       │   │           ├── elements: (length: 1)
         │   │       │   │           │   └── @ StringNode (location: (3213...3216))
+        │   │       │   │           │       ├── flags: ∅
         │   │       │   │           │       ├── opening_loc: ∅
         │   │       │   │           │       ├── content_loc: (3213...3216) = "foo"
         │   │       │   │           │       ├── closing_loc: ∅
@@ -3964,6 +3992,7 @@
         │   │       │   │       └── @ ArrayNode (location: (3247...3254))
         │   │       │   │           ├── elements: (length: 1)
         │   │       │   │           │   └── @ StringNode (location: (3250...3253))
+        │   │       │   │           │       ├── flags: ∅
         │   │       │   │           │       ├── opening_loc: ∅
         │   │       │   │           │       ├── content_loc: (3250...3253) = "foo"
         │   │       │   │           │       ├── closing_loc: ∅
@@ -4003,6 +4032,7 @@
         │   │       │   │   @ StatementsNode (location: (3284...3291))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ StringNode (location: (3284...3291))
+        │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── opening_loc: (3284...3287) = "%q["
         │   │       │   │           ├── content_loc: (3287...3290) = "foo"
         │   │       │   │           ├── closing_loc: (3290...3291) = "]"
@@ -4040,6 +4070,7 @@
         │   │       │   │   @ StatementsNode (location: (3321...3328))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ StringNode (location: (3321...3328))
+        │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── opening_loc: (3321...3324) = "%Q["
         │   │       │   │           ├── content_loc: (3324...3327) = "foo"
         │   │       │   │           ├── closing_loc: (3327...3328) = "]"
@@ -4077,6 +4108,7 @@
         │   │       │   │   @ StatementsNode (location: (3358...3363))
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ StringNode (location: (3358...3363))
+        │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── opening_loc: (3358...3359) = "\""
         │   │       │   │           ├── content_loc: (3359...3362) = "foo"
         │   │       │   │           ├── closing_loc: (3362...3363) = "\""

--- a/test/yarp/snapshots/regex.txt
+++ b/test/yarp/snapshots/regex.txt
@@ -37,6 +37,7 @@
         │   ├── opening_loc: (28...29) = "/"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (29...33))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (29...33) = "aaa "
         │   │   │   ├── closing_loc: ∅
@@ -52,6 +53,7 @@
         │   ├── opening_loc: (41...42) = "/"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (42...46))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (42...46) = "aaa "
         │   │   │   ├── closing_loc: ∅
@@ -73,6 +75,7 @@
         │   │   │   │           └── name: "bbb"
         │   │   │   └── closing_loc: (51...52) = "}"
         │   │   └── @ StringNode (location: (52...56))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (52...56) = " ccc"
         │   │       ├── closing_loc: ∅
@@ -159,6 +162,7 @@
         │   │   @ ArgumentsNode (location: (263...267))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (263...267))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (263...264) = "\""
         │   │           ├── content_loc: (264...266) = "hi"
         │   │           ├── closing_loc: (266...267) = "\""
@@ -177,6 +181,7 @@
             ├── opening_loc: (280...281) = "/"
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (281...285))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (281...285) = "aaa "
             │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/rescue.txt
+++ b/test/yarp/snapshots/rescue.txt
@@ -222,6 +222,7 @@
         │   │   │               │           │   @ ArgumentsNode (location: (203...208))
         │   │   │               │           │   └── arguments: (length: 1)
         │   │   │               │           │       └── @ StringNode (location: (203...208))
+        │   │   │               │           │           ├── flags: ∅
         │   │   │               │           │           ├── opening_loc: (203...204) = "\""
         │   │   │               │           │           ├── content_loc: (204...207) = "baz"
         │   │   │               │           │           ├── closing_loc: (207...208) = "\""

--- a/test/yarp/snapshots/seattlerb/TestRubyParserShared.txt
+++ b/test/yarp/snapshots/seattlerb/TestRubyParserShared.txt
@@ -28,11 +28,13 @@
         ├── @ ArrayNode (location: (37...54))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (41...46))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (41...46) = "line2"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "line2"
         │   │   └── @ StringNode (location: (47...52))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (47...52) = "line3"
         │   │       ├── closing_loc: ∅
@@ -70,11 +72,13 @@
         ├── @ ArrayNode (location: (102...119))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (106...111))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (106...111) = "line2"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "line2"
         │   │   └── @ StringNode (location: (112...117))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (112...117) = "line3"
         │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/array_line_breaks.txt
+++ b/test/yarp/snapshots/seattlerb/array_line_breaks.txt
@@ -6,11 +6,13 @@
         ├── @ ArrayNode (location: (0...11))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (2...5))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (2...3) = "'"
         │   │   │   ├── content_loc: (3...4) = "a"
         │   │   │   ├── closing_loc: (4...5) = "'"
         │   │   │   └── unescaped: "a"
         │   │   └── @ StringNode (location: (7...10))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: (7...8) = "'"
         │   │       ├── content_loc: (8...9) = "b"
         │   │       ├── closing_loc: (9...10) = "'"

--- a/test/yarp/snapshots/seattlerb/attrasgn_array_lhs.txt
+++ b/test/yarp/snapshots/seattlerb/attrasgn_array_lhs.txt
@@ -51,16 +51,19 @@
             │       └── @ ArrayNode (location: (27...42))
             │           ├── elements: (length: 3)
             │           │   ├── @ StringNode (location: (28...31))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: (28...29) = "\""
             │           │   │   ├── content_loc: (29...30) = "a"
             │           │   │   ├── closing_loc: (30...31) = "\""
             │           │   │   └── unescaped: "a"
             │           │   ├── @ StringNode (location: (33...36))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: (33...34) = "\""
             │           │   │   ├── content_loc: (34...35) = "b"
             │           │   │   ├── closing_loc: (35...36) = "\""
             │           │   │   └── unescaped: "b"
             │           │   └── @ StringNode (location: (38...41))
+            │           │       ├── flags: ∅
             │           │       ├── opening_loc: (38...39) = "\""
             │           │       ├── content_loc: (39...40) = "c"
             │           │       ├── closing_loc: (40...41) = "\""

--- a/test/yarp/snapshots/seattlerb/bug191.txt
+++ b/test/yarp/snapshots/seattlerb/bug191.txt
@@ -20,6 +20,7 @@
         │   │   @ StatementsNode (location: (4...6))
         │   │   └── body: (length: 1)
         │   │       └── @ StringNode (location: (4...6))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (4...5) = "\""
         │   │           ├── content_loc: (5...5) = ""
         │   │           ├── closing_loc: (5...6) = "\""
@@ -59,6 +60,7 @@
             │   @ StatementsNode (location: (15...17))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (15...17))
+            │           ├── flags: ∅
             │           ├── opening_loc: (15...16) = "'"
             │           ├── content_loc: (16...16) = ""
             │           ├── closing_loc: (16...17) = "'"

--- a/test/yarp/snapshots/seattlerb/bug_249.txt
+++ b/test/yarp/snapshots/seattlerb/bug_249.txt
@@ -71,6 +71,7 @@
             │                   │   └── unescaped: "at"
             │                   ├── value:
             │                   │   @ StringNode (location: (57...67))
+            │                   │   ├── flags: ∅
             │                   │   ├── opening_loc: (57...58) = "'"
             │                   │   ├── content_loc: (58...66) = "endpoint"
             │                   │   ├── closing_loc: (66...67) = "'"

--- a/test/yarp/snapshots/seattlerb/bug_comma.txt
+++ b/test/yarp/snapshots/seattlerb/bug_comma.txt
@@ -15,6 +15,7 @@
             │   │   @ ArgumentsNode (location: (8...15))
             │   │   └── arguments: (length: 2)
             │   │       ├── @ StringNode (location: (8...10))
+            │   │       │   ├── flags: ∅
             │   │       │   ├── opening_loc: (8...9) = "?"
             │   │       │   ├── content_loc: (9...10) = "d"
             │   │       │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/case_in.txt
+++ b/test/yarp/snapshots/seattlerb/case_in.txt
@@ -77,11 +77,13 @@
         │   │       │   @ ArrayNode (location: (58...65))
         │   │       │   ├── elements: (length: 2)
         │   │       │   │   ├── @ StringNode (location: (61...62))
+        │   │       │   │   │   ├── flags: ∅
         │   │       │   │   │   ├── opening_loc: ∅
         │   │       │   │   │   ├── content_loc: (61...62) = "a"
         │   │       │   │   │   ├── closing_loc: ∅
         │   │       │   │   │   └── unescaped: "a"
         │   │       │   │   └── @ StringNode (location: (63...64))
+        │   │       │   │       ├── flags: ∅
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── content_loc: (63...64) = "b"
         │   │       │   │       ├── closing_loc: ∅
@@ -137,11 +139,13 @@
         │   │       │   @ ArrayNode (location: (106...113))
         │   │       │   ├── elements: (length: 2)
         │   │       │   │   ├── @ StringNode (location: (109...110))
+        │   │       │   │   │   ├── flags: ∅
         │   │       │   │   │   ├── opening_loc: ∅
         │   │       │   │   │   ├── content_loc: (109...110) = "a"
         │   │       │   │   │   ├── closing_loc: ∅
         │   │       │   │   │   └── unescaped: "a"
         │   │       │   │   └── @ StringNode (location: (111...112))
+        │   │       │   │       ├── flags: ∅
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── content_loc: (111...112) = "b"
         │   │       │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/case_in_hash_pat.txt
+++ b/test/yarp/snapshots/seattlerb/case_in_hash_pat.txt
@@ -25,6 +25,7 @@
             │       │   │   │   │   └── unescaped: "b"
             │       │   │   │   ├── value:
             │       │   │   │   │   @ StringNode (location: (16...19))
+            │       │   │   │   │   ├── flags: ∅
             │       │   │   │   │   ├── opening_loc: (16...17) = "'"
             │       │   │   │   │   ├── content_loc: (17...18) = "c"
             │       │   │   │   │   ├── closing_loc: (18...19) = "'"
@@ -39,6 +40,7 @@
             │       │   │       │   └── unescaped: "d"
             │       │   │       ├── value:
             │       │   │       │   @ StringNode (location: (24...27))
+            │       │   │       │   ├── flags: ∅
             │       │   │       │   ├── opening_loc: (24...25) = "\""
             │       │   │       │   ├── content_loc: (25...26) = "e"
             │       │   │       │   ├── closing_loc: (26...27) = "\""

--- a/test/yarp/snapshots/seattlerb/case_in_hash_pat_assign.txt
+++ b/test/yarp/snapshots/seattlerb/case_in_hash_pat_assign.txt
@@ -43,6 +43,7 @@
             │       │   │   │   │   └── unescaped: "d"
             │       │   │   │   ├── value:
             │       │   │   │   │   @ StringNode (location: (33...36))
+            │       │   │   │   │   ├── flags: ∅
             │       │   │   │   │   ├── opening_loc: (33...34) = "\""
             │       │   │   │   │   ├── content_loc: (34...35) = "e"
             │       │   │   │   │   ├── closing_loc: (35...36) = "\""

--- a/test/yarp/snapshots/seattlerb/difficult0_.txt
+++ b/test/yarp/snapshots/seattlerb/difficult0_.txt
@@ -16,6 +16,7 @@
             │           │   @ CallNode (location: (2...26))
             │           │   ├── receiver:
             │           │   │   @ StringNode (location: (2...8))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: (2...8) = "<<-END"
             │           │   │   ├── content_loc: (12...16) = "  a\n"
             │           │   │   ├── closing_loc: (16...22) = "  END\n"
@@ -30,11 +31,13 @@
             │           │   │           ├── opening_loc: (9...10) = "'"
             │           │   │           ├── parts: (length: 2)
             │           │   │           │   ├── @ StringNode (location: (10...12))
+            │           │   │           │   │   ├── flags: ∅
             │           │   │           │   │   ├── opening_loc: ∅
             │           │   │           │   │   ├── content_loc: (10...12) = "b\n"
             │           │   │           │   │   ├── closing_loc: ∅
             │           │   │           │   │   └── unescaped: "b\n"
             │           │   │           │   └── @ StringNode (location: (22...25))
+            │           │   │           │       ├── flags: ∅
             │           │   │           │       ├── opening_loc: ∅
             │           │   │           │       ├── content_loc: (22...25) = "  c"
             │           │   │           │       ├── closing_loc: ∅
@@ -51,6 +54,7 @@
             │           │   @ ArgumentsNode (location: (27...30))
             │           │   └── arguments: (length: 1)
             │           │       └── @ StringNode (location: (27...30))
+            │           │           ├── flags: ∅
             │           │           ├── opening_loc: (27...28) = "'"
             │           │           ├── content_loc: (28...29) = "d"
             │           │           ├── closing_loc: (29...30) = "'"

--- a/test/yarp/snapshots/seattlerb/difficult1_line_numbers2.txt
+++ b/test/yarp/snapshots/seattlerb/difficult1_line_numbers2.txt
@@ -19,6 +19,7 @@
         │   │       │   │   @ ArgumentsNode (location: (17...20))
         │   │       │   │   └── arguments: (length: 1)
         │   │       │   │       └── @ StringNode (location: (17...20))
+        │   │       │   │           ├── flags: ∅
         │   │       │   │           ├── opening_loc: (17...18) = "\""
         │   │       │   │           ├── content_loc: (18...19) = "a"
         │   │       │   │           ├── closing_loc: (19...20) = "\""

--- a/test/yarp/snapshots/seattlerb/difficult2_.txt
+++ b/test/yarp/snapshots/seattlerb/difficult2_.txt
@@ -20,6 +20,7 @@
         │   │           │   @ ArgumentsNode (location: (6...8))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (6...8))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (6...7) = "'"
         │   │           │           ├── content_loc: (7...7) = ""
         │   │           │           ├── closing_loc: (7...8) = "'"

--- a/test/yarp/snapshots/seattlerb/dstr_evstr.txt
+++ b/test/yarp/snapshots/seattlerb/dstr_evstr.txt
@@ -12,6 +12,7 @@
             │   │   │   @ StatementsNode (location: (3...6))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (3...6))
+            │   │   │           ├── flags: ∅
             │   │   │           ├── opening_loc: (3...4) = "'"
             │   │   │           ├── content_loc: (4...5) = "a"
             │   │   │           ├── closing_loc: (5...6) = "'"

--- a/test/yarp/snapshots/seattlerb/dstr_str.txt
+++ b/test/yarp/snapshots/seattlerb/dstr_str.txt
@@ -12,12 +12,14 @@
             │   │   │   @ StatementsNode (location: (3...6))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (3...6))
+            │   │   │           ├── flags: ∅
             │   │   │           ├── opening_loc: (3...4) = "'"
             │   │   │           ├── content_loc: (4...5) = "a"
             │   │   │           ├── closing_loc: (5...6) = "'"
             │   │   │           └── unescaped: "a"
             │   │   └── closing_loc: (6...7) = "}"
             │   └── @ StringNode (location: (7...9))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (7...9) = " b"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/evstr_str.txt
+++ b/test/yarp/snapshots/seattlerb/evstr_str.txt
@@ -23,6 +23,7 @@
             │   │   │           └── name: "a"
             │   │   └── closing_loc: (4...5) = "}"
             │   └── @ StringNode (location: (5...7))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (5...7) = " b"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc__backslash_dos_format.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc__backslash_dos_format.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...3) = "str"
             ├── value:
             │   @ StringNode (location: (6...12))
+            │   ├── flags: ∅
             │   ├── opening_loc: (6...12) = "<<-XXX"
             │   ├── content_loc: (14...30) = "before\\\r\nafter\r\n"
             │   ├── closing_loc: (30...35) = "XXX\r\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_backslash_nl.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_backslash_nl.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...49))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...40))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...1) = "\""
         │   ├── content_loc: (1...39) = "  why would someone do this? \\\n  blah\n"
         │   ├── closing_loc: (39...40) = "\""
         │   └── unescaped: "  why would someone do this?   blah\n"
         └── @ StringNode (location: (42...49))
+            ├── flags: ∅
             ├── opening_loc: (42...49) = "<<-DESC"
             ├── content_loc: (50...88) = "  why would someone do this? \\\n  blah\n"
             ├── closing_loc: (88...93) = "DESC\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_bad_hex_escape.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_bad_hex_escape.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "s"
             ├── value:
             │   @ StringNode (location: (4...9))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...9) = "<<eos"
             │   ├── content_loc: (10...17) = "a\\xE9b\n"
             │   ├── closing_loc: (17...21) = "eos\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_bad_oct_escape.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_bad_oct_escape.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "s"
             ├── value:
             │   @ StringNode (location: (4...10))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...10) = "<<-EOS"
             │   ├── content_loc: (11...23) = "a\\247b\ncöd\n"
             │   ├── closing_loc: (23...27) = "EOS\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_comma_arg.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_comma_arg.txt
@@ -6,6 +6,7 @@
         ├── @ ArrayNode (location: (0...17))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (1...15))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: (1...2) = "\""
         │   │       ├── content_loc: (2...14) = "  some text\n"
         │   │       ├── closing_loc: (14...15) = "\""
@@ -15,6 +16,7 @@
         └── @ ArrayNode (location: (19...47))
             ├── elements: (length: 1)
             │   └── @ StringNode (location: (20...27))
+            │       ├── flags: ∅
             │       ├── opening_loc: (20...27) = "<<-FILE"
             │       ├── content_loc: (29...41) = "  some text\n"
             │       ├── closing_loc: (41...46) = "FILE\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_lineno.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_lineno.txt
@@ -9,6 +9,7 @@
         │   ├── name_loc: (0...1) = "c"
         │   ├── value:
         │   │   @ StringNode (location: (4...11))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (4...11) = "<<'CCC'"
         │   │   ├── content_loc: (12...30) = "line2\nline3\nline4\n"
         │   │   ├── closing_loc: (30...34) = "CCC\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_nested.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_nested.txt
@@ -14,17 +14,20 @@
             │   │   │   │   │   @ StatementsNode (location: (8...11))
             │   │   │   │   │   └── body: (length: 1)
             │   │   │   │   │       └── @ StringNode (location: (8...11))
+            │   │   │   │   │           ├── flags: ∅
             │   │   │   │   │           ├── opening_loc: (8...11) = "<<B"
             │   │   │   │   │           ├── content_loc: (13...15) = "b\n"
             │   │   │   │   │           ├── closing_loc: (15...17) = "B\n"
             │   │   │   │   │           └── unescaped: "b\n"
             │   │   │   │   └── closing_loc: (11...12) = "}"
             │   │   │   ├── @ StringNode (location: (12...13))
+            │   │   │   │   ├── flags: ∅
             │   │   │   │   ├── opening_loc: ∅
             │   │   │   │   ├── content_loc: (12...13) = "\n"
             │   │   │   │   ├── closing_loc: ∅
             │   │   │   │   └── unescaped: "\n"
             │   │   │   └── @ StringNode (location: (17...19))
+            │   │   │       ├── flags: ∅
             │   │   │       ├── opening_loc: ∅
             │   │   │       ├── content_loc: (17...19) = "a\n"
             │   │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "a"
             ├── value:
             │   @ StringNode (location: (4...12))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...12) = "<<~\"EOF\""
             │   ├── content_loc: (13...25) = "  x\n  y\n  z\n"
             │   ├── closing_loc: (25...31) = "  EOF\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.txt
@@ -22,6 +22,7 @@
             │   │           │   ├── opening_loc: (8...14) = "<<~EOF"
             │   │           │   ├── parts: (length: 3)
             │   │           │   │   ├── @ StringNode (location: (21...26))
+            │   │           │   │   │   ├── flags: ∅
             │   │           │   │   │   ├── opening_loc: ∅
             │   │           │   │   │   ├── content_loc: (21...26) = "\n    "
             │   │           │   │   │   ├── closing_loc: ∅
@@ -43,6 +44,7 @@
             │   │           │   │   │   │           └── name: "bar"
             │   │           │   │   │   └── closing_loc: (31...32) = "}"
             │   │           │   │   └── @ StringNode (location: (32...36))
+            │   │           │   │       ├── flags: ∅
             │   │           │   │       ├── opening_loc: ∅
             │   │           │   │       ├── content_loc: (32...36) = "baz\n"
             │   │           │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_blank_lines.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "a"
             ├── value:
             │   @ StringNode (location: (4...10))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...10) = "<<~EOF"
             │   ├── content_loc: (11...20) = "  x\n\n  z\n"
             │   ├── closing_loc: (20...24) = "EOF\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_empty.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_empty.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...4))
     └── body: (length: 1)
         └── @ StringNode (location: (0...4))
+            ├── flags: ∅
             ├── opening_loc: (0...4) = "<<~A"
             ├── content_loc: (5...5) = ""
             ├── closing_loc: (5...7) = "A\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_interp.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_interp.txt
@@ -12,6 +12,7 @@
             │   ├── opening_loc: (4...10) = "<<~EOF"
             │   ├── parts: (length: 3)
             │   │   ├── @ StringNode (location: (11...22))
+            │   │   │   ├── flags: ∅
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── content_loc: (11...22) = "      w\n  x"
             │   │   │   ├── closing_loc: ∅
@@ -25,6 +26,7 @@
             │   │   │   │           └── flags: decimal
             │   │   │   └── closing_loc: (26...27) = "}"
             │   │   └── @ StringNode (location: (27...36))
+            │   │       ├── flags: ∅
             │   │       ├── opening_loc: ∅
             │   │       ├── content_loc: (27...36) = " y\n    z\n"
             │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_no_indent.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_no_indent.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...4))
     └── body: (length: 1)
         └── @ StringNode (location: (0...4))
+            ├── flags: ∅
             ├── opening_loc: (0...4) = "<<~A"
             ├── content_loc: (5...7) = "a\n"
             ├── closing_loc: (7...9) = "A\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_tabs.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_tabs.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "a"
             ├── value:
             │   @ StringNode (location: (4...12))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...12) = "<<~\"EOF\""
             │   ├── content_loc: (13...43) = "        blah blah\n\t blah blah\n"
             │   ├── closing_loc: (43...49) = "  EOF\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_tabs_extra.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "a"
             ├── value:
             │   @ StringNode (location: (4...12))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...12) = "<<~\"EOF\""
             │   ├── content_loc: (13...37) = "  blah blah\n \tblah blah\n"
             │   ├── closing_loc: (37...43) = "  EOF\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "a"
             ├── value:
             │   @ StringNode (location: (4...10))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...10) = "<<~EOF"
             │   ├── content_loc: (11...21) = "  x\n \n  z\n"
             │   ├── closing_loc: (21...25) = "EOF\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_trailing_slash_continued_call.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_trailing_slash_continued_call.txt
@@ -6,6 +6,7 @@
         └── @ CallNode (location: (0...22))
             ├── receiver:
             │   @ StringNode (location: (0...5))
+            │   ├── flags: ∅
             │   ├── opening_loc: (0...5) = "<<END"
             │   ├── content_loc: (7...12) = "blah\n"
             │   ├── closing_loc: (12...16) = "END\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_unicode.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_unicode.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...9))
     └── body: (length: 1)
         └── @ StringNode (location: (0...9))
+            ├── flags: ∅
             ├── opening_loc: (0...9) = "<<OOTPÜT"
             ├── content_loc: (10...12) = ".\n"
             ├── closing_loc: (12...20) = "OOTPÜT\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_carriage_return_escapes.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_carriage_return_escapes.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (6...21) = "foo\\rbar\nbaz\\r\n"
             ├── closing_loc: (21...25) = "EOS\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (7...24) = "foo\\rbar\r\nbaz\\r\r\n"
             ├── closing_loc: (24...29) = "EOS\r\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...7))
     └── body: (length: 1)
         └── @ StringNode (location: (0...7))
+            ├── flags: ∅
             ├── opening_loc: (0...7) = "<<'eot'"
             ├── content_loc: (9...15) = "body\r\n"
             ├── closing_loc: (15...19) = "eot\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_returns.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_returns.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (6...19) = "foo\rbar\r\nbaz\n"
             ├── closing_loc: (19...23) = "EOS\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (7...22) = "foo\rbar\r\r\nbaz\r\n"
             ├── closing_loc: (22...27) = "EOS\r\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...5) = "<<EOS"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (6...11))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (6...11) = "foo\\r"
             │   │   ├── closing_loc: ∅
@@ -17,6 +18,7 @@
             │   │       @ InstanceVariableReadNode (location: (12...16))
             │   │       └── name: :@bar
             │   └── @ StringNode (location: (16...17))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (16...17) = "\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...5) = "<<EOS"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (7...12))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (7...12) = "foo\\r"
             │   │   ├── closing_loc: ∅
@@ -17,6 +18,7 @@
             │   │       @ InstanceVariableReadNode (location: (13...17))
             │   │       └── name: :@bar
             │   └── @ StringNode (location: (17...19))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (17...19) = "\r\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/heredoc_with_not_global_interpolation.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_not_global_interpolation.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...10))
     └── body: (length: 1)
         └── @ StringNode (location: (0...10))
+            ├── flags: ∅
             ├── opening_loc: (0...10) = "<<-HEREDOC"
             ├── content_loc: (11...15) = "\#${\n"
             ├── closing_loc: (15...23) = "HEREDOC\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_only_carriage_returns.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_only_carriage_returns.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (6...14) = "\r\n\r\r\n\\r\n"
             ├── closing_loc: (14...18) = "EOS\n"

--- a/test/yarp/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.txt
+++ b/test/yarp/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...5))
     └── body: (length: 1)
         └── @ StringNode (location: (0...5))
+            ├── flags: ∅
             ├── opening_loc: (0...5) = "<<EOS"
             ├── content_loc: (7...18) = "\r\r\n\r\r\r\n\\r\r\n"
             ├── closing_loc: (18...23) = "EOS\r\n"

--- a/test/yarp/snapshots/seattlerb/in_expr_no_case.txt
+++ b/test/yarp/snapshots/seattlerb/in_expr_no_case.txt
@@ -6,6 +6,7 @@
         └── @ MatchPredicateNode (location: (0...16))
             ├── value:
             │   @ StringNode (location: (0...6))
+            │   ├── flags: ∅
             │   ├── opening_loc: (0...1) = "'"
             │   ├── content_loc: (1...5) = "woot"
             │   ├── closing_loc: (5...6) = "'"

--- a/test/yarp/snapshots/seattlerb/interpolated_word_array_line_breaks.txt
+++ b/test/yarp/snapshots/seattlerb/interpolated_word_array_line_breaks.txt
@@ -6,11 +6,13 @@
         ├── @ ArrayNode (location: (0...9))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (4...5))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (4...5) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   └── @ StringNode (location: (6...7))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (6...7) = "b"
         │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/label_vs_string.txt
+++ b/test/yarp/snapshots/seattlerb/label_vs_string.txt
@@ -22,6 +22,7 @@
             │   @ ArgumentsNode (location: (8...12))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (8...12))
+            │           ├── flags: ∅
             │           ├── opening_loc: (8...9) = "'"
             │           ├── content_loc: (9...11) = ":\n"
             │           ├── closing_loc: (11...12) = "'"

--- a/test/yarp/snapshots/seattlerb/non_interpolated_word_array_line_breaks.txt
+++ b/test/yarp/snapshots/seattlerb/non_interpolated_word_array_line_breaks.txt
@@ -6,11 +6,13 @@
         ├── @ ArrayNode (location: (0...9))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (4...5))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (4...5) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   └── @ StringNode (location: (6...7))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (6...7) = "b"
         │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/parse_if_not_canonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_if_not_canonical.txt
@@ -40,6 +40,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"
@@ -51,6 +52,7 @@
             │   │   @ StatementsNode (location: (32...37))
             │   │   └── body: (length: 1)
             │   │       └── @ StringNode (location: (32...37))
+            │   │           ├── flags: ∅
             │   │           ├── opening_loc: (32...33) = "'"
             │   │           ├── content_loc: (33...36) = "bar"
             │   │           ├── closing_loc: (36...37) = "'"

--- a/test/yarp/snapshots/seattlerb/parse_if_not_noncanonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_if_not_noncanonical.txt
@@ -40,6 +40,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"
@@ -51,6 +52,7 @@
             │   │   @ StatementsNode (location: (32...37))
             │   │   └── body: (length: 1)
             │   │       └── @ StringNode (location: (32...37))
+            │   │           ├── flags: ∅
             │   │           ├── opening_loc: (32...33) = "'"
             │   │           ├── content_loc: (33...36) = "bar"
             │   │           ├── closing_loc: (36...37) = "'"

--- a/test/yarp/snapshots/seattlerb/parse_line_dstr_escaped_newline.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_dstr_escaped_newline.txt
@@ -7,6 +7,7 @@
         │   ├── opening_loc: (0...1) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (1...4))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (1...4) = "a\\n"
         │   │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/parse_line_dstr_soft_newline.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_dstr_soft_newline.txt
@@ -7,6 +7,7 @@
         │   ├── opening_loc: (0...1) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (1...3))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (1...3) = "a\n"
         │   │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/parse_line_evstr_after_break.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_evstr_after_break.txt
@@ -6,6 +6,7 @@
         └── @ StringConcatNode (location: (0...11))
             ├── left:
             │   @ StringNode (location: (0...3))
+            │   ├── flags: ∅
             │   ├── opening_loc: (0...1) = "\""
             │   ├── content_loc: (1...2) = "a"
             │   ├── closing_loc: (2...3) = "\""

--- a/test/yarp/snapshots/seattlerb/parse_line_heredoc.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_heredoc.txt
@@ -11,6 +11,7 @@
         │   │   @ CallNode (location: (15...31))
         │   │   ├── receiver:
         │   │   │   @ StringNode (location: (15...25))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (15...25) = "<<-HEREDOC"
         │   │   │   ├── content_loc: (32...57) = "        very long string\n"
         │   │   │   ├── closing_loc: (57...71) = "      HEREDOC\n"

--- a/test/yarp/snapshots/seattlerb/parse_line_heredoc_evstr.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_heredoc_evstr.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...4) = "<<-A"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (5...7))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (5...7) = "a\n"
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "b"
             │   │   └── closing_loc: (10...11) = "}"
             │   └── @ StringNode (location: (11...12))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (11...12) = "\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_heredoc_hardnewline.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...48))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...8))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...8) = "<<-EOFOO"
         │   ├── content_loc: (9...28) = "\\n\\n\\n\\n\\n\\n\\n\\n\\n\n"
         │   ├── closing_loc: (28...34) = "EOFOO\n"

--- a/test/yarp/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_heredoc_regexp_chars.txt
@@ -9,6 +9,7 @@
         │   ├── name_loc: (6...12) = "string"
         │   ├── value:
         │   │   @ StringNode (location: (15...22))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (15...22) = "<<-\"^D\""
         │   │   ├── content_loc: (23...48) = "        very long string\n"
         │   │   ├── closing_loc: (48...57) = "      ^D\n"

--- a/test/yarp/snapshots/seattlerb/parse_line_multiline_str.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_multiline_str.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...7))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...5))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...1) = "\""
         │   ├── content_loc: (1...4) = "a\nb"
         │   ├── closing_loc: (4...5) = "\""

--- a/test/yarp/snapshots/seattlerb/parse_line_multiline_str_literal_n.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_multiline_str_literal_n.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...8))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...1) = "\""
         │   ├── content_loc: (1...5) = "a\\nb"
         │   ├── closing_loc: (5...6) = "\""

--- a/test/yarp/snapshots/seattlerb/parse_line_str_with_newline_escape.txt
+++ b/test/yarp/snapshots/seattlerb/parse_line_str_with_newline_escape.txt
@@ -12,6 +12,7 @@
             │   @ ArgumentsNode (location: (2...12))
             │   └── arguments: (length: 2)
             │       ├── @ StringNode (location: (2...6))
+            │       │   ├── flags: ∅
             │       │   ├── opening_loc: (2...3) = "\""
             │       │   ├── content_loc: (3...5) = "\\n"
             │       │   ├── closing_loc: (5...6) = "\""

--- a/test/yarp/snapshots/seattlerb/parse_until_not_canonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_until_not_canonical.txt
@@ -41,6 +41,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"

--- a/test/yarp/snapshots/seattlerb/parse_until_not_noncanonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_until_not_noncanonical.txt
@@ -41,6 +41,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"

--- a/test/yarp/snapshots/seattlerb/parse_while_not_canonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_while_not_canonical.txt
@@ -41,6 +41,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"

--- a/test/yarp/snapshots/seattlerb/parse_while_not_noncanonical.txt
+++ b/test/yarp/snapshots/seattlerb/parse_while_not_noncanonical.txt
@@ -41,6 +41,7 @@
             │   @ StatementsNode (location: (21...26))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (21...26))
+            │           ├── flags: ∅
             │           ├── opening_loc: (21...22) = "'"
             │           ├── content_loc: (22...25) = "foo"
             │           ├── closing_loc: (25...26) = "'"

--- a/test/yarp/snapshots/seattlerb/pctW_lineno.txt
+++ b/test/yarp/snapshots/seattlerb/pctW_lineno.txt
@@ -6,36 +6,43 @@
         └── @ ArrayNode (location: (0...28))
             ├── elements: (length: 7)
             │   ├── @ StringNode (location: (3...7))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (3...7) = "a\\nb"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "a\nb"
             │   ├── @ StringNode (location: (8...9))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (8...9) = "c"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "c"
             │   ├── @ StringNode (location: (10...11))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (10...11) = "d"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "d"
             │   ├── @ StringNode (location: (12...16))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (12...16) = "e\\\nf"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "ef"
             │   ├── @ StringNode (location: (17...19))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (17...19) = "gy"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "gy"
             │   ├── @ StringNode (location: (20...23))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (20...23) = "h\\y"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "hy"
             │   └── @ StringNode (location: (24...27))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (24...27) = "i\\y"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/pct_Q_backslash_nl.txt
+++ b/test/yarp/snapshots/seattlerb/pct_Q_backslash_nl.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...7))
     └── body: (length: 1)
         └── @ StringNode (location: (0...7))
+            ├── flags: ∅
             ├── opening_loc: (0...3) = "%q{"
             ├── content_loc: (3...6) = " \\\n"
             ├── closing_loc: (6...7) = "}"

--- a/test/yarp/snapshots/seattlerb/pct_nl.txt
+++ b/test/yarp/snapshots/seattlerb/pct_nl.txt
@@ -9,6 +9,7 @@
             ├── name_loc: (0...1) = "x"
             ├── value:
             │   @ StringNode (location: (4...7))
+            │   ├── flags: ∅
             │   ├── opening_loc: (4...6) = "%\n"
             │   ├── content_loc: (6...6) = ""
             │   ├── closing_loc: (6...7) = "\n"

--- a/test/yarp/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
+++ b/test/yarp/snapshots/seattlerb/pct_w_heredoc_interp_nested.txt
@@ -6,6 +6,7 @@
         └── @ ArrayNode (location: (0...30))
             ├── elements: (length: 5)
             │   ├── @ StringNode (location: (4...5))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (4...5) = "1"
             │   │   ├── closing_loc: ∅
@@ -19,6 +20,7 @@
             │   │   │       │   @ StatementsNode (location: (8...11))
             │   │   │       │   └── body: (length: 1)
             │   │   │       │       └── @ StringNode (location: (8...11))
+            │   │   │       │           ├── flags: ∅
             │   │   │       │           ├── opening_loc: (8...11) = "<<A"
             │   │   │       │           ├── content_loc: (15...17) = "2\n"
             │   │   │       │           ├── closing_loc: (17...19) = "A\n"
@@ -26,16 +28,19 @@
             │   │   │       └── closing_loc: (11...12) = "}"
             │   │   └── closing_loc: ∅
             │   ├── @ StringNode (location: (13...14))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (13...14) = "3"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "3"
             │   ├── @ StringNode (location: (25...26))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (25...26) = "4"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "4"
             │   └── @ StringNode (location: (27...28))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (27...28) = "5"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/qsymbols_interp.txt
+++ b/test/yarp/snapshots/seattlerb/qsymbols_interp.txt
@@ -14,6 +14,7 @@
             │   │   ├── opening_loc: ∅
             │   │   ├── parts: (length: 2)
             │   │   │   ├── @ StringNode (location: (5...6))
+            │   │   │   │   ├── flags: ∅
             │   │   │   │   ├── opening_loc: ∅
             │   │   │   │   ├── content_loc: (5...6) = "b"
             │   │   │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/qw_escape.txt
+++ b/test/yarp/snapshots/seattlerb/qw_escape.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...7))
     └── body: (length: 1)
         └── @ StringNode (location: (0...7))
+            ├── flags: ∅
             ├── opening_loc: (0...3) = "%q("
             ├── content_loc: (3...6) = "\u0001\\'"
             ├── closing_loc: (6...7) = ")"

--- a/test/yarp/snapshots/seattlerb/qw_escape_term.txt
+++ b/test/yarp/snapshots/seattlerb/qw_escape_term.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...26))
     └── body: (length: 1)
         └── @ StringNode (location: (0...26))
+            ├── flags: ∅
             ├── opening_loc: (0...3) = "%q|"
             ├── content_loc: (3...25) = "blah blah \\| blah blah"
             ├── closing_loc: (25...26) = "|"

--- a/test/yarp/snapshots/seattlerb/read_escape_unicode_curlies.txt
+++ b/test/yarp/snapshots/seattlerb/read_escape_unicode_curlies.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...9))
     └── body: (length: 1)
         └── @ StringNode (location: (0...9))
+            ├── flags: ∅
             ├── opening_loc: (0...1) = "?"
             ├── content_loc: (1...9) = "\\u{00a0}"
             ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/read_escape_unicode_h4.txt
+++ b/test/yarp/snapshots/seattlerb/read_escape_unicode_h4.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...7))
     └── body: (length: 1)
         └── @ StringNode (location: (0...7))
+            ├── flags: ∅
             ├── opening_loc: (0...1) = "?"
             ├── content_loc: (1...7) = "\\u00a0"
             ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/slashy_newlines_within_string.txt
+++ b/test/yarp/snapshots/seattlerb/slashy_newlines_within_string.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (5...33))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (5...33))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (5...6) = "\""
         │   │           ├── content_loc: (6...32) = "hello\\\n my\\\n dear\\\n friend"
         │   │           ├── closing_loc: (32...33) = "\""

--- a/test/yarp/snapshots/seattlerb/str_backslashes.txt
+++ b/test/yarp/snapshots/seattlerb/str_backslashes.txt
@@ -12,6 +12,7 @@
             │   @ ArgumentsNode (location: (2...204))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (2...204))
+            │           ├── flags: ∅
             │           ├── opening_loc: (2...3) = "'"
             │           ├── content_loc: (3...203) = "\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n"
             │           ├── closing_loc: (203...204) = "'"

--- a/test/yarp/snapshots/seattlerb/str_double_double_escaped_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_double_double_escaped_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...7))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...7))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "\""
         │   │           ├── content_loc: (3...6) = "\\\\n"
         │   │           ├── closing_loc: (6...7) = "\""

--- a/test/yarp/snapshots/seattlerb/str_double_escaped_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_double_escaped_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...6))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...6))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "\""
         │   │           ├── content_loc: (3...5) = "\\n"
         │   │           ├── closing_loc: (5...6) = "\""

--- a/test/yarp/snapshots/seattlerb/str_double_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_double_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...5))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...5))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "\""
         │   │           ├── content_loc: (3...4) = "\n"
         │   │           ├── closing_loc: (4...5) = "\""

--- a/test/yarp/snapshots/seattlerb/str_evstr.txt
+++ b/test/yarp/snapshots/seattlerb/str_evstr.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "\""
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (1...3))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...3) = "a "
             │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/str_evstr_escape.txt
+++ b/test/yarp/snapshots/seattlerb/str_evstr_escape.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1...3))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...3) = "a "
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "b"
             │   │   └── closing_loc: (6...7) = "}"
             │   └── @ StringNode (location: (7...15))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (7...15) = "\\302\\275"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/str_heredoc_interp.txt
+++ b/test/yarp/snapshots/seattlerb/str_heredoc_interp.txt
@@ -23,6 +23,7 @@
             │   │   │           └── name: "x"
             │   │   └── closing_loc: (8...9) = "}"
             │   └── @ StringNode (location: (9...16))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (9...16) = "\nblah2\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/str_interp_ternary_or_label.txt
+++ b/test/yarp/snapshots/seattlerb/str_interp_ternary_or_label.txt
@@ -42,6 +42,7 @@
             │       │           │           │   @ CallNode (location: (10...14))
             │       │           │           │   ├── receiver:
             │       │           │           │   │   @ StringNode (location: (10...12))
+            │       │           │           │   │   ├── flags: ∅
             │       │           │           │   │   ├── opening_loc: (10...11) = "\""
             │       │           │           │   │   ├── content_loc: (11...11) = ""
             │       │           │           │   │   ├── closing_loc: (11...12) = "\""
@@ -73,6 +74,7 @@
             │       │           │           │   @ ArgumentsNode (location: (15...17))
             │       │           │           │   └── arguments: (length: 1)
             │       │           │           │       └── @ StringNode (location: (15...17))
+            │       │           │           │           ├── flags: ∅
             │       │           │           │           ├── opening_loc: (15...16) = "\""
             │       │           │           │           ├── content_loc: (16...16) = ""
             │       │           │           │           ├── closing_loc: (16...17) = "\""
@@ -88,6 +90,7 @@
             │       │           │   │   @ StatementsNode (location: (19...21))
             │       │           │   │   └── body: (length: 1)
             │       │           │   │       └── @ StringNode (location: (19...21))
+            │       │           │   │           ├── flags: ∅
             │       │           │   │           ├── opening_loc: (19...20) = "\""
             │       │           │   │           ├── content_loc: (20...20) = ""
             │       │           │   │           ├── closing_loc: (20...21) = "\""

--- a/test/yarp/snapshots/seattlerb/str_lit_concat_bad_encodings.txt
+++ b/test/yarp/snapshots/seattlerb/str_lit_concat_bad_encodings.txt
@@ -6,12 +6,14 @@
         └── @ StringConcatNode (location: (0...131))
             ├── left:
             │   @ StringNode (location: (0...62))
+            │   ├── flags: ∅
             │   ├── opening_loc: (0...1) = "\""
             │   ├── content_loc: (1...61) = "\\xE3\\xD3\\x8B\\xE3\\x83\\xBC\\x83\\xE3\\x83\\xE3\\x82\\xB3\\xA3\\x82\\x99"
             │   ├── closing_loc: (61...62) = "\""
             │   └── unescaped: "\xE3Ӌー\x83\xE3\x83コ\xA3\x82\x99"
             └── right:
                 @ StringNode (location: (73...131))
+                ├── flags: ∅
                 ├── opening_loc: (73...74) = "\""
                 ├── content_loc: (74...130) = "\\xE3\\x83\\xB3\\xE3\\x83\\x8F\\xE3\\x82\\x9A\\xC3\\xBD;foo@bar.com"
                 ├── closing_loc: (130...131) = "\""

--- a/test/yarp/snapshots/seattlerb/str_newline_hash_line_number.txt
+++ b/test/yarp/snapshots/seattlerb/str_newline_hash_line_number.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...13))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...11))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...1) = "\""
         │   ├── content_loc: (1...10) = "\\n\\n\\n\\n#"
         │   ├── closing_loc: (10...11) = "\""

--- a/test/yarp/snapshots/seattlerb/str_pct_Q_nested.txt
+++ b/test/yarp/snapshots/seattlerb/str_pct_Q_nested.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...3) = "%Q["
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (3...11))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (3...11) = "before ["
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "nest"
             │   │   └── closing_loc: (17...18) = "}"
             │   └── @ StringNode (location: (18...25))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (18...25) = "] after"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/str_pct_nested_nested.txt
+++ b/test/yarp/snapshots/seattlerb/str_pct_nested_nested.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...2) = "%{"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (2...5))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (2...5) = " { "
             │   │   ├── closing_loc: ∅
@@ -30,6 +31,7 @@
             │   │   │           └── closing_loc: (13...14) = "\""
             │   │   └── closing_loc: (15...16) = "}"
             │   └── @ StringNode (location: (16...19))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (16...19) = " } "
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/str_pct_q.txt
+++ b/test/yarp/snapshots/seattlerb/str_pct_q.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...9))
     └── body: (length: 1)
         └── @ StringNode (location: (0...9))
+            ├── flags: ∅
             ├── opening_loc: (0...3) = "%q{"
             ├── content_loc: (3...8) = "a b c"
             ├── closing_loc: (8...9) = "}"

--- a/test/yarp/snapshots/seattlerb/str_single_double_escaped_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_single_double_escaped_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...7))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...7))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "'"
         │   │           ├── content_loc: (3...6) = "\\\\n"
         │   │           ├── closing_loc: (6...7) = "'"

--- a/test/yarp/snapshots/seattlerb/str_single_escaped_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_single_escaped_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...6))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...6))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "'"
         │   │           ├── content_loc: (3...5) = "\\n"
         │   │           ├── closing_loc: (5...6) = "'"

--- a/test/yarp/snapshots/seattlerb/str_single_newline.txt
+++ b/test/yarp/snapshots/seattlerb/str_single_newline.txt
@@ -12,6 +12,7 @@
         │   │   @ ArgumentsNode (location: (2...5))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (2...5))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (2...3) = "'"
         │   │           ├── content_loc: (3...4) = "\n"
         │   │           ├── closing_loc: (4...5) = "'"

--- a/test/yarp/snapshots/seattlerb/str_str.txt
+++ b/test/yarp/snapshots/seattlerb/str_str.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "\""
             ├── parts: (length: 2)
             │   ├── @ StringNode (location: (1...3))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...3) = "a "
             │   │   ├── closing_loc: ∅
@@ -17,6 +18,7 @@
             │       │   @ StatementsNode (location: (5...8))
             │       │   └── body: (length: 1)
             │       │       └── @ StringNode (location: (5...8))
+            │       │           ├── flags: ∅
             │       │           ├── opening_loc: (5...6) = "'"
             │       │           ├── content_loc: (6...7) = "b"
             │       │           ├── closing_loc: (7...8) = "'"

--- a/test/yarp/snapshots/seattlerb/str_str_str.txt
+++ b/test/yarp/snapshots/seattlerb/str_str_str.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1...3))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...3) = "a "
             │   │   ├── closing_loc: ∅
@@ -17,12 +18,14 @@
             │   │   │   @ StatementsNode (location: (5...8))
             │   │   │   └── body: (length: 1)
             │   │   │       └── @ StringNode (location: (5...8))
+            │   │   │           ├── flags: ∅
             │   │   │           ├── opening_loc: (5...6) = "'"
             │   │   │           ├── content_loc: (6...7) = "b"
             │   │   │           ├── closing_loc: (7...8) = "'"
             │   │   │           └── unescaped: "b"
             │   │   └── closing_loc: (8...9) = "}"
             │   └── @ StringNode (location: (9...11))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (9...11) = " c"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/seattlerb/words_interp.txt
+++ b/test/yarp/snapshots/seattlerb/words_interp.txt
@@ -17,6 +17,7 @@
             │       │   │   │           └── flags: decimal
             │       │   │   └── closing_loc: (6...7) = "}"
             │       │   └── @ StringNode (location: (7...8))
+            │       │       ├── flags: ∅
             │       │       ├── opening_loc: ∅
             │       │       ├── content_loc: (7...8) = "b"
             │       │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/single_quote_heredocs.txt
+++ b/test/yarp/snapshots/single_quote_heredocs.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...8))
     └── body: (length: 1)
         └── @ StringNode (location: (0...8))
+            ├── flags: ∅
             ├── opening_loc: (0...8) = "<<-'EOS'"
             ├── content_loc: (9...44) = "    cd L:\\Work\\MG3710IQPro\\Develop\n"
             ├── closing_loc: (44...48) = "EOS\n"

--- a/test/yarp/snapshots/spanning_heredoc.txt
+++ b/test/yarp/snapshots/spanning_heredoc.txt
@@ -14,6 +14,7 @@
         │   │       └── @ CallNode (location: (167...192))
         │   │           ├── receiver:
         │   │           │   @ StringNode (location: (167...171))
+        │   │           │   ├── flags: ∅
         │   │           │   ├── opening_loc: (167...171) = "<<-A"
         │   │           │   ├── content_loc: (181...183) = "a\n"
         │   │           │   ├── closing_loc: (183...185) = "A\n"
@@ -28,11 +29,13 @@
         │   │           │       │   ├── opening_loc: (177...178) = "/"
         │   │           │       │   ├── parts: (length: 2)
         │   │           │       │   │   ├── @ StringNode (location: (178...181))
+        │   │           │       │   │   │   ├── flags: ∅
         │   │           │       │   │   │   ├── opening_loc: ∅
         │   │           │       │   │   │   ├── content_loc: (178...181) = "b\\\n"
         │   │           │       │   │   │   ├── closing_loc: ∅
         │   │           │       │   │   │   └── unescaped: "b"
         │   │           │       │   │   └── @ StringNode (location: (185...186))
+        │   │           │       │   │       ├── flags: ∅
         │   │           │       │   │       ├── opening_loc: ∅
         │   │           │       │   │       ├── content_loc: (185...186) = "b"
         │   │           │       │   │       ├── closing_loc: ∅
@@ -40,6 +43,7 @@
         │   │           │       │   ├── closing_loc: (186...187) = "/"
         │   │           │       │   └── flags: ∅
         │   │           │       └── @ StringNode (location: (189...191))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (189...190) = "\""
         │   │           │           ├── content_loc: (190...190) = ""
         │   │           │           ├── closing_loc: (190...191) = "\""
@@ -61,6 +65,7 @@
         │   │   @ ArgumentsNode (location: (279...295))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (279...283))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (279...283) = "<<-A"
         │   │       │   ├── content_loc: (289...291) = "c\n"
         │   │       │   ├── closing_loc: (291...293) = "A\n"
@@ -69,11 +74,13 @@
         │   │           ├── opening_loc: (285...286) = "\""
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (286...289))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (286...289) = "d\\\n"
         │   │           │   │   ├── closing_loc: ∅
         │   │           │   │   └── unescaped: "d"
         │   │           │   └── @ StringNode (location: (293...294))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (293...294) = "d"
         │   │           │       ├── closing_loc: ∅
@@ -92,6 +99,7 @@
         │   │   @ ArgumentsNode (location: (325...343))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (325...329))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (325...329) = "<<-A"
         │   │       │   ├── content_loc: (337...339) = "e\n"
         │   │       │   ├── closing_loc: (339...341) = "A\n"
@@ -100,11 +108,13 @@
         │   │           ├── opening_loc: (331...334) = "%q["
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (334...337))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (334...337) = "f\\\n"
         │   │           │   │   ├── closing_loc: ∅
         │   │           │   │   └── unescaped: "f\\\n"
         │   │           │   └── @ StringNode (location: (341...342))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (341...342) = "f"
         │   │           │       ├── closing_loc: ∅
@@ -123,6 +133,7 @@
         │   │   @ ArgumentsNode (location: (430...448))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (430...434))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (430...434) = "<<-A"
         │   │       │   ├── content_loc: (442...444) = "g\n"
         │   │       │   ├── closing_loc: (444...446) = "A\n"
@@ -131,11 +142,13 @@
         │   │           ├── opening_loc: (436...439) = "%Q["
         │   │           ├── parts: (length: 2)
         │   │           │   ├── @ StringNode (location: (439...442))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (439...442) = "h\\\n"
         │   │           │   │   ├── closing_loc: ∅
         │   │           │   │   └── unescaped: "h"
         │   │           │   └── @ StringNode (location: (446...447))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (446...447) = "h"
         │   │           │       ├── closing_loc: ∅
@@ -154,6 +167,7 @@
         │   │   @ ArgumentsNode (location: (523...541))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (523...527))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (523...527) = "<<-A"
         │   │       │   ├── content_loc: (535...537) = "i\n"
         │   │       │   ├── closing_loc: (537...539) = "A\n"
@@ -161,11 +175,13 @@
         │   │       └── @ ArrayNode (location: (529...541))
         │   │           ├── elements: (length: 2)
         │   │           │   ├── @ StringNode (location: (532...535))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (532...535) = "j\\\n"
         │   │           │   │   ├── closing_loc: ∅
         │   │           │   │   └── unescaped: "j\\\n"
         │   │           │   └── @ StringNode (location: (539...540))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (539...540) = "j"
         │   │           │       ├── closing_loc: ∅
@@ -185,6 +201,7 @@
         │   │   @ ArgumentsNode (location: (691...709))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (691...695))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (691...695) = "<<-A"
         │   │       │   ├── content_loc: (703...705) = "k\n"
         │   │       │   ├── closing_loc: (705...707) = "A\n"
@@ -195,11 +212,13 @@
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── parts: (length: 2)
         │   │           │       │   ├── @ StringNode (location: (700...703))
+        │   │           │       │   │   ├── flags: ∅
         │   │           │       │   │   ├── opening_loc: ∅
         │   │           │       │   │   ├── content_loc: (700...703) = "l\\\n"
         │   │           │       │   │   ├── closing_loc: ∅
         │   │           │       │   │   └── unescaped: "l"
         │   │           │       │   └── @ StringNode (location: (707...708))
+        │   │           │       │       ├── flags: ∅
         │   │           │       │       ├── opening_loc: ∅
         │   │           │       │       ├── content_loc: (707...708) = "l"
         │   │           │       │       ├── closing_loc: ∅
@@ -220,6 +239,7 @@
         │   │   @ ArgumentsNode (location: (784...802))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (784...788))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (784...788) = "<<-A"
         │   │       │   ├── content_loc: (796...798) = "m\n"
         │   │       │   ├── closing_loc: (798...800) = "A\n"
@@ -251,6 +271,7 @@
             │   @ ArgumentsNode (location: (946...964))
             │   └── arguments: (length: 2)
             │       ├── @ StringNode (location: (946...950))
+            │       │   ├── flags: ∅
             │       │   ├── opening_loc: (946...950) = "<<-A"
             │       │   ├── content_loc: (958...960) = "o\n"
             │       │   ├── closing_loc: (960...962) = "A\n"
@@ -266,6 +287,7 @@
             │           │       │   │   ├── closing_loc: ∅
             │           │       │   │   └── unescaped: "p"
             │           │       │   └── @ StringNode (location: (962...963))
+            │           │       │       ├── flags: ∅
             │           │       │       ├── opening_loc: ∅
             │           │       │       ├── content_loc: (962...963) = "p"
             │           │       │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/strings.txt
+++ b/test/yarp/snapshots/strings.txt
@@ -4,61 +4,73 @@
     @ StatementsNode (location: (0...506))
     └── body: (length: 48)
         ├── @ StringNode (location: (0...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...2) = "%%"
         │   ├── content_loc: (2...5) = "abc"
         │   ├── closing_loc: (5...6) = "%"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (8...14))
+        │   ├── flags: ∅
         │   ├── opening_loc: (8...10) = "%^"
         │   ├── content_loc: (10...13) = "abc"
         │   ├── closing_loc: (13...14) = "^"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (16...22))
+        │   ├── flags: ∅
         │   ├── opening_loc: (16...18) = "%&"
         │   ├── content_loc: (18...21) = "abc"
         │   ├── closing_loc: (21...22) = "&"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (24...30))
+        │   ├── flags: ∅
         │   ├── opening_loc: (24...26) = "%*"
         │   ├── content_loc: (26...29) = "abc"
         │   ├── closing_loc: (29...30) = "*"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (32...38))
+        │   ├── flags: ∅
         │   ├── opening_loc: (32...34) = "%_"
         │   ├── content_loc: (34...37) = "abc"
         │   ├── closing_loc: (37...38) = "_"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (40...46))
+        │   ├── flags: ∅
         │   ├── opening_loc: (40...42) = "%+"
         │   ├── content_loc: (42...45) = "abc"
         │   ├── closing_loc: (45...46) = "+"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (48...54))
+        │   ├── flags: ∅
         │   ├── opening_loc: (48...50) = "%-"
         │   ├── content_loc: (50...53) = "abc"
         │   ├── closing_loc: (53...54) = "-"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (56...62))
+        │   ├── flags: ∅
         │   ├── opening_loc: (56...58) = "%:"
         │   ├── content_loc: (58...61) = "abc"
         │   ├── closing_loc: (61...62) = ":"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (64...70))
+        │   ├── flags: ∅
         │   ├── opening_loc: (64...66) = "%;"
         │   ├── content_loc: (66...69) = "abc"
         │   ├── closing_loc: (69...70) = ";"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (72...78))
+        │   ├── flags: ∅
         │   ├── opening_loc: (72...74) = "%'"
         │   ├── content_loc: (74...77) = "abc"
         │   ├── closing_loc: (77...78) = "'"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (80...86))
+        │   ├── flags: ∅
         │   ├── opening_loc: (80...82) = "%~"
         │   ├── content_loc: (82...85) = "abc"
         │   ├── closing_loc: (85...86) = "~"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (88...94))
+        │   ├── flags: ∅
         │   ├── opening_loc: (88...90) = "%?"
         │   ├── content_loc: (90...93) = "abc"
         │   ├── closing_loc: (93...94) = "?"
@@ -68,11 +80,13 @@
         │   ├── opening_loc: (96...99) = "%w{"
         │   └── closing_loc: (103...104) = "}"
         ├── @ StringNode (location: (106...112))
+        │   ├── flags: ∅
         │   ├── opening_loc: (106...108) = "%/"
         │   ├── content_loc: (108...111) = "abc"
         │   ├── closing_loc: (111...112) = "/"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (114...120))
+        │   ├── flags: ∅
         │   ├── opening_loc: (114...116) = "%`"
         │   ├── content_loc: (116...119) = "abc"
         │   ├── closing_loc: (119...120) = "`"
@@ -87,6 +101,7 @@
         │   │           └── name: :@@foo
         │   └── closing_loc: (129...130) = "\""
         ├── @ StringNode (location: (132...138))
+        │   ├── flags: ∅
         │   ├── opening_loc: (132...134) = "%\\"
         │   ├── content_loc: (134...137) = "abc"
         │   ├── closing_loc: (137...138) = "\\"
@@ -95,6 +110,7 @@
         │   ├── opening_loc: (140...142) = "%{"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (142...146))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (142...146) = "aaa "
         │   │   │   ├── closing_loc: ∅
@@ -116,12 +132,14 @@
         │   │   │   │           └── name: "bbb"
         │   │   │   └── closing_loc: (151...152) = "}"
         │   │   └── @ StringNode (location: (152...156))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (152...156) = " ccc"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: " ccc"
         │   └── closing_loc: (156...157) = "}"
         ├── @ StringNode (location: (159...167))
+        │   ├── flags: ∅
         │   ├── opening_loc: (159...161) = "%["
         │   ├── content_loc: (161...166) = "foo[]"
         │   ├── closing_loc: (166...167) = "]"
@@ -129,6 +147,7 @@
         ├── @ CallNode (location: (169...184))
         │   ├── receiver:
         │   │   @ StringNode (location: (169...174))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (169...170) = "\""
         │   │   ├── content_loc: (170...173) = "foo"
         │   │   ├── closing_loc: (173...174) = "\""
@@ -140,6 +159,7 @@
         │   │   @ ArgumentsNode (location: (179...184))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (179...184))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (179...180) = "\""
         │   │           ├── content_loc: (180...183) = "bar"
         │   │           ├── closing_loc: (183...184) = "\""
@@ -149,6 +169,7 @@
         │   ├── flags: ∅
         │   └── name: "+"
         ├── @ StringNode (location: (186...193))
+        │   ├── flags: ∅
         │   ├── opening_loc: (186...189) = "%q{"
         │   ├── content_loc: (189...192) = "abc"
         │   ├── closing_loc: (192...193) = "}"
@@ -159,21 +180,25 @@
         │   ├── closing_loc: (201...202) = "]"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (204...210))
+        │   ├── flags: ∅
         │   ├── opening_loc: (204...206) = "%{"
         │   ├── content_loc: (206...209) = "abc"
         │   ├── closing_loc: (209...210) = "}"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (212...214))
+        │   ├── flags: ∅
         │   ├── opening_loc: (212...213) = "'"
         │   ├── content_loc: (213...213) = ""
         │   ├── closing_loc: (213...214) = "'"
         │   └── unescaped: ""
         ├── @ StringNode (location: (216...221))
+        │   ├── flags: ∅
         │   ├── opening_loc: (216...217) = "\""
         │   ├── content_loc: (217...220) = "abc"
         │   ├── closing_loc: (220...221) = "\""
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (223...230))
+        │   ├── flags: ∅
         │   ├── opening_loc: (223...224) = "\""
         │   ├── content_loc: (224...229) = "\#@---"
         │   ├── closing_loc: (229...230) = "\""
@@ -182,6 +207,7 @@
         │   ├── opening_loc: (232...233) = "\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (233...237))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (233...237) = "aaa "
         │   │   │   ├── closing_loc: ∅
@@ -203,12 +229,14 @@
         │   │   │   │           └── name: "bbb"
         │   │   │   └── closing_loc: (242...243) = "}"
         │   │   └── @ StringNode (location: (243...247))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (243...247) = " ccc"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: " ccc"
         │   └── closing_loc: (247...248) = "\""
         ├── @ StringNode (location: (250...255))
+        │   ├── flags: ∅
         │   ├── opening_loc: (250...251) = "'"
         │   ├── content_loc: (251...254) = "abc"
         │   ├── closing_loc: (254...255) = "'"
@@ -216,16 +244,19 @@
         ├── @ ArrayNode (location: (257...266))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (260...261))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (260...261) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ StringNode (location: (262...263))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (262...263) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   └── @ StringNode (location: (264...265))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (264...265) = "c"
         │   │       ├── closing_loc: ∅
@@ -235,16 +266,19 @@
         ├── @ ArrayNode (location: (268...285))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (271...274))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (271...274) = "a[]"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a[]"
         │   │   ├── @ StringNode (location: (275...280))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (275...280) = "b[[]]"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b[[]]"
         │   │   └── @ StringNode (location: (281...284))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (281...284) = "c[]"
         │   │       ├── closing_loc: ∅
@@ -254,11 +288,13 @@
         ├── @ ArrayNode (location: (287...305))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (290...298))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (290...298) = "foo\\ bar"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "foo\\ bar"
         │   │   └── @ StringNode (location: (299...304))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (299...304) = "\\\#{1}"
         │   │       ├── closing_loc: ∅
@@ -268,11 +304,13 @@
         ├── @ ArrayNode (location: (307...323))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (310...318))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (310...318) = "foo\\ bar"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "foo\\ bar"
         │   │   └── @ StringNode (location: (319...322))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (319...322) = "baz"
         │   │       ├── closing_loc: ∅
@@ -282,6 +320,7 @@
         ├── @ ArrayNode (location: (325...339))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (328...329))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (328...329) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -290,6 +329,7 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── parts: (length: 3)
         │   │   │   │   ├── @ StringNode (location: (330...331))
+        │   │   │   │   │   ├── flags: ∅
         │   │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   │   ├── content_loc: (330...331) = "b"
         │   │   │   │   │   ├── closing_loc: ∅
@@ -311,12 +351,14 @@
         │   │   │   │   │   │           └── name: "c"
         │   │   │   │   │   └── closing_loc: (334...335) = "}"
         │   │   │   │   └── @ StringNode (location: (335...336))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (335...336) = "d"
         │   │   │   │       ├── closing_loc: ∅
         │   │   │   │       └── unescaped: "d"
         │   │   │   └── closing_loc: ∅
         │   │   └── @ StringNode (location: (337...338))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (337...338) = "e"
         │   │       ├── closing_loc: ∅
@@ -326,16 +368,19 @@
         ├── @ ArrayNode (location: (341...350))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (344...345))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (344...345) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ StringNode (location: (346...347))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (346...347) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   └── @ StringNode (location: (348...349))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (348...349) = "c"
         │   │       ├── closing_loc: ∅
@@ -345,16 +390,19 @@
         ├── @ ArrayNode (location: (352...369))
         │   ├── elements: (length: 3)
         │   │   ├── @ StringNode (location: (358...359))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (358...359) = "a"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "a"
         │   │   ├── @ StringNode (location: (362...363))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (362...363) = "b"
         │   │   │   ├── closing_loc: ∅
         │   │   │   └── unescaped: "b"
         │   │   └── @ StringNode (location: (366...367))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (366...367) = "c"
         │   │       ├── closing_loc: ∅
@@ -362,11 +410,13 @@
         │   ├── opening_loc: (352...355) = "%w["
         │   └── closing_loc: (368...369) = "]"
         ├── @ StringNode (location: (371...386))
+        │   ├── flags: ∅
         │   ├── opening_loc: (371...372) = "'"
         │   ├── content_loc: (372...385) = "\\' foo \\' bar"
         │   ├── closing_loc: (385...386) = "'"
         │   └── unescaped: "' foo ' bar"
         ├── @ StringNode (location: (388...403))
+        │   ├── flags: ∅
         │   ├── opening_loc: (388...389) = "'"
         │   ├── content_loc: (389...402) = "\\\\ foo \\\\ bar"
         │   ├── closing_loc: (402...403) = "'"
@@ -390,36 +440,43 @@
         │   │           └── name: :@foo
         │   └── closing_loc: (420...421) = "\""
         ├── @ StringNode (location: (423...438))
+        │   ├── flags: ∅
         │   ├── opening_loc: (423...424) = "\""
         │   ├── content_loc: (424...437) = "\\x7 \\x23 \\x61"
         │   ├── closing_loc: (437...438) = "\""
         │   └── unescaped: "\a # a"
         ├── @ StringNode (location: (440...453))
+        │   ├── flags: ∅
         │   ├── opening_loc: (440...441) = "\""
         │   ├── content_loc: (441...452) = "\\7 \\43 \\141"
         │   ├── closing_loc: (452...453) = "\""
         │   └── unescaped: "\a # a"
         ├── @ StringNode (location: (455...461))
+        │   ├── flags: ∅
         │   ├── opening_loc: (455...457) = "%["
         │   ├── content_loc: (457...460) = "abc"
         │   ├── closing_loc: (460...461) = "]"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (463...469))
+        │   ├── flags: ∅
         │   ├── opening_loc: (463...465) = "%("
         │   ├── content_loc: (465...468) = "abc"
         │   ├── closing_loc: (468...469) = ")"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (471...477))
+        │   ├── flags: ∅
         │   ├── opening_loc: (471...473) = "%@"
         │   ├── content_loc: (473...476) = "abc"
         │   ├── closing_loc: (476...477) = "@"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (479...485))
+        │   ├── flags: ∅
         │   ├── opening_loc: (479...481) = "%$"
         │   ├── content_loc: (481...484) = "abc"
         │   ├── closing_loc: (484...485) = "$"
         │   └── unescaped: "abc"
         ├── @ StringNode (location: (487...489))
+        │   ├── flags: ∅
         │   ├── opening_loc: (487...488) = "?"
         │   ├── content_loc: (488...489) = "a"
         │   ├── closing_loc: ∅
@@ -427,17 +484,20 @@
         ├── @ StringConcatNode (location: (491...497))
         │   ├── left:
         │   │   @ StringNode (location: (491...493))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (491...492) = "?"
         │   │   ├── content_loc: (492...493) = "a"
         │   │   ├── closing_loc: ∅
         │   │   └── unescaped: "a"
         │   └── right:
         │       @ StringNode (location: (494...497))
+        │       ├── flags: ∅
         │       ├── opening_loc: (494...495) = "\""
         │       ├── content_loc: (495...496) = "a"
         │       ├── closing_loc: (496...497) = "\""
         │       └── unescaped: "a"
         └── @ StringNode (location: (499...506))
+            ├── flags: ∅
             ├── opening_loc: (499...502) = "%Q{"
             ├── content_loc: (502...505) = "abc"
             ├── closing_loc: (505...506) = "}"

--- a/test/yarp/snapshots/symbols.txt
+++ b/test/yarp/snapshots/symbols.txt
@@ -32,6 +32,7 @@
         │   ├── opening_loc: (19...21) = ":\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (21...24))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (21...24) = "abc"
         │   │   │   ├── closing_loc: ∅
@@ -198,6 +199,7 @@
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── parts: (length: 2)
         │   │   │   │   ├── @ StringNode (location: (165...166))
+        │   │   │   │   │   ├── flags: ∅
         │   │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   │   ├── content_loc: (165...166) = "b"
         │   │   │   │   │   ├── closing_loc: ∅
@@ -223,6 +225,7 @@
         │   │   │   │   │   │           └── flags: decimal
         │   │   │   │   │   └── closing_loc: (174...175) = "}"
         │   │   │   │   └── @ StringNode (location: (175...176))
+        │   │   │   │       ├── flags: ∅
         │   │   │   │       ├── opening_loc: ∅
         │   │   │   │       ├── content_loc: (175...176) = "c"
         │   │   │   │       ├── closing_loc: ∅
@@ -232,6 +235,7 @@
         │   │       ├── opening_loc: ∅
         │   │       ├── parts: (length: 3)
         │   │       │   ├── @ StringNode (location: (177...178))
+        │   │       │   │   ├── flags: ∅
         │   │       │   │   ├── opening_loc: ∅
         │   │       │   │   ├── content_loc: (177...178) = "d"
         │   │       │   │   ├── closing_loc: ∅
@@ -245,6 +249,7 @@
         │   │       │   │   │           └── flags: decimal
         │   │       │   │   └── closing_loc: (181...182) = "}"
         │   │       │   └── @ StringNode (location: (182...183))
+        │   │       │       ├── flags: ∅
         │   │       │       ├── opening_loc: ∅
         │   │       │       ├── content_loc: (182...183) = "f"
         │   │       │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/tilde_heredocs.txt
+++ b/test/yarp/snapshots/tilde_heredocs.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...372))
     └── body: (length: 18)
         ├── @ StringNode (location: (0...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...6) = "<<~EOF"
         │   ├── content_loc: (7...11) = "  a\n"
         │   ├── closing_loc: (11...15) = "EOF\n"
         │   └── unescaped: "a\n"
         ├── @ StringNode (location: (16...22))
+        │   ├── flags: ∅
         │   ├── opening_loc: (16...22) = "<<~EOF"
         │   ├── content_loc: (23...34) = "\ta\n  b\n\t\tc\n"
         │   ├── closing_loc: (34...38) = "EOF\n"
@@ -25,6 +27,7 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (51...52) = "}"
         │   │   └── @ StringNode (location: (52...55))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (52...55) = " a\n"
         │   │       ├── closing_loc: ∅
@@ -34,6 +37,7 @@
         │   ├── opening_loc: (60...66) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (67...71))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (67...71) = "  a "
         │   │   │   ├── closing_loc: ∅
@@ -47,6 +51,7 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (74...75) = "}"
         │   │   └── @ StringNode (location: (75...76))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (75...76) = "\n"
         │   │       ├── closing_loc: ∅
@@ -56,6 +61,7 @@
         │   ├── opening_loc: (81...87) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (88...93))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (88...93) = "  a\n "
         │   │   │   ├── closing_loc: ∅
@@ -69,6 +75,7 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (96...97) = "}"
         │   │   └── @ StringNode (location: (97...98))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (97...98) = "\n"
         │   │       ├── closing_loc: ∅
@@ -78,6 +85,7 @@
         │   ├── opening_loc: (103...109) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (110...116))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (110...116) = "  a\n  "
         │   │   │   ├── closing_loc: ∅
@@ -91,57 +99,68 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (119...120) = "}"
         │   │   └── @ StringNode (location: (120...121))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (120...121) = "\n"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "\n"
         │   └── closing_loc: (121...125) = "EOF\n"
         ├── @ StringNode (location: (126...132))
+        │   ├── flags: ∅
         │   ├── opening_loc: (126...132) = "<<~EOF"
         │   ├── content_loc: (133...141) = "  a\n  b\n"
         │   ├── closing_loc: (141...145) = "EOF\n"
         │   └── unescaped: "a\nb\n"
         ├── @ StringNode (location: (146...152))
+        │   ├── flags: ∅
         │   ├── opening_loc: (146...152) = "<<~EOF"
         │   ├── content_loc: (153...162) = "  a\n   b\n"
         │   ├── closing_loc: (162...166) = "EOF\n"
         │   └── unescaped: "a\n b\n"
         ├── @ StringNode (location: (167...173))
+        │   ├── flags: ∅
         │   ├── opening_loc: (167...173) = "<<~EOF"
         │   ├── content_loc: (174...183) = "\t\t\ta\n\t\tb\n"
         │   ├── closing_loc: (183...187) = "EOF\n"
         │   └── unescaped: "\ta\nb\n"
         ├── @ StringNode (location: (188...196))
+        │   ├── flags: ∅
         │   ├── opening_loc: (188...196) = "<<~'EOF'"
         │   ├── content_loc: (197...206) = "  a \#{1}\n"
         │   ├── closing_loc: (206...210) = "EOF\n"
         │   └── unescaped: "a \#{1}\n"
         ├── @ StringNode (location: (211...217))
+        │   ├── flags: ∅
         │   ├── opening_loc: (211...217) = "<<~EOF"
         │   ├── content_loc: (218...225) = "\ta\n\t b\n"
         │   ├── closing_loc: (225...229) = "EOF\n"
         │   └── unescaped: "a\n b\n"
         ├── @ StringNode (location: (230...236))
+        │   ├── flags: ∅
         │   ├── opening_loc: (230...236) = "<<~EOF"
         │   ├── content_loc: (237...244) = "\t a\n\tb\n"
         │   ├── closing_loc: (244...248) = "EOF\n"
         │   └── unescaped: " a\nb\n"
         ├── @ StringNode (location: (249...255))
+        │   ├── flags: ∅
         │   ├── opening_loc: (249...255) = "<<~EOF"
         │   ├── content_loc: (256...271) = "  \ta\n        b\n"
         │   ├── closing_loc: (271...275) = "EOF\n"
         │   └── unescaped: "a\nb\n"
         ├── @ StringNode (location: (276...282))
+        │   ├── flags: ∅
         │   ├── opening_loc: (276...282) = "<<~EOF"
         │   ├── content_loc: (283...292) = "  a\n\n  b\n"
         │   ├── closing_loc: (292...296) = "EOF\n"
         │   └── unescaped: "a\n\nb\n"
         ├── @ StringNode (location: (297...303))
+        │   ├── flags: ∅
         │   ├── opening_loc: (297...303) = "<<~EOF"
         │   ├── content_loc: (304...313) = "  a\n\n  b\n"
         │   ├── closing_loc: (313...317) = "EOF\n"
         │   └── unescaped: "a\n\nb\n"
         ├── @ StringNode (location: (318...324))
+        │   ├── flags: ∅
         │   ├── opening_loc: (318...324) = "<<~EOF"
         │   ├── content_loc: (325...336) = "  a\n\n\n\n  b\n"
         │   ├── closing_loc: (336...340) = "EOF\n"
@@ -150,6 +169,7 @@
         │   ├── opening_loc: (341...347) = "<<~EOF"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (348...351))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (348...351) = "\n  "
         │   │   │   ├── closing_loc: ∅
@@ -163,6 +183,7 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (354...355) = "}"
         │   │   └── @ StringNode (location: (355...357))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (355...357) = "a\n"
         │   │       ├── closing_loc: ∅
@@ -180,6 +201,7 @@
             │   │   │           └── flags: decimal
             │   │   └── closing_loc: (378...379) = "}"
             │   └── @ StringNode (location: (379...383))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (379...383) = "\n\tb\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/undef.txt
+++ b/test/yarp/snapshots/undef.txt
@@ -80,6 +80,7 @@
         │   │       ├── opening_loc: (90...92) = ":\""
         │   │       ├── parts: (length: 2)
         │   │       │   ├── @ StringNode (location: (92...95))
+        │   │       │   │   ├── flags: ∅
         │   │       │   │   ├── opening_loc: ∅
         │   │       │   │   ├── content_loc: (92...95) = "abc"
         │   │       │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/unescaping.txt
+++ b/test/yarp/snapshots/unescaping.txt
@@ -6,6 +6,7 @@
         ├── @ ArrayNode (location: (0...10))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (1...9))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: (1...2) = "\""
         │   │       ├── content_loc: (2...8) = "\\c\#{1}"
         │   │       ├── closing_loc: (8...9) = "\""
@@ -19,11 +20,13 @@
         │   ├── unescaped: "\u0003{1}"
         │   └── flags: ∅
         ├── @ StringNode (location: (22...30))
+        │   ├── flags: ∅
         │   ├── opening_loc: (22...23) = "\""
         │   ├── content_loc: (23...29) = "\\c\#{1}"
         │   ├── closing_loc: (29...30) = "\""
         │   └── unescaped: "\u0003{1}"
         └── @ StringNode (location: (32...39))
+            ├── flags: ∅
             ├── opening_loc: (32...39) = "<<~HERE"
             ├── content_loc: (40...50) = "   \\c\#{1}\n"
             ├── closing_loc: (50...55) = "HERE\n"

--- a/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/assignment.txt
@@ -727,6 +727,7 @@
         │   ├── name_loc: (507...508) = "x"
         │   ├── value:
         │   │   @ StringNode (location: (511...514))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (511...513) = "%("
         │   │   ├── content_loc: (513...513) = ""
         │   │   ├── closing_loc: (513...514) = ")"
@@ -744,6 +745,7 @@
         │   │   @ ArgumentsNode (location: (519...522))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (519...522))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (519...521) = "%("
         │   │           ├── content_loc: (521...521) = ""
         │   │           ├── closing_loc: (521...522) = ")"
@@ -764,6 +766,7 @@
         │   │   @ ArgumentsNode (location: (525...535))
         │   │   └── arguments: (length: 2)
         │   │       ├── @ StringNode (location: (525...528))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (525...527) = "%("
         │   │       │   ├── content_loc: (527...527) = ""
         │   │       │   ├── closing_loc: (527...528) = ")"
@@ -794,6 +797,7 @@
         │   │   @ ArgumentsNode (location: (538...541))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (538...541))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (538...540) = "%("
         │   │           ├── content_loc: (540...540) = ""
         │   │           ├── closing_loc: (540...541) = ")"
@@ -820,6 +824,7 @@
         │   ├── operator_loc: (554...557) = "||="
         │   └── value:
         │       @ StringNode (location: (558...561))
+        │       ├── flags: ∅
         │       ├── opening_loc: (558...560) = "%("
         │       ├── content_loc: (560...560) = ""
         │       ├── closing_loc: (560...561) = ")"
@@ -833,6 +838,7 @@
         │   │   ├── opening_loc: (566...576) = "<<-HEREDOC"
         │   │   ├── parts: (length: 3)
         │   │   │   ├── @ StringNode (location: (577...579))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── content_loc: (577...579) = "  "
         │   │   │   │   ├── closing_loc: ∅
@@ -842,6 +848,7 @@
         │   │   │   │   ├── statements: ∅
         │   │   │   │   └── closing_loc: (581...582) = "}"
         │   │   │   └── @ StringNode (location: (582...583))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (582...583) = "\n"
         │   │   │       ├── closing_loc: ∅
@@ -863,6 +870,7 @@
         │   │           ├── opening_loc: (595...605) = "<<-HEREDOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (606...608))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (606...608) = "  "
         │   │           │   │   ├── closing_loc: ∅
@@ -872,6 +880,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (610...611) = "}"
         │   │           │   └── @ StringNode (location: (611...612))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (611...612) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -896,6 +905,7 @@
         │   │           ├── opening_loc: (626...636) = "<<-HEREDOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (637...639))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (637...639) = "  "
         │   │           │   │   ├── closing_loc: ∅
@@ -905,6 +915,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (641...642) = "}"
         │   │           │   └── @ StringNode (location: (642...643))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (642...643) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -929,6 +940,7 @@
         │   │           ├── opening_loc: (653...663) = "<<-HEREDOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (673...675))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (673...675) = "  "
         │   │           │   │   ├── closing_loc: ∅
@@ -938,6 +950,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (677...678) = "}"
         │   │           │   └── @ StringNode (location: (678...679))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (678...679) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -968,6 +981,7 @@
                 ├── opening_loc: (694...704) = "<<-HEREDOC"
                 ├── parts: (length: 3)
                 │   ├── @ StringNode (location: (705...707))
+                │   │   ├── flags: ∅
                 │   │   ├── opening_loc: ∅
                 │   │   ├── content_loc: (705...707) = "  "
                 │   │   ├── closing_loc: ∅
@@ -977,6 +991,7 @@
                 │   │   ├── statements: ∅
                 │   │   └── closing_loc: (709...710) = "}"
                 │   └── @ StringNode (location: (710...711))
+                │       ├── flags: ∅
                 │       ├── opening_loc: ∅
                 │       ├── content_loc: (710...711) = "\n"
                 │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/unparser/corpus/literal/def.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/def.txt
@@ -1097,6 +1097,7 @@
         │   │   │       ├── name_loc: (837...841) = "baz:"
         │   │   │       └── value:
         │   │   │           @ StringNode (location: (842...849))
+        │   │   │           ├── flags: ∅
         │   │   │           ├── opening_loc: (842...843) = "\""
         │   │   │           ├── content_loc: (843...848) = "value"
         │   │   │           ├── closing_loc: (848...849) = "\""
@@ -1123,6 +1124,7 @@
         │   │           ├── opening_loc: (864...874) = "<<-HEREDOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (875...879))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (875...879) = "    "
         │   │           │   │   ├── closing_loc: ∅
@@ -1132,6 +1134,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (881...882) = "}"
         │   │           │   └── @ StringNode (location: (882...883))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (882...883) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -1153,6 +1156,7 @@
             │   @ StatementsNode (location: (906...909))
             │   └── body: (length: 1)
             │       └── @ StringNode (location: (906...909))
+            │           ├── flags: ∅
             │           ├── opening_loc: (906...908) = "%("
             │           ├── content_loc: (908...908) = ""
             │           ├── closing_loc: (908...909) = ")"

--- a/test/yarp/snapshots/unparser/corpus/literal/dstr.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/dstr.txt
@@ -18,6 +18,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (13...14) = "}"
         │   │           │   └── @ StringNode (location: (14...15))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (14...15) = "a"
         │   │           │       ├── closing_loc: ∅
@@ -36,6 +37,7 @@
         │   │       │   ├── opening_loc: (31...41) = "<<-HEREDOC"
         │   │       │   ├── parts: (length: 3)
         │   │       │   │   ├── @ StringNode (location: (42...44))
+        │   │       │   │   │   ├── flags: ∅
         │   │       │   │   │   ├── opening_loc: ∅
         │   │       │   │   │   ├── content_loc: (42...44) = "a\n"
         │   │       │   │   │   ├── closing_loc: ∅
@@ -45,6 +47,7 @@
         │   │       │   │   │   ├── statements: ∅
         │   │       │   │   │   └── closing_loc: (46...47) = "}"
         │   │       │   │   └── @ StringNode (location: (47...51))
+        │   │       │   │       ├── flags: ∅
         │   │       │   │       ├── opening_loc: ∅
         │   │       │   │       ├── content_loc: (47...51) = "a\nb\n"
         │   │       │   │       ├── closing_loc: ∅
@@ -66,6 +69,7 @@
         │   ├── opening_loc: (69...79) = "<<-HEREDOC"
         │   ├── parts: (length: 7)
         │   │   ├── @ StringNode (location: (80...89))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (80...89) = "\\\#{}\\\#{}\n"
         │   │   │   ├── closing_loc: ∅
@@ -75,6 +79,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (91...92) = "}"
         │   │   ├── @ StringNode (location: (92...93))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (92...93) = "\n"
         │   │   │   ├── closing_loc: ∅
@@ -84,6 +89,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (95...96) = "}"
         │   │   ├── @ StringNode (location: (96...97))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (96...97) = "\n"
         │   │   │   ├── closing_loc: ∅
@@ -93,6 +99,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (99...100) = "}"
         │   │   └── @ StringNode (location: (100...101))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (100...101) = "\n"
         │   │       ├── closing_loc: ∅
@@ -108,6 +115,7 @@
         │   │   │   │   ├── statements: ∅
         │   │   │   │   └── closing_loc: (133...134) = "}"
         │   │   │   └── @ StringNode (location: (134...137))
+        │   │   │       ├── flags: ∅
         │   │   │       ├── opening_loc: ∅
         │   │   │       ├── content_loc: (134...137) = "\na\n"
         │   │   │       ├── closing_loc: ∅
@@ -120,6 +128,7 @@
         │   ├── opening_loc: (145...146) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (146...147))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (146...147) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -134,6 +143,7 @@
         │   ├── opening_loc: (152...153) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (153...154))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (153...154) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -148,6 +158,7 @@
         │   ├── opening_loc: (159...160) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (160...161))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (160...161) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -162,6 +173,7 @@
         │   ├── opening_loc: (166...167) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (167...168))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (167...168) = "a"
         │   │   │   ├── closing_loc: ∅
@@ -188,6 +200,7 @@
         │   │                       ├── opening_loc: (191...201) = "<<-HEREDOC"
         │   │                       ├── parts: (length: 3)
         │   │                       │   ├── @ StringNode (location: (202...206))
+        │   │                       │   │   ├── flags: ∅
         │   │                       │   │   ├── opening_loc: ∅
         │   │                       │   │   ├── content_loc: (202...206) = "    "
         │   │                       │   │   ├── closing_loc: ∅
@@ -201,6 +214,7 @@
         │   │                       │   │   │           └── flags: decimal
         │   │                       │   │   └── closing_loc: (210...211) = "}"
         │   │                       │   └── @ StringNode (location: (211...212))
+        │   │                       │       ├── flags: ∅
         │   │                       │       ├── opening_loc: ∅
         │   │                       │       ├── content_loc: (211...212) = "\n"
         │   │                       │       ├── closing_loc: ∅
@@ -220,6 +234,7 @@
         │   │           ├── opening_loc: (230...240) = "<<-HEREDOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (242...244))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (242...244) = "  "
         │   │           │   │   ├── closing_loc: ∅
@@ -241,6 +256,7 @@
         │   │           │   │   │           └── name: "bar"
         │   │           │   │   └── closing_loc: (249...250) = "}"
         │   │           │   └── @ StringNode (location: (250...251))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (250...251) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -262,6 +278,7 @@
             │           ├── opening_loc: (263...273) = "<<-HEREDOC"
             │           ├── parts: (length: 3)
             │           │   ├── @ StringNode (location: (281...283))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: ∅
             │           │   │   ├── content_loc: (281...283) = "  "
             │           │   │   ├── closing_loc: ∅
@@ -283,6 +300,7 @@
             │           │   │   │           └── name: "bar"
             │           │   │   └── closing_loc: (288...289) = "}"
             │           │   └── @ StringNode (location: (289...290))
+            │           │       ├── flags: ∅
             │           │       ├── opening_loc: ∅
             │           │       ├── content_loc: (289...290) = "\n"
             │           │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/unparser/corpus/literal/literal.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/literal.txt
@@ -9,6 +9,7 @@
         │   │   ├── @ AssocNode (location: (2...21))
         │   │   │   ├── key:
         │   │   │   │   @ StringNode (location: (2...7))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (2...3) = "\""
         │   │   │   │   ├── content_loc: (3...6) = "foo"
         │   │   │   │   ├── closing_loc: (6...7) = "\""
@@ -18,6 +19,7 @@
         │   │   │   │   ├── opening_loc: (11...21) = "<<-HEREDOC"
         │   │   │   │   ├── parts: (length: 3)
         │   │   │   │   │   ├── @ StringNode (location: (39...41))
+        │   │   │   │   │   │   ├── flags: ∅
         │   │   │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   │   │   ├── content_loc: (39...41) = "  "
         │   │   │   │   │   │   ├── closing_loc: ∅
@@ -27,6 +29,7 @@
         │   │   │   │   │   │   ├── statements: ∅
         │   │   │   │   │   │   └── closing_loc: (43...44) = "}"
         │   │   │   │   │   └── @ StringNode (location: (44...45))
+        │   │   │   │   │       ├── flags: ∅
         │   │   │   │   │       ├── opening_loc: ∅
         │   │   │   │   │       ├── content_loc: (44...45) = "\n"
         │   │   │   │   │       ├── closing_loc: ∅
@@ -36,6 +39,7 @@
         │   │   └── @ AssocNode (location: (23...36))
         │   │       ├── key:
         │   │       │   @ StringNode (location: (23...28))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (23...24) = "\""
         │   │       │   ├── content_loc: (24...27) = "bar"
         │   │       │   ├── closing_loc: (27...28) = "\""
@@ -54,12 +58,14 @@
         │   │   ├── @ AssocNode (location: (55...67))
         │   │   │   ├── key:
         │   │   │   │   @ StringNode (location: (55...60))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (55...56) = "\""
         │   │   │   │   ├── content_loc: (56...59) = "foo"
         │   │   │   │   ├── closing_loc: (59...60) = "\""
         │   │   │   │   └── unescaped: "foo"
         │   │   │   ├── value:
         │   │   │   │   @ StringNode (location: (64...67))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (64...66) = "%("
         │   │   │   │   ├── content_loc: (66...66) = ""
         │   │   │   │   ├── closing_loc: (66...67) = ")"
@@ -68,6 +74,7 @@
         │   │   └── @ AssocNode (location: (69...82))
         │   │       ├── key:
         │   │       │   @ StringNode (location: (69...74))
+        │   │       │   ├── flags: ∅
         │   │       │   ├── opening_loc: (69...70) = "\""
         │   │       │   ├── content_loc: (70...73) = "bar"
         │   │       │   ├── closing_loc: (73...74) = "\""
@@ -83,11 +90,13 @@
         ├── @ ArrayNode (location: (85...97))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (86...91))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (86...87) = "\""
         │   │   │   ├── content_loc: (87...90) = "foo"
         │   │   │   ├── closing_loc: (90...91) = "\""
         │   │   │   └── unescaped: "foo"
         │   │   └── @ StringNode (location: (93...96))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: (93...95) = "%("
         │   │       ├── content_loc: (95...95) = ""
         │   │       ├── closing_loc: (95...96) = ")"
@@ -108,6 +117,7 @@
         │   │   │           ├── opening_loc: (100...110) = "<<-HEREDOC"
         │   │   │           ├── parts: (length: 3)
         │   │   │           │   ├── @ StringNode (location: (114...116))
+        │   │   │           │   │   ├── flags: ∅
         │   │   │           │   │   ├── opening_loc: ∅
         │   │   │           │   │   ├── content_loc: (114...116) = "  "
         │   │   │           │   │   ├── closing_loc: ∅
@@ -117,6 +127,7 @@
         │   │   │           │   │   ├── statements: ∅
         │   │   │           │   │   └── closing_loc: (118...119) = "}"
         │   │   │           │   └── @ StringNode (location: (119...120))
+        │   │   │           │       ├── flags: ∅
         │   │   │           │       ├── opening_loc: ∅
         │   │   │           │       ├── content_loc: (119...120) = "\n"
         │   │   │           │       ├── closing_loc: ∅
@@ -145,6 +156,7 @@
         │   │   │   @ ArgumentsNode (location: (130...133))
         │   │   │   └── arguments: (length: 1)
         │   │   │       └── @ StringNode (location: (130...133))
+        │   │   │           ├── flags: ∅
         │   │   │           ├── opening_loc: (130...132) = "%("
         │   │   │           ├── content_loc: (132...132) = ""
         │   │   │           ├── closing_loc: (132...133) = ")"
@@ -167,6 +179,7 @@
         │   │   ├── @ AssocNode (location: (139...158))
         │   │   │   ├── key:
         │   │   │   │   @ StringNode (location: (139...144))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (139...140) = "\""
         │   │   │   │   ├── content_loc: (140...143) = "foo"
         │   │   │   │   ├── closing_loc: (143...144) = "\""
@@ -176,6 +189,7 @@
         │   │   │   │   ├── opening_loc: (148...158) = "<<-HEREDOC"
         │   │   │   │   ├── parts: (length: 3)
         │   │   │   │   │   ├── @ StringNode (location: (168...170))
+        │   │   │   │   │   │   ├── flags: ∅
         │   │   │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   │   │   ├── content_loc: (168...170) = "  "
         │   │   │   │   │   │   ├── closing_loc: ∅
@@ -185,6 +199,7 @@
         │   │   │   │   │   │   ├── statements: ∅
         │   │   │   │   │   │   └── closing_loc: (172...173) = "}"
         │   │   │   │   │   └── @ StringNode (location: (173...174))
+        │   │   │   │   │       ├── flags: ∅
         │   │   │   │   │       ├── opening_loc: ∅
         │   │   │   │   │       ├── content_loc: (173...174) = "\n"
         │   │   │   │   │       ├── closing_loc: ∅
@@ -211,12 +226,14 @@
         │   │   ├── @ AssocNode (location: (184...196))
         │   │   │   ├── key:
         │   │   │   │   @ StringNode (location: (184...189))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (184...185) = "\""
         │   │   │   │   ├── content_loc: (185...188) = "foo"
         │   │   │   │   ├── closing_loc: (188...189) = "\""
         │   │   │   │   └── unescaped: "foo"
         │   │   │   ├── value:
         │   │   │   │   @ StringNode (location: (193...196))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: (193...195) = "%("
         │   │   │   │   ├── content_loc: (195...195) = ""
         │   │   │   │   ├── closing_loc: (195...196) = ")"
@@ -245,6 +262,7 @@
         │   │   │       @ InstanceVariableReadNode (location: (208...210))
         │   │   │       └── name: :@a
         │   │   ├── @ StringNode (location: (210...211))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (210...211) = " "
         │   │   │   ├── closing_loc: ∅
@@ -255,6 +273,7 @@
         │   │   │       @ ClassVariableReadNode (location: (212...215))
         │   │   │       └── name: :@@a
         │   │   ├── @ StringNode (location: (215...216))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (215...216) = " "
         │   │   │   ├── closing_loc: ∅
@@ -320,12 +339,14 @@
         ├── @ StringConcatNode (location: (299...310))
         │   ├── left:
         │   │   @ StringNode (location: (299...304))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (299...300) = "\""
         │   │   ├── content_loc: (300...303) = "foo"
         │   │   ├── closing_loc: (303...304) = "\""
         │   │   └── unescaped: "foo"
         │   └── right:
         │       @ StringNode (location: (305...310))
+        │       ├── flags: ∅
         │       ├── opening_loc: (305...306) = "\""
         │       ├── content_loc: (306...309) = "bar"
         │       ├── closing_loc: (309...310) = "\""
@@ -334,6 +355,7 @@
         │   ├── opening_loc: (311...312) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (312...319))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (312...319) = "foobar "
         │   │   │   ├── closing_loc: ∅
@@ -359,6 +381,7 @@
         │   ├── opening_loc: (327...328) = "\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (328...331))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (328...331) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -372,6 +395,7 @@
         │   │   │   │           └── flags: decimal
         │   │   │   └── closing_loc: (334...335) = "}"
         │   │   └── @ StringNode (location: (335...338))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (335...338) = "bar"
         │   │       ├── closing_loc: ∅
@@ -381,6 +405,7 @@
         │   ├── opening_loc: (340...341) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (341...345))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (341...345) = "\\\\\\\\"
         │   │   │   ├── closing_loc: ∅
@@ -398,6 +423,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (353...354) = "}"
         │   │   └── @ StringNode (location: (354...358))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (354...358) = "\\\#{}"
         │   │       ├── closing_loc: ∅
@@ -407,6 +433,7 @@
         │   ├── opening_loc: (360...361) = "\""
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (361...365))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (361...365) = "\\\#{}"
         │   │   │   ├── closing_loc: ∅
@@ -417,21 +444,25 @@
         │   │       └── closing_loc: (367...368) = "}"
         │   └── closing_loc: (368...369) = "\""
         ├── @ StringNode (location: (370...385))
+        │   ├── flags: ∅
         │   ├── opening_loc: (370...371) = "\""
         │   ├── content_loc: (371...384) = "foo\\\\\\\#{@bar}"
         │   ├── closing_loc: (384...385) = "\""
         │   └── unescaped: "foo\\\#{@bar}"
         ├── @ StringNode (location: (386...390))
+        │   ├── flags: ∅
         │   ├── opening_loc: (386...387) = "\""
         │   ├── content_loc: (387...389) = "\\\""
         │   ├── closing_loc: (389...390) = "\""
         │   └── unescaped: "\""
         ├── @ StringNode (location: (391...400))
+        │   ├── flags: ∅
         │   ├── opening_loc: (391...392) = "\""
         │   ├── content_loc: (392...399) = "foo bar"
         │   ├── closing_loc: (399...400) = "\""
         │   └── unescaped: "foo bar"
         ├── @ StringNode (location: (401...411))
+        │   ├── flags: ∅
         │   ├── opening_loc: (401...402) = "\""
         │   ├── content_loc: (402...410) = "foo\\nbar"
         │   ├── closing_loc: (410...411) = "\""
@@ -445,6 +476,7 @@
         │   ├── opening_loc: (418...419) = "`"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (419...422))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (419...422) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -519,6 +551,7 @@
         │   ├── opening_loc: (515...516) = "/"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (516...519))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (516...519) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -537,6 +570,7 @@
         │   ├── opening_loc: (528...529) = "/"
         │   ├── parts: (length: 2)
         │   │   ├── @ StringNode (location: (529...532))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (529...532) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -560,6 +594,7 @@
         │   │       │   @ StatementsNode (location: (547...555))
         │   │       │   └── body: (length: 1)
         │   │       │       └── @ StringNode (location: (547...555))
+        │   │       │           ├── flags: ∅
         │   │       │           ├── opening_loc: (547...548) = "\""
         │   │       │           ├── content_loc: (548...554) = "\\u0000"
         │   │       │           ├── closing_loc: (554...555) = "\""
@@ -595,6 +630,7 @@
         │   ├── opening_loc: (582...584) = ":\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (584...587))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (584...587) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -616,6 +652,7 @@
         │   │   │   │           └── name: "bar"
         │   │   │   └── closing_loc: (592...593) = "}"
         │   │   └── @ StringNode (location: (593...596))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (593...596) = "baz"
         │   │       ├── closing_loc: ∅
@@ -630,6 +667,7 @@
         │   │       │   @ StatementsNode (location: (602...607))
         │   │       │   └── body: (length: 1)
         │   │       │       └── @ StringNode (location: (602...607))
+        │   │       │           ├── flags: ∅
         │   │       │           ├── opening_loc: (602...603) = "\""
         │   │       │           ├── content_loc: (603...606) = "foo"
         │   │       │           ├── closing_loc: (606...607) = "\""
@@ -973,6 +1011,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (860...861) = "}"
         │   │   ├── @ StringNode (location: (861...862))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (861...862) = "\n"
         │   │   │   ├── closing_loc: ∅
@@ -982,6 +1021,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (864...865) = "}"
         │   │   └── @ StringNode (location: (865...868))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (865...868) = "\\na"
         │   │       ├── closing_loc: ∅
@@ -1009,6 +1049,7 @@
         │   │   │           │   │   ├── statements: ∅
         │   │   │           │   │   └── closing_loc: (881...882) = "}"
         │   │   │           │   ├── @ StringNode (location: (882...883))
+        │   │   │           │   │   ├── flags: ∅
         │   │   │           │   │   ├── opening_loc: ∅
         │   │   │           │   │   ├── content_loc: (882...883) = "\n"
         │   │   │           │   │   ├── closing_loc: ∅
@@ -1018,6 +1059,7 @@
         │   │   │           │   │   ├── statements: ∅
         │   │   │           │   │   └── closing_loc: (885...886) = "}"
         │   │   │           │   └── @ StringNode (location: (886...889))
+        │   │   │           │       ├── flags: ∅
         │   │   │           │       ├── opening_loc: ∅
         │   │   │           │       ├── content_loc: (886...889) = "\\na"
         │   │   │           │       ├── closing_loc: ∅
@@ -1036,6 +1078,7 @@
             ├── opening_loc: (902...903) = "`"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (903...907))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (903...907) = "  x\n"
             │   │   ├── closing_loc: ∅
@@ -1057,6 +1100,7 @@
             │   │   │           └── name: "foo"
             │   │   └── closing_loc: (912...913) = "}"
             │   └── @ StringNode (location: (913...915))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (913...915) = "\n#"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/unparser/corpus/literal/send.txt
+++ b/test/yarp/snapshots/unparser/corpus/literal/send.txt
@@ -1280,6 +1280,7 @@
         │   │               └── @ AssocNode (location: (710...722))
         │   │                   ├── key:
         │   │                   │   @ StringNode (location: (710...715))
+        │   │                   │   ├── flags: ∅
         │   │                   │   ├── opening_loc: (710...711) = "\""
         │   │                   │   ├── content_loc: (711...714) = "baz"
         │   │                   │   ├── closing_loc: (714...715) = "\""

--- a/test/yarp/snapshots/unparser/corpus/semantic/block.txt
+++ b/test/yarp/snapshots/unparser/corpus/semantic/block.txt
@@ -114,6 +114,7 @@
         │   │   @ ArgumentsNode (location: (86...92))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (86...92))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (86...92) = "<<-DOC"
         │   │           ├── content_loc: (101...105) = "  b\n"
         │   │           ├── closing_loc: (105...109) = "DOC\n"
@@ -157,6 +158,7 @@
             │   @ ArgumentsNode (location: (122...128))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (122...128))
+            │           ├── flags: ∅
             │           ├── opening_loc: (122...128) = "<<-DOC"
             │           ├── content_loc: (133...137) = "  b\n"
             │           ├── closing_loc: (137...141) = "DOC\n"

--- a/test/yarp/snapshots/unparser/corpus/semantic/dstr.txt
+++ b/test/yarp/snapshots/unparser/corpus/semantic/dstr.txt
@@ -4,31 +4,37 @@
     @ StatementsNode (location: (0...608))
     └── body: (length: 33)
         ├── @ StringNode (location: (0...5))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...5) = "<<DOC"
         │   ├── content_loc: (6...6) = ""
         │   ├── closing_loc: (6...10) = "DOC\n"
         │   └── unescaped: ""
         ├── @ StringNode (location: (11...18))
+        │   ├── flags: ∅
         │   ├── opening_loc: (11...18) = "<<'DOC'"
         │   ├── content_loc: (19...19) = ""
         │   ├── closing_loc: (19...23) = "DOC\n"
         │   └── unescaped: ""
         ├── @ StringNode (location: (24...30))
+        │   ├── flags: ∅
         │   ├── opening_loc: (24...30) = "<<~DOC"
         │   ├── content_loc: (31...31) = ""
         │   ├── closing_loc: (31...35) = "DOC\n"
         │   └── unescaped: ""
         ├── @ StringNode (location: (36...44))
+        │   ├── flags: ∅
         │   ├── opening_loc: (36...44) = "<<~'DOC'"
         │   ├── content_loc: (45...45) = ""
         │   ├── closing_loc: (45...49) = "DOC\n"
         │   └── unescaped: ""
         ├── @ StringNode (location: (50...55))
+        │   ├── flags: ∅
         │   ├── opening_loc: (50...55) = "<<DOC"
         │   ├── content_loc: (56...60) = "  a\n"
         │   ├── closing_loc: (60...64) = "DOC\n"
         │   └── unescaped: "  a\n"
         ├── @ StringNode (location: (65...72))
+        │   ├── flags: ∅
         │   ├── opening_loc: (65...72) = "<<'DOC'"
         │   ├── content_loc: (73...77) = "  a\n"
         │   ├── closing_loc: (77...81) = "DOC\n"
@@ -37,6 +43,7 @@
         │   ├── opening_loc: (82...87) = "<<DOC"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (88...94))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (88...94) = "  a\n  "
         │   │   │   ├── closing_loc: ∅
@@ -46,6 +53,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (96...97) = "}"
         │   │   └── @ StringNode (location: (97...98))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (97...98) = "\n"
         │   │       ├── closing_loc: ∅
@@ -55,6 +63,7 @@
         │   ├── opening_loc: (103...109) = "<<~DOC"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (110...116))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (110...116) = "  a\n  "
         │   │   │   ├── closing_loc: ∅
@@ -64,6 +73,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (118...119) = "}"
         │   │   └── @ StringNode (location: (119...120))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (119...120) = "\n"
         │   │       ├── closing_loc: ∅
@@ -73,6 +83,7 @@
         │   ├── opening_loc: (125...131) = "<<~DOC"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (132...138))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (132...138) = "  a\n  "
         │   │   │   ├── closing_loc: ∅
@@ -82,27 +93,32 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (140...141) = "}"
         │   │   └── @ StringNode (location: (141...146))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (141...146) = "\n  b\n"
         │   │       ├── closing_loc: ∅
         │   │       └── unescaped: "\nb\n"
         │   └── closing_loc: (146...150) = "DOC\n"
         ├── @ StringNode (location: (151...157))
+        │   ├── flags: ∅
         │   ├── opening_loc: (151...157) = "<<~DOC"
         │   ├── content_loc: (158...168) = "  a\n    b\n"
         │   ├── closing_loc: (168...172) = "DOC\n"
         │   └── unescaped: "a\n  b\n"
         ├── @ StringNode (location: (173...180))
+        │   ├── flags: ∅
         │   ├── opening_loc: (173...180) = "<<'DOC'"
         │   ├── content_loc: (181...186) = "a\n\nb\n"
         │   ├── closing_loc: (186...190) = "DOC\n"
         │   └── unescaped: "a\n\nb\n"
         ├── @ StringNode (location: (191...198))
+        │   ├── flags: ∅
         │   ├── opening_loc: (191...198) = "<<'DOC'"
         │   ├── content_loc: (199...206) = " a\n\n b\n"
         │   ├── closing_loc: (206...210) = "DOC\n"
         │   └── unescaped: " a\n\n b\n"
         ├── @ StringNode (location: (211...218))
+        │   ├── flags: ∅
         │   ├── opening_loc: (211...218) = "<<'DOC'"
         │   ├── content_loc: (219...225) = " a\\nb\n"
         │   ├── closing_loc: (225...229) = "DOC\n"
@@ -115,6 +131,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (238...239) = "}"
         │   │   ├── @ StringNode (location: (239...242))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (239...242) = "a\n "
         │   │   │   ├── closing_loc: ∅
@@ -124,6 +141,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (244...245) = "}"
         │   │   └── @ StringNode (location: (245...247))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (245...247) = "a\n"
         │   │       ├── closing_loc: ∅
@@ -133,6 +151,7 @@
         │   ├── opening_loc: (252...257) = "<<DOC"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (258...260))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (258...260) = "  "
         │   │   │   ├── closing_loc: ∅
@@ -142,6 +161,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (262...263) = "}"
         │   │   └── @ StringNode (location: (263...271))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (263...271) = "\n  \\\#{}\n"
         │   │       ├── closing_loc: ∅
@@ -151,6 +171,7 @@
         │   ├── opening_loc: (276...281) = "<<DOC"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (282...284))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (282...284) = " a"
         │   │   │   ├── closing_loc: ∅
@@ -160,6 +181,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (286...287) = "}"
         │   │   └── @ StringNode (location: (287...292))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (287...292) = "b\n c\n"
         │   │       ├── closing_loc: ∅
@@ -173,6 +195,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (308...309) = "}"
         │   │   └── @ StringNode (location: (309...310))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (309...310) = "\n"
         │   │       ├── closing_loc: ∅
@@ -193,6 +216,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (338...339) = "}"
         │   │           │   └── @ StringNode (location: (339...340))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (339...340) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -211,6 +235,7 @@
         │   │           ├── opening_loc: (361...367) = "<<~DOC"
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (368...373))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (368...373) = "    b"
         │   │           │   │   ├── closing_loc: ∅
@@ -220,6 +245,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (375...376) = "}"
         │   │           │   └── @ StringNode (location: (376...377))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (376...377) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -242,6 +268,7 @@
         │   │           │   │   ├── statements: ∅
         │   │           │   │   └── closing_loc: (411...412) = "}"
         │   │           │   └── @ StringNode (location: (412...414))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (412...414) = "a\n"
         │   │           │       ├── closing_loc: ∅
@@ -257,6 +284,7 @@
         │   │   @ StatementsNode (location: (435...443))
         │   │   └── body: (length: 1)
         │   │       └── @ StringNode (location: (435...443))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (435...443) = "<<-'DOC'"
         │   │           ├── content_loc: (444...455) = "   a\n\n   b\n"
         │   │           ├── closing_loc: (455...461) = "  DOC\n"
@@ -271,6 +299,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (469...470) = "}"
         │   │   └── @ StringNode (location: (470...471))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (470...471) = "a"
         │   │       ├── closing_loc: ∅
@@ -280,6 +309,7 @@
         │   ├── opening_loc: (474...476) = "%("
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (476...479))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (476...479) = "\\n\""
         │   │   │   ├── closing_loc: ∅
@@ -289,6 +319,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (481...482) = "}"
         │   │   └── @ StringNode (location: (482...485))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (482...485) = "\"\\n"
         │   │       ├── closing_loc: ∅
@@ -298,6 +329,7 @@
         │   ├── opening_loc: (488...491) = "%Q("
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (491...495))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (491...495) = "-\\n\""
         │   │   │   ├── closing_loc: ∅
@@ -307,6 +339,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (497...498) = "}"
         │   │   └── @ StringNode (location: (498...501))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (498...501) = "\"\\n"
         │   │       ├── closing_loc: ∅
@@ -316,6 +349,7 @@
         │   ├── opening_loc: (504...505) = "\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (505...507))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (505...507) = "a\n"
         │   │   │   ├── closing_loc: ∅
@@ -325,6 +359,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (509...510) = "}"
         │   │   └── @ StringNode (location: (510...512))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (510...512) = "\nb"
         │   │       ├── closing_loc: ∅
@@ -334,6 +369,7 @@
         │   ├── opening_loc: (515...516) = "\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (516...519))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (516...519) = "a\\n"
         │   │   │   ├── closing_loc: ∅
@@ -343,6 +379,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (521...522) = "}"
         │   │   └── @ StringNode (location: (522...524))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (522...524) = "\nb"
         │   │       ├── closing_loc: ∅
@@ -352,6 +389,7 @@
         │   ├── opening_loc: (527...528) = "\""
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (528...530))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (528...530) = "a\n"
         │   │   │   ├── closing_loc: ∅
@@ -361,6 +399,7 @@
         │   │   │   ├── statements: ∅
         │   │   │   └── closing_loc: (532...533) = "}"
         │   │   └── @ StringNode (location: (533...536))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (533...536) = "\\nb"
         │   │       ├── closing_loc: ∅
@@ -369,6 +408,7 @@
         ├── @ StringConcatNode (location: (539...550))
         │   ├── left:
         │   │   @ StringNode (location: (539...542))
+        │   │   ├── flags: ∅
         │   │   ├── opening_loc: (539...540) = "'"
         │   │   ├── content_loc: (540...541) = "a"
         │   │   ├── closing_loc: (541...542) = "'"
@@ -387,18 +427,21 @@
         │   │   @ StringConcatNode (location: (552...557))
         │   │   ├── left:
         │   │   │   @ StringNode (location: (552...554))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: (552...553) = "\""
         │   │   │   ├── content_loc: (553...553) = ""
         │   │   │   ├── closing_loc: (553...554) = "\""
         │   │   │   └── unescaped: ""
         │   │   └── right:
         │   │       @ StringNode (location: (555...557))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: (555...556) = "\""
         │   │       ├── content_loc: (556...556) = ""
         │   │       ├── closing_loc: (556...557) = "\""
         │   │       └── unescaped: ""
         │   └── right:
         │       @ StringNode (location: (558...560))
+        │       ├── flags: ∅
         │       ├── opening_loc: (558...559) = "\""
         │       ├── content_loc: (559...559) = ""
         │       ├── closing_loc: (559...560) = "\""
@@ -409,6 +452,7 @@
         │   │   ├── opening_loc: (562...563) = "\""
         │   │   ├── parts: (length: 2)
         │   │   │   ├── @ StringNode (location: (563...564))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── content_loc: (563...564) = "a"
         │   │   │   │   ├── closing_loc: ∅
@@ -424,6 +468,7 @@
         │   │   └── closing_loc: (569...570) = "\""
         │   └── right:
         │       @ StringNode (location: (571...574))
+        │       ├── flags: ∅
         │       ├── opening_loc: (571...572) = "\""
         │       ├── content_loc: (572...573) = "b"
         │       ├── closing_loc: (573...574) = "\""
@@ -434,6 +479,7 @@
         │   │   ├── opening_loc: (575...576) = "\""
         │   │   ├── parts: (length: 2)
         │   │   │   ├── @ StringNode (location: (576...577))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── content_loc: (576...577) = "a"
         │   │   │   │   ├── closing_loc: ∅
@@ -446,6 +492,7 @@
         │   │   └── closing_loc: (580...581) = "\""
         │   └── right:
         │       @ StringNode (location: (582...585))
+        │       ├── flags: ∅
         │       ├── opening_loc: (582...583) = "\""
         │       ├── content_loc: (583...584) = "b"
         │       ├── closing_loc: (584...585) = "\""
@@ -456,6 +503,7 @@
         │   │   ├── opening_loc: (586...587) = "\""
         │   │   ├── parts: (length: 2)
         │   │   │   ├── @ StringNode (location: (587...588))
+        │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── opening_loc: ∅
         │   │   │   │   ├── content_loc: (587...588) = "a"
         │   │   │   │   ├── closing_loc: ∅
@@ -468,6 +516,7 @@
         │   │   └── closing_loc: (591...592) = "\""
         │   └── right:
         │       @ StringNode (location: (593...596))
+        │       ├── flags: ∅
         │       ├── opening_loc: (593...594) = "\""
         │       ├── content_loc: (594...595) = "b"
         │       ├── closing_loc: (595...596) = "\""
@@ -478,6 +527,7 @@
             │   ├── opening_loc: (597...598) = "\""
             │   ├── parts: (length: 2)
             │   │   ├── @ StringNode (location: (598...599))
+            │   │   │   ├── flags: ∅
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── content_loc: (598...599) = "a"
             │   │   │   ├── closing_loc: ∅
@@ -490,6 +540,7 @@
             │   └── closing_loc: (603...604) = "\""
             └── right:
                 @ StringNode (location: (605...608))
+                ├── flags: ∅
                 ├── opening_loc: (605...606) = "\""
                 ├── content_loc: (606...607) = "b"
                 ├── closing_loc: (607...608) = "\""

--- a/test/yarp/snapshots/unparser/corpus/semantic/literal.txt
+++ b/test/yarp/snapshots/unparser/corpus/semantic/literal.txt
@@ -18,6 +18,7 @@
         ├── @ FloatNode (location: (24...38))
         ├── @ FloatNode (location: (39...54))
         ├── @ StringNode (location: (55...57))
+        │   ├── flags: ∅
         │   ├── opening_loc: (55...56) = "?"
         │   ├── content_loc: (56...57) = "c"
         │   ├── closing_loc: ∅
@@ -46,6 +47,7 @@
         │   │   │   │           └── name: :@bar
         │   │   │   └── closing_loc: (80...81) = "}"
         │   │   └── @ StringNode (location: (81...84))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (81...84) = "baz"
         │   │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/unparser/corpus/semantic/while.txt
+++ b/test/yarp/snapshots/unparser/corpus/semantic/while.txt
@@ -186,6 +186,7 @@
         │   │   │   @ ArgumentsNode (location: (108...114))
         │   │   │   └── arguments: (length: 1)
         │   │   │       └── @ StringNode (location: (108...114))
+        │   │   │           ├── flags: ∅
         │   │   │           ├── opening_loc: (108...114) = "<<-FOO"
         │   │   │           ├── content_loc: (119...119) = ""
         │   │   │           ├── closing_loc: (119...123) = "FOO\n"

--- a/test/yarp/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
+++ b/test/yarp/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
@@ -38,6 +38,7 @@
             │           │   @ ArgumentsNode (location: (8...10))
             │           │   └── arguments: (length: 1)
             │           │       └── @ StringNode (location: (8...10))
+            │           │           ├── flags: ∅
             │           │           ├── opening_loc: (8...9) = "'"
             │           │           ├── content_loc: (9...9) = ""
             │           │           ├── closing_loc: (9...10) = "'"

--- a/test/yarp/snapshots/whitequark/array_symbols_interp.txt
+++ b/test/yarp/snapshots/whitequark/array_symbols_interp.txt
@@ -38,6 +38,7 @@
             │       ├── opening_loc: ∅
             │       ├── parts: (length: 2)
             │       │   ├── @ StringNode (location: (19...22))
+            │       │   │   ├── flags: ∅
             │       │   │   ├── opening_loc: ∅
             │       │   │   ├── content_loc: (19...22) = "foo"
             │       │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/array_words.txt
+++ b/test/yarp/snapshots/whitequark/array_words.txt
@@ -6,11 +6,13 @@
         └── @ ArrayNode (location: (0...11))
             ├── elements: (length: 2)
             │   ├── @ StringNode (location: (3...6))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (3...6) = "foo"
             │   │   ├── closing_loc: ∅
             │   │   └── unescaped: "foo"
             │   └── @ StringNode (location: (7...10))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (7...10) = "bar"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/array_words_interp.txt
+++ b/test/yarp/snapshots/whitequark/array_words_interp.txt
@@ -6,6 +6,7 @@
         ├── @ ArrayNode (location: (0...14))
         │   ├── elements: (length: 2)
         │   │   ├── @ StringNode (location: (3...6))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (3...6) = "foo"
         │   │   │   ├── closing_loc: ∅
@@ -35,6 +36,7 @@
         └── @ ArrayNode (location: (16...38))
             ├── elements: (length: 2)
             │   ├── @ StringNode (location: (19...22))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (19...22) = "foo"
             │   │   ├── closing_loc: ∅
@@ -59,6 +61,7 @@
             │       │   │   │           └── name: "bar"
             │       │   │   └── closing_loc: (28...29) = "}"
             │       │   ├── @ StringNode (location: (29...32))
+            │       │   │   ├── flags: ∅
             │       │   │   ├── opening_loc: ∅
             │       │   │   ├── content_loc: (29...32) = "foo"
             │       │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/bug_ascii_8bit_in_literal.txt
+++ b/test/yarp/snapshots/whitequark/bug_ascii_8bit_in_literal.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (24...90))
     └── body: (length: 1)
         └── @ StringNode (location: (24...90))
+            ├── flags: ∅
             ├── opening_loc: (24...25) = "\""
             ├── content_loc: (25...89) = "\\xD0\\xBF\\xD1\\x80\\xD0\\xBE\\xD0\\xB2\\xD0\\xB5\\xD1\\x80\\xD0\\xBA\\xD0\\xB0"
             ├── closing_loc: (89...90) = "\""

--- a/test/yarp/snapshots/whitequark/bug_cmd_string_lookahead.txt
+++ b/test/yarp/snapshots/whitequark/bug_cmd_string_lookahead.txt
@@ -12,6 +12,7 @@
             │   @ ArgumentsNode (location: (5...10))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (5...10))
+            │           ├── flags: ∅
             │           ├── opening_loc: (5...6) = "\""
             │           ├── content_loc: (6...9) = "foo"
             │           ├── closing_loc: (9...10) = "\""

--- a/test/yarp/snapshots/whitequark/bug_heredoc_do.txt
+++ b/test/yarp/snapshots/whitequark/bug_heredoc_do.txt
@@ -12,6 +12,7 @@
             │   @ ArgumentsNode (location: (2...10))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (2...10))
+            │           ├── flags: ∅
             │           ├── opening_loc: (2...10) = "<<-TABLE"
             │           ├── content_loc: (14...14) = ""
             │           ├── closing_loc: (14...20) = "TABLE\n"

--- a/test/yarp/snapshots/whitequark/case_cond.txt
+++ b/test/yarp/snapshots/whitequark/case_cond.txt
@@ -23,6 +23,7 @@
             │           @ StatementsNode (location: (16...21))
             │           └── body: (length: 1)
             │               └── @ StringNode (location: (16...21))
+            │                   ├── flags: ∅
             │                   ├── opening_loc: (16...17) = "'"
             │                   ├── content_loc: (17...20) = "foo"
             │                   ├── closing_loc: (20...21) = "'"

--- a/test/yarp/snapshots/whitequark/case_cond_else.txt
+++ b/test/yarp/snapshots/whitequark/case_cond_else.txt
@@ -23,6 +23,7 @@
             │           @ StatementsNode (location: (16...21))
             │           └── body: (length: 1)
             │               └── @ StringNode (location: (16...21))
+            │                   ├── flags: ∅
             │                   ├── opening_loc: (16...17) = "'"
             │                   ├── content_loc: (17...20) = "foo"
             │                   ├── closing_loc: (20...21) = "'"
@@ -34,6 +35,7 @@
             │   │   @ StatementsNode (location: (28...33))
             │   │   └── body: (length: 1)
             │   │       └── @ StringNode (location: (28...33))
+            │   │           ├── flags: ∅
             │   │           ├── opening_loc: (28...29) = "'"
             │   │           ├── content_loc: (29...32) = "bar"
             │   │           ├── closing_loc: (32...33) = "'"

--- a/test/yarp/snapshots/whitequark/case_expr.txt
+++ b/test/yarp/snapshots/whitequark/case_expr.txt
@@ -20,6 +20,7 @@
             │       ├── keyword_loc: (10...14) = "when"
             │       ├── conditions: (length: 1)
             │       │   └── @ StringNode (location: (15...20))
+            │       │       ├── flags: ∅
             │       │       ├── opening_loc: (15...16) = "'"
             │       │       ├── content_loc: (16...19) = "bar"
             │       │       ├── closing_loc: (19...20) = "'"

--- a/test/yarp/snapshots/whitequark/case_expr_else.txt
+++ b/test/yarp/snapshots/whitequark/case_expr_else.txt
@@ -20,6 +20,7 @@
             │       ├── keyword_loc: (10...14) = "when"
             │       ├── conditions: (length: 1)
             │       │   └── @ StringNode (location: (15...20))
+            │       │       ├── flags: ∅
             │       │       ├── opening_loc: (15...16) = "'"
             │       │       ├── content_loc: (16...19) = "bar"
             │       │       ├── closing_loc: (19...20) = "'"

--- a/test/yarp/snapshots/whitequark/character.txt
+++ b/test/yarp/snapshots/whitequark/character.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...2))
     └── body: (length: 1)
         └── @ StringNode (location: (0...2))
+            ├── flags: ∅
             ├── opening_loc: (0...1) = "?"
             ├── content_loc: (1...2) = "a"
             ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/dedenting_heredoc.txt
+++ b/test/yarp/snapshots/whitequark/dedenting_heredoc.txt
@@ -15,6 +15,7 @@
         │   │           ├── opening_loc: (2...8) = "<<~\"E\""
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (9...17))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (9...17) = "    x\n  "
         │   │           │   │   ├── closing_loc: ∅
@@ -25,12 +26,14 @@
         │   │           │   │   │   @ StatementsNode (location: (19...24))
         │   │           │   │   │   └── body: (length: 1)
         │   │           │   │   │       └── @ StringNode (location: (19...24))
+        │   │           │   │   │           ├── flags: ∅
         │   │           │   │   │           ├── opening_loc: (19...20) = "\""
         │   │           │   │   │           ├── content_loc: (20...23) = "  y"
         │   │           │   │   │           ├── closing_loc: (23...24) = "\""
         │   │           │   │   │           └── unescaped: "  y"
         │   │           │   │   └── closing_loc: (24...25) = "}"
         │   │           │   └── @ StringNode (location: (25...26))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (25...26) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -52,6 +55,7 @@
         │   │           ├── opening_loc: (31...37) = "<<~\"E\""
         │   │           ├── parts: (length: 3)
         │   │           │   ├── @ StringNode (location: (38...46))
+        │   │           │   │   ├── flags: ∅
         │   │           │   │   ├── opening_loc: ∅
         │   │           │   │   ├── content_loc: (38...46) = "    x\n  "
         │   │           │   │   ├── closing_loc: ∅
@@ -73,6 +77,7 @@
         │   │           │   │   │           └── name: "foo"
         │   │           │   │   └── closing_loc: (51...52) = "}"
         │   │           │   └── @ StringNode (location: (52...53))
+        │   │           │       ├── flags: ∅
         │   │           │       ├── opening_loc: ∅
         │   │           │       ├── content_loc: (52...53) = "\n"
         │   │           │       ├── closing_loc: ∅
@@ -91,6 +96,7 @@
         │   │   @ ArgumentsNode (location: (58...62))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (58...62))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (58...62) = "<<~E"
         │   │           ├── content_loc: (63...76) = "\tx\n        y\n"
         │   │           ├── closing_loc: (76...78) = "E\n"
@@ -108,6 +114,7 @@
         │   │   @ ArgumentsNode (location: (81...85))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (81...85))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (81...85) = "<<~E"
         │   │           ├── content_loc: (86...95) = "\tx\n    y\n"
         │   │           ├── closing_loc: (95...97) = "E\n"
@@ -125,6 +132,7 @@
         │   │   @ ArgumentsNode (location: (100...104))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (100...104))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (100...104) = "<<~E"
         │   │           ├── content_loc: (105...122) = "    \tx\n        y\n"
         │   │           ├── closing_loc: (122...124) = "E\n"
@@ -142,6 +150,7 @@
         │   │   @ ArgumentsNode (location: (127...131))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (127...131))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (127...131) = "<<~E"
         │   │           ├── content_loc: (132...146) = "        \tx\n\ty\n"
         │   │           ├── closing_loc: (146...148) = "E\n"
@@ -159,6 +168,7 @@
         │   │   @ ArgumentsNode (location: (151...155))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (151...155))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (151...155) = "<<~E"
         │   │           ├── content_loc: (156...168) = "    x\n  \\\ty\n"
         │   │           ├── closing_loc: (168...170) = "E\n"
@@ -176,6 +186,7 @@
         │   │   @ ArgumentsNode (location: (173...177))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (173...177))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (173...177) = "<<~E"
         │   │           ├── content_loc: (178...191) = "    x\n  \\  y\n"
         │   │           ├── closing_loc: (191...193) = "E\n"
@@ -193,6 +204,7 @@
         │   │   @ ArgumentsNode (location: (196...200))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (196...200))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (196...200) = "<<~E"
         │   │           ├── content_loc: (201...201) = ""
         │   │           ├── closing_loc: (201...205) = "  E\n"
@@ -210,6 +222,7 @@
         │   │   @ ArgumentsNode (location: (208...212))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (208...212))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (208...212) = "<<~E"
         │   │           ├── content_loc: (213...220) = "  x\n\ny\n"
         │   │           ├── closing_loc: (220...222) = "E\n"
@@ -227,6 +240,7 @@
         │   │   @ ArgumentsNode (location: (225...229))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (225...229))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (225...229) = "<<~E"
         │   │           ├── content_loc: (230...243) = "  x\n    \n  y\n"
         │   │           ├── closing_loc: (243...245) = "E\n"
@@ -244,6 +258,7 @@
         │   │   @ ArgumentsNode (location: (248...252))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (248...252))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (248...252) = "<<~E"
         │   │           ├── content_loc: (253...263) = "  x\n    y\n"
         │   │           ├── closing_loc: (263...265) = "E\n"
@@ -261,6 +276,7 @@
         │   │   @ ArgumentsNode (location: (268...272))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (268...272))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (268...272) = "<<~E"
         │   │           ├── content_loc: (273...277) = "  x\n"
         │   │           ├── closing_loc: (277...279) = "E\n"
@@ -278,6 +294,7 @@
         │   │   @ ArgumentsNode (location: (282...286))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (282...286))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (282...286) = "<<~E"
         │   │           ├── content_loc: (287...292) = "  ð\n"
         │   │           ├── closing_loc: (292...294) = "E\n"
@@ -295,6 +312,7 @@
         │   │   @ ArgumentsNode (location: (297...301))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (297...301))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (297...301) = "<<~E"
         │   │           ├── content_loc: (302...302) = ""
         │   │           ├── closing_loc: (302...304) = "E\n"
@@ -315,6 +333,7 @@
             │           ├── opening_loc: (307...313) = "<<~`E`"
             │           ├── parts: (length: 3)
             │           │   ├── @ StringNode (location: (314...322))
+            │           │   │   ├── flags: ∅
             │           │   │   ├── opening_loc: ∅
             │           │   │   ├── content_loc: (314...322) = "    x\n  "
             │           │   │   ├── closing_loc: ∅
@@ -336,6 +355,7 @@
             │           │   │   │           └── name: "foo"
             │           │   │   └── closing_loc: (327...328) = "}"
             │           │   └── @ StringNode (location: (328...329))
+            │           │       ├── flags: ∅
             │           │       ├── opening_loc: ∅
             │           │       ├── content_loc: (328...329) = "\n"
             │           │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
+++ b/test/yarp/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...8))
     └── body: (length: 1)
         └── @ StringNode (location: (0...8))
+            ├── flags: ∅
             ├── opening_loc: (0...8) = "<<~'FOO'"
             ├── content_loc: (9...23) = "  baz\\\\\n  qux\n"
             ├── closing_loc: (23...27) = "FOO\n"

--- a/test/yarp/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
+++ b/test/yarp/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...8))
     └── body: (length: 1)
         └── @ StringNode (location: (0...8))
+            ├── flags: ∅
             ├── opening_loc: (0...8) = "<<~'FOO'"
             ├── content_loc: (9...22) = "  baz\\\n  qux\n"
             ├── closing_loc: (22...26) = "FOO\n"

--- a/test/yarp/snapshots/whitequark/endless_method_command_syntax.txt
+++ b/test/yarp/snapshots/whitequark/endless_method_command_syntax.txt
@@ -20,6 +20,7 @@
         │   │           │   @ ArgumentsNode (location: (15...22))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (15...22))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (15...16) = "\""
         │   │           │           ├── content_loc: (16...21) = "Hello"
         │   │           │           ├── closing_loc: (21...22) = "\""
@@ -52,6 +53,7 @@
         │   │           │   @ ArgumentsNode (location: (41...48))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (41...48))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (41...42) = "\""
         │   │           │           ├── content_loc: (42...47) = "Hello"
         │   │           │           ├── closing_loc: (47...48) = "\""
@@ -134,6 +136,7 @@
         │   │           │   @ ArgumentsNode (location: (90...97))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (90...97))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (90...91) = "\""
         │   │           │           ├── content_loc: (91...96) = "Hello"
         │   │           │           ├── closing_loc: (96...97) = "\""
@@ -176,6 +179,7 @@
         │   │           │   @ ArgumentsNode (location: (120...127))
         │   │           │   └── arguments: (length: 1)
         │   │           │       └── @ StringNode (location: (120...127))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (120...121) = "\""
         │   │           │           ├── content_loc: (121...126) = "Hello"
         │   │           │           ├── closing_loc: (126...127) = "\""
@@ -270,6 +274,7 @@
         │   │           │       └── @ RescueModifierNode (location: (177...214))
         │   │           │           ├── expression:
         │   │           │           │   @ StringNode (location: (177...191))
+        │   │           │           │   ├── flags: ∅
         │   │           │           │   ├── opening_loc: (177...178) = "\""
         │   │           │           │   ├── content_loc: (178...190) = "to be caught"
         │   │           │           │   ├── closing_loc: (190...191) = "\""
@@ -280,6 +285,7 @@
         │   │           │               ├── opening_loc: (199...200) = "\""
         │   │           │               ├── parts: (length: 2)
         │   │           │               │   ├── @ StringNode (location: (200...209))
+        │   │           │               │   │   ├── flags: ∅
         │   │           │               │   │   ├── opening_loc: ∅
         │   │           │               │   │   ├── content_loc: (200...209) = "instance "
         │   │           │               │   │   ├── closing_loc: ∅
@@ -335,6 +341,7 @@
             │           │       └── @ RescueModifierNode (location: (244...278))
             │           │           ├── expression:
             │           │           │   @ StringNode (location: (244...258))
+            │           │           │   ├── flags: ∅
             │           │           │   ├── opening_loc: (244...245) = "\""
             │           │           │   ├── content_loc: (245...257) = "to be caught"
             │           │           │   ├── closing_loc: (257...258) = "\""
@@ -345,6 +352,7 @@
             │           │               ├── opening_loc: (266...267) = "\""
             │           │               ├── parts: (length: 2)
             │           │               │   ├── @ StringNode (location: (267...273))
+            │           │               │   │   ├── flags: ∅
             │           │               │   │   ├── opening_loc: ∅
             │           │               │   │   ├── content_loc: (267...273) = "class "
             │           │               │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/hash_hashrocket.txt
+++ b/test/yarp/snapshots/whitequark/hash_hashrocket.txt
@@ -35,6 +35,7 @@
             │       │   └── unescaped: "foo"
             │       ├── value:
             │       │   @ StringNode (location: (30...35))
+            │       │   ├── flags: ∅
             │       │   ├── opening_loc: (30...31) = "\""
             │       │   ├── content_loc: (31...34) = "bar"
             │       │   ├── closing_loc: (34...35) = "\""

--- a/test/yarp/snapshots/whitequark/hash_label_end.txt
+++ b/test/yarp/snapshots/whitequark/hash_label_end.txt
@@ -28,6 +28,7 @@
         │   │           │   @ StatementsNode (location: (6...9))
         │   │           │   └── body: (length: 1)
         │   │           │       └── @ StringNode (location: (6...9))
+        │   │           │           ├── flags: ∅
         │   │           │           ├── opening_loc: (6...7) = "\""
         │   │           │           ├── content_loc: (7...8) = "a"
         │   │           │           ├── closing_loc: (8...9) = "\""

--- a/test/yarp/snapshots/whitequark/heredoc.txt
+++ b/test/yarp/snapshots/whitequark/heredoc.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...52))
     └── body: (length: 3)
         ├── @ StringNode (location: (0...8))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...8) = "<<'HERE'"
         │   ├── content_loc: (9...17) = "foo\nbar\n"
         │   ├── closing_loc: (17...22) = "HERE\n"
         │   └── unescaped: "foo\nbar\n"
         ├── @ StringNode (location: (23...29))
+        │   ├── flags: ∅
         │   ├── opening_loc: (23...29) = "<<HERE"
         │   ├── content_loc: (30...38) = "foo\nbar\n"
         │   ├── closing_loc: (38...43) = "HERE\n"

--- a/test/yarp/snapshots/whitequark/interp_digit_var.txt
+++ b/test/yarp/snapshots/whitequark/interp_digit_var.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (1...465))
     └── body: (length: 38)
         ├── @ StringNode (location: (1...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (1...2) = "\""
         │   ├── content_loc: (2...5) = "\#@1"
         │   ├── closing_loc: (5...6) = "\""
         │   └── unescaped: "\#@1"
         ├── @ StringNode (location: (10...16))
+        │   ├── flags: ∅
         │   ├── opening_loc: (10...11) = "\""
         │   ├── content_loc: (11...15) = "\#@@1"
         │   ├── closing_loc: (15...16) = "\""
@@ -32,11 +34,13 @@
         │   ├── opening_loc: (31...34) = "%I["
         │   └── closing_loc: (38...39) = "]"
         ├── @ StringNode (location: (43...50))
+        │   ├── flags: ∅
         │   ├── opening_loc: (43...46) = "%Q{"
         │   ├── content_loc: (46...49) = "\#@1"
         │   ├── closing_loc: (49...50) = "}"
         │   └── unescaped: "\#@1"
         ├── @ StringNode (location: (54...62))
+        │   ├── flags: ∅
         │   ├── opening_loc: (54...57) = "%Q{"
         │   ├── content_loc: (57...61) = "\#@@1"
         │   ├── closing_loc: (61...62) = "}"
@@ -44,6 +48,7 @@
         ├── @ ArrayNode (location: (66...73))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (69...72))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (69...72) = "\#@1"
         │   │       ├── closing_loc: ∅
@@ -53,6 +58,7 @@
         ├── @ ArrayNode (location: (77...85))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (80...84))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (80...84) = "\#@@1"
         │   │       ├── closing_loc: ∅
@@ -78,11 +84,13 @@
         │   ├── opening_loc: (102...105) = "%i["
         │   └── closing_loc: (111...112) = "]"
         ├── @ StringNode (location: (116...123))
+        │   ├── flags: ∅
         │   ├── opening_loc: (116...119) = "%q{"
         │   ├── content_loc: (119...122) = "\#@1"
         │   ├── closing_loc: (122...123) = "}"
         │   └── unescaped: "\#@1"
         ├── @ StringNode (location: (127...135))
+        │   ├── flags: ∅
         │   ├── opening_loc: (127...130) = "%q{"
         │   ├── content_loc: (130...134) = "\#@@1"
         │   ├── closing_loc: (134...135) = "}"
@@ -112,6 +120,7 @@
         ├── @ ArrayNode (location: (185...194))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (189...192))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (189...192) = "\#@1"
         │   │       ├── closing_loc: ∅
@@ -121,6 +130,7 @@
         ├── @ ArrayNode (location: (198...208))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (202...206))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (202...206) = "\#@@1"
         │   │       ├── closing_loc: ∅
@@ -138,21 +148,25 @@
         │   ├── closing_loc: (230...231) = "}"
         │   └── unescaped: "\#@@1"
         ├── @ StringNode (location: (235...241))
+        │   ├── flags: ∅
         │   ├── opening_loc: (235...237) = "%{"
         │   ├── content_loc: (237...240) = "\#@1"
         │   ├── closing_loc: (240...241) = "}"
         │   └── unescaped: "\#@1"
         ├── @ StringNode (location: (245...252))
+        │   ├── flags: ∅
         │   ├── opening_loc: (245...247) = "%{"
         │   ├── content_loc: (247...251) = "\#@@1"
         │   ├── closing_loc: (251...252) = "}"
         │   └── unescaped: "\#@@1"
         ├── @ StringNode (location: (256...261))
+        │   ├── flags: ∅
         │   ├── opening_loc: (256...257) = "'"
         │   ├── content_loc: (257...260) = "\#@1"
         │   ├── closing_loc: (260...261) = "'"
         │   └── unescaped: "\#@1"
         ├── @ StringNode (location: (265...271))
+        │   ├── flags: ∅
         │   ├── opening_loc: (265...266) = "'"
         │   ├── content_loc: (266...270) = "\#@@1"
         │   ├── closing_loc: (270...271) = "'"
@@ -200,21 +214,25 @@
         │   ├── closing_loc: (350...351) = "`"
         │   └── unescaped: "\#@@1"
         ├── @ StringNode (location: (354...363))
+        │   ├── flags: ∅
         │   ├── opening_loc: (354...363) = "<<-\"HERE\""
         │   ├── content_loc: (364...368) = "\#@1\n"
         │   ├── closing_loc: (368...373) = "HERE\n"
         │   └── unescaped: "\#@1\n"
         ├── @ StringNode (location: (374...383))
+        │   ├── flags: ∅
         │   ├── opening_loc: (374...383) = "<<-\"HERE\""
         │   ├── content_loc: (384...389) = "\#@@1\n"
         │   ├── closing_loc: (389...394) = "HERE\n"
         │   └── unescaped: "\#@@1\n"
         ├── @ StringNode (location: (395...404))
+        │   ├── flags: ∅
         │   ├── opening_loc: (395...404) = "<<-'HERE'"
         │   ├── content_loc: (405...409) = "\#@1\n"
         │   ├── closing_loc: (409...414) = "HERE\n"
         │   └── unescaped: "\#@1\n"
         ├── @ StringNode (location: (415...424))
+        │   ├── flags: ∅
         │   ├── opening_loc: (415...424) = "<<-'HERE'"
         │   ├── content_loc: (425...430) = "\#@@1\n"
         │   ├── closing_loc: (430...435) = "HERE\n"

--- a/test/yarp/snapshots/whitequark/lvar_injecting_match.txt
+++ b/test/yarp/snapshots/whitequark/lvar_injecting_match.txt
@@ -18,6 +18,7 @@
         │   │   @ ArgumentsNode (location: (19...24))
         │   │   └── arguments: (length: 1)
         │   │       └── @ StringNode (location: (19...24))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (19...20) = "'"
         │   │           ├── content_loc: (20...23) = "bar"
         │   │           ├── closing_loc: (23...24) = "'"

--- a/test/yarp/snapshots/whitequark/non_lvar_injecting_match.txt
+++ b/test/yarp/snapshots/whitequark/non_lvar_injecting_match.txt
@@ -17,6 +17,7 @@
             │   │   │   │           └── flags: decimal
             │   │   │   └── closing_loc: (4...5) = "}"
             │   │   └── @ StringNode (location: (5...18))
+            │   │       ├── flags: ∅
             │   │       ├── opening_loc: ∅
             │   │       ├── content_loc: (5...18) = "(?<match>bar)"
             │   │       ├── closing_loc: ∅
@@ -30,6 +31,7 @@
             │   @ ArgumentsNode (location: (23...28))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (23...28))
+            │           ├── flags: ∅
             │           ├── opening_loc: (23...24) = "'"
             │           ├── content_loc: (24...27) = "bar"
             │           ├── closing_loc: (27...28) = "'"

--- a/test/yarp/snapshots/whitequark/parser_bug_640.txt
+++ b/test/yarp/snapshots/whitequark/parser_bug_640.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...6))
     └── body: (length: 1)
         └── @ StringNode (location: (0...6))
+            ├── flags: ∅
             ├── opening_loc: (0...6) = "<<~FOO"
             ├── content_loc: (7...20) = "  baz\\\n  qux\n"
             ├── closing_loc: (20...24) = "FOO\n"

--- a/test/yarp/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.txt
+++ b/test/yarp/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.txt
@@ -11,6 +11,7 @@
             │   │   ├── statements: ∅
             │   │   └── closing_loc: (12...13) = "}"
             │   └── @ StringNode (location: (13...14))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (13...14) = "\n"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
+++ b/test/yarp/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.txt
@@ -4,6 +4,7 @@
     @ StatementsNode (location: (0...210))
     └── body: (length: 19)
         ├── @ StringNode (location: (0...6))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...1) = "\""
         │   ├── content_loc: (1...5) = "a\\\nb"
         │   ├── closing_loc: (5...6) = "\""
@@ -18,6 +19,7 @@
         │   ├── opening_loc: (8...11) = "%I{"
         │   └── closing_loc: (15...16) = "}"
         ├── @ StringNode (location: (18...26))
+        │   ├── flags: ∅
         │   ├── opening_loc: (18...21) = "%Q{"
         │   ├── content_loc: (21...25) = "a\\\nb"
         │   ├── closing_loc: (25...26) = "}"
@@ -25,6 +27,7 @@
         ├── @ ArrayNode (location: (28...36))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (31...35))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (31...35) = "a\\\nb"
         │   │       ├── closing_loc: ∅
@@ -41,6 +44,7 @@
         │   ├── opening_loc: (38...41) = "%i{"
         │   └── closing_loc: (45...46) = "}"
         ├── @ StringNode (location: (48...56))
+        │   ├── flags: ∅
         │   ├── opening_loc: (48...51) = "%q{"
         │   ├── content_loc: (51...55) = "a\\\nb"
         │   ├── closing_loc: (55...56) = "}"
@@ -59,6 +63,7 @@
         ├── @ ArrayNode (location: (78...86))
         │   ├── elements: (length: 1)
         │   │   └── @ StringNode (location: (81...85))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (81...85) = "a\\\nb"
         │   │       ├── closing_loc: ∅
@@ -71,11 +76,13 @@
         │   ├── closing_loc: (95...96) = "}"
         │   └── unescaped: "ab"
         ├── @ StringNode (location: (98...105))
+        │   ├── flags: ∅
         │   ├── opening_loc: (98...100) = "%{"
         │   ├── content_loc: (100...104) = "a\\\nb"
         │   ├── closing_loc: (104...105) = "}"
         │   └── unescaped: "ab"
         ├── @ StringNode (location: (107...113))
+        │   ├── flags: ∅
         │   ├── opening_loc: (107...108) = "'"
         │   ├── content_loc: (108...112) = "a\\\nb"
         │   ├── closing_loc: (112...113) = "'"
@@ -97,11 +104,13 @@
         │   ├── closing_loc: (138...139) = "'"
         │   └── unescaped: "ab"
         ├── @ StringNode (location: (141...150))
+        │   ├── flags: ∅
         │   ├── opening_loc: (141...150) = "<<-\"HERE\""
         │   ├── content_loc: (151...156) = "a\\\nb\n"
         │   ├── closing_loc: (156...161) = "HERE\n"
         │   └── unescaped: "ab\n"
         ├── @ StringNode (location: (162...171))
+        │   ├── flags: ∅
         │   ├── opening_loc: (162...171) = "<<-'HERE'"
         │   ├── content_loc: (172...177) = "a\\\nb\n"
         │   ├── closing_loc: (177...182) = "HERE\n"

--- a/test/yarp/snapshots/whitequark/regex_interp.txt
+++ b/test/yarp/snapshots/whitequark/regex_interp.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "/"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1...4))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...4) = "foo"
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "bar"
             │   │   └── closing_loc: (9...10) = "}"
             │   └── @ StringNode (location: (10...13))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (10...13) = "baz"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/ruby_bug_11873.txt
+++ b/test/yarp/snapshots/whitequark/ruby_bug_11873.txt
@@ -46,6 +46,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   └── name: "b"
         │   │       └── @ StringNode (location: (10...13))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (10...11) = "\""
         │   │           ├── content_loc: (11...12) = "x"
         │   │           ├── closing_loc: (12...13) = "\""
@@ -219,6 +220,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   └── name: "b"
         │   │       └── @ StringNode (location: (78...81))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (78...79) = "\""
         │   │           ├── content_loc: (79...80) = "x"
         │   │           ├── closing_loc: (80...81) = "\""
@@ -398,6 +400,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   └── name: "b"
         │   │       └── @ StringNode (location: (147...150))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (147...148) = "\""
         │   │           ├── content_loc: (148...149) = "x"
         │   │           ├── closing_loc: (149...150) = "\""
@@ -589,6 +592,7 @@
         │   │       │   ├── flags: ∅
         │   │       │   └── name: "b"
         │   │       └── @ StringNode (location: (215...218))
+        │   │           ├── flags: ∅
         │   │           ├── opening_loc: (215...216) = "\""
         │   │           ├── content_loc: (216...217) = "x"
         │   │           ├── closing_loc: (217...218) = "\""

--- a/test/yarp/snapshots/whitequark/ruby_bug_11989.txt
+++ b/test/yarp/snapshots/whitequark/ruby_bug_11989.txt
@@ -12,6 +12,7 @@
             │   @ ArgumentsNode (location: (2...8))
             │   └── arguments: (length: 1)
             │       └── @ StringNode (location: (2...8))
+            │           ├── flags: ∅
             │           ├── opening_loc: (2...8) = "<<~\"E\""
             │           ├── content_loc: (9...19) = "  x\\n   y\n"
             │           ├── closing_loc: (19...21) = "E\n"

--- a/test/yarp/snapshots/whitequark/ruby_bug_11990.txt
+++ b/test/yarp/snapshots/whitequark/ruby_bug_11990.txt
@@ -14,12 +14,14 @@
             │       └── @ StringConcatNode (location: (2...12))
             │           ├── left:
             │           │   @ StringNode (location: (2...6))
+            │           │   ├── flags: ∅
             │           │   ├── opening_loc: (2...6) = "<<~E"
             │           │   ├── content_loc: (13...17) = "  x\n"
             │           │   ├── closing_loc: (17...19) = "E\n"
             │           │   └── unescaped: "x\n"
             │           └── right:
             │               @ StringNode (location: (7...12))
+            │               ├── flags: ∅
             │               ├── opening_loc: (7...8) = "\""
             │               ├── content_loc: (8...11) = "  y"
             │               ├── closing_loc: (11...12) = "\""

--- a/test/yarp/snapshots/whitequark/ruby_bug_12073.txt
+++ b/test/yarp/snapshots/whitequark/ruby_bug_12073.txt
@@ -71,6 +71,7 @@
             │           │       │   │   └── name: :B
             │           │       │   └── delimiter_loc: (37...39) = "::"
             │           │       └── @ StringNode (location: (42...44))
+            │           │           ├── flags: ∅
             │           │           ├── opening_loc: (42...43) = "'"
             │           │           ├── content_loc: (43...43) = ""
             │           │           ├── closing_loc: (43...44) = "'"

--- a/test/yarp/snapshots/whitequark/slash_newline_in_heredocs.txt
+++ b/test/yarp/snapshots/whitequark/slash_newline_in_heredocs.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...33))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...4))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...4) = "<<-E"
         │   ├── content_loc: (5...25) = "    1 \\\n    2\n    3\n"
         │   ├── closing_loc: (25...27) = "E\n"
         │   └── unescaped: "    1     2\n    3\n"
         └── @ StringNode (location: (29...33))
+            ├── flags: ∅
             ├── opening_loc: (29...33) = "<<~E"
             ├── content_loc: (34...54) = "    1 \\\n    2\n    3\n"
             ├── closing_loc: (54...56) = "E\n"

--- a/test/yarp/snapshots/whitequark/string_concat.txt
+++ b/test/yarp/snapshots/whitequark/string_concat.txt
@@ -9,6 +9,7 @@
             │   ├── opening_loc: (0...1) = "\""
             │   ├── parts: (length: 2)
             │   │   ├── @ StringNode (location: (1...4))
+            │   │   │   ├── flags: ∅
             │   │   │   ├── opening_loc: ∅
             │   │   │   ├── content_loc: (1...4) = "foo"
             │   │   │   ├── closing_loc: ∅
@@ -21,6 +22,7 @@
             │   └── closing_loc: (7...8) = "\""
             └── right:
                 @ StringNode (location: (9...14))
+                ├── flags: ∅
                 ├── opening_loc: (9...10) = "\""
                 ├── content_loc: (10...13) = "bar"
                 ├── closing_loc: (13...14) = "\""

--- a/test/yarp/snapshots/whitequark/string_dvar.txt
+++ b/test/yarp/snapshots/whitequark/string_dvar.txt
@@ -12,6 +12,7 @@
             │   │       @ InstanceVariableReadNode (location: (2...4))
             │   │       └── name: :@a
             │   ├── @ StringNode (location: (4...5))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (4...5) = " "
             │   │   ├── closing_loc: ∅
@@ -22,6 +23,7 @@
             │   │       @ ClassVariableReadNode (location: (6...9))
             │   │       └── name: :@@a
             │   ├── @ StringNode (location: (9...10))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (9...10) = " "
             │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/string_interp.txt
+++ b/test/yarp/snapshots/whitequark/string_interp.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1...4))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...4) = "foo"
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "bar"
             │   │   └── closing_loc: (9...10) = "}"
             │   └── @ StringNode (location: (10...13))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (10...13) = "baz"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/string_plain.txt
+++ b/test/yarp/snapshots/whitequark/string_plain.txt
@@ -4,11 +4,13 @@
     @ StatementsNode (location: (0...20))
     └── body: (length: 2)
         ├── @ StringNode (location: (0...10))
+        │   ├── flags: ∅
         │   ├── opening_loc: (0...3) = "%q("
         │   ├── content_loc: (3...9) = "foobar"
         │   ├── closing_loc: (9...10) = ")"
         │   └── unescaped: "foobar"
         └── @ StringNode (location: (12...20))
+            ├── flags: ∅
             ├── opening_loc: (12...13) = "'"
             ├── content_loc: (13...19) = "foobar"
             ├── closing_loc: (19...20) = "'"

--- a/test/yarp/snapshots/whitequark/symbol_interp.txt
+++ b/test/yarp/snapshots/whitequark/symbol_interp.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...2) = ":\""
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (2...5))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (2...5) = "foo"
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "bar"
             │   │   └── closing_loc: (10...11) = "}"
             │   └── @ StringNode (location: (11...14))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (11...14) = "baz"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/undef.txt
+++ b/test/yarp/snapshots/whitequark/undef.txt
@@ -19,6 +19,7 @@
             │       ├── opening_loc: (17...19) = ":\""
             │       ├── parts: (length: 2)
             │       │   ├── @ StringNode (location: (19...22))
+            │       │   │   ├── flags: ∅
             │       │   │   ├── opening_loc: ∅
             │       │   │   ├── content_loc: (19...22) = "foo"
             │       │   │   ├── closing_loc: ∅

--- a/test/yarp/snapshots/whitequark/when_multi.txt
+++ b/test/yarp/snapshots/whitequark/when_multi.txt
@@ -20,11 +20,13 @@
             │       ├── keyword_loc: (10...14) = "when"
             │       ├── conditions: (length: 2)
             │       │   ├── @ StringNode (location: (15...20))
+            │       │   │   ├── flags: ∅
             │       │   │   ├── opening_loc: (15...16) = "'"
             │       │   │   ├── content_loc: (16...19) = "bar"
             │       │   │   ├── closing_loc: (19...20) = "'"
             │       │   │   └── unescaped: "bar"
             │       │   └── @ StringNode (location: (22...27))
+            │       │       ├── flags: ∅
             │       │       ├── opening_loc: (22...23) = "'"
             │       │       ├── content_loc: (23...26) = "baz"
             │       │       ├── closing_loc: (26...27) = "'"

--- a/test/yarp/snapshots/whitequark/when_then.txt
+++ b/test/yarp/snapshots/whitequark/when_then.txt
@@ -20,6 +20,7 @@
             │       ├── keyword_loc: (10...14) = "when"
             │       ├── conditions: (length: 1)
             │       │   └── @ StringNode (location: (15...20))
+            │       │       ├── flags: ∅
             │       │       ├── opening_loc: (15...16) = "'"
             │       │       ├── content_loc: (16...19) = "bar"
             │       │       ├── closing_loc: (19...20) = "'"

--- a/test/yarp/snapshots/whitequark/xstring_interp.txt
+++ b/test/yarp/snapshots/whitequark/xstring_interp.txt
@@ -7,6 +7,7 @@
             ├── opening_loc: (0...1) = "`"
             ├── parts: (length: 3)
             │   ├── @ StringNode (location: (1...4))
+            │   │   ├── flags: ∅
             │   │   ├── opening_loc: ∅
             │   │   ├── content_loc: (1...4) = "foo"
             │   │   ├── closing_loc: ∅
@@ -28,6 +29,7 @@
             │   │   │           └── name: "bar"
             │   │   └── closing_loc: (9...10) = "}"
             │   └── @ StringNode (location: (10...13))
+            │       ├── flags: ∅
             │       ├── opening_loc: ∅
             │       ├── content_loc: (10...13) = "baz"
             │       ├── closing_loc: ∅

--- a/test/yarp/snapshots/xstring.txt
+++ b/test/yarp/snapshots/xstring.txt
@@ -12,6 +12,7 @@
         │   ├── opening_loc: (9...10) = "`"
         │   ├── parts: (length: 3)
         │   │   ├── @ StringNode (location: (10...14))
+        │   │   │   ├── flags: ∅
         │   │   │   ├── opening_loc: ∅
         │   │   │   ├── content_loc: (10...14) = "foo "
         │   │   │   ├── closing_loc: ∅
@@ -33,6 +34,7 @@
         │   │   │   │           └── name: "bar"
         │   │   │   └── closing_loc: (19...20) = "}"
         │   │   └── @ StringNode (location: (20...24))
+        │   │       ├── flags: ∅
         │   │       ├── opening_loc: ∅
         │   │       ├── content_loc: (20...24) = " baz"
         │   │       ├── closing_loc: ∅


### PR DESCRIPTION
Parse out frozen string literal comments, add a static_literal common flag, and a string-specific frozen flag.

Note that this doesn't close #157 or #574 yet, because we are not exposing this flag yet and we still aren't supporting all of the different magic comment syntax. But this is a stepping stone to get there.