### PR TITLE
don't use varargs for `accept_any_p` and most `match_any_type_p` cases

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7773,13 +7773,13 @@ yp_xstring_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openi
 
 // Returns true if the current token is of the specified type.
 static inline bool
-match_type_p(yp_parser_t *parser, yp_token_type_t type) {
+match_type_p(const yp_parser_t *parser, yp_token_type_t type) {
     return parser->current.type == type;
 }
 
 // Returns true if the current token is of any of the specified types.
 static bool
-match_any_type_p(yp_parser_t *parser, size_t count, ...) {
+match_any_type_p(const yp_parser_t *parser, size_t count, ...) {
     va_list types;
     va_start(types, count);
 


### PR DESCRIPTION
varargs functions don't typically (ever?) get inlined by compilers, so `accept_any_p` and `match_any_type_p` are doing a lot more work than they need to be.  `accept_any_p` only gets called with two different cases, so we can have separate functions for those and get rid of the rest.  The majority of the cases for `match_any_type_p` are 2 and 3 types, so I added functions for those and left the rest to be inefficient.  Happy to clean those up too.

All the new functions are getting inlined on arm64 mac (clang) and x86-64 linux (gcc)...except `accept_any_2` on x86-64 linux, presumably because it gets called more.  `match_any_type_p` was the hotter function in any event, so this doesn't seem like cause for concern.

This change improves the performance of:

```ruby
debug = YARP.const_get(:Debug)
files.each do |file|
  debug.profile_file(file)
end
```

by about 5% on a subset of Stripe's codebase.