### PR TITLE
Remove varargs entirely

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7771,39 +7771,6 @@ yp_xstring_node_create_and_unescape(yp_parser_t *parser, const yp_token_t *openi
     return node;
 }
 
-// Returns true if the current token is of the specified type.
-static inline bool
-match_type_p(const yp_parser_t *parser, yp_token_type_t type) {
-    return parser->current.type == type;
-}
-
-static bool
-match_any_2_type_p(const yp_parser_t *parser, yp_token_type_t t1, yp_token_type_t t2) {
-    return match_type_p(parser, t1) || match_type_p(parser, t2);
-}
-
-static bool
-match_any_3_type_p(const yp_parser_t *parser, yp_token_type_t t1, yp_token_type_t t2, yp_token_type_t t3) {
-    return match_type_p(parser, t1) || match_type_p(parser, t2) || match_type_p(parser, t3);
-}
-
-// Returns true if the current token is of any of the specified types.
-static bool
-match_any_type_p(const yp_parser_t *parser, size_t count, ...) {
-    va_list types;
-    va_start(types, count);
-
-    for (size_t index = 0; index < count; index++) {
-        if (match_type_p(parser, va_arg(types, yp_token_type_t))) {
-            va_end(types);
-            return true;
-        }
-    }
-
-    va_end(types);
-    return false;
-}
-
 // These are the various precedence rules. Because we are using a Pratt parser,
 // they are named binding power to represent the manner in which nodes are bound
 // together in the stack.
@@ -7965,28 +7932,82 @@ yp_binding_powers_t yp_binding_powers[YP_TOKEN_MAXIMUM] = {
 #undef RIGHT_ASSOCIATIVE
 #undef RIGHT_ASSOCIATIVE_UNARY
 
+// Returns true if the current token is of the given type.
+static inline bool
+match1(const yp_parser_t *parser, yp_token_type_t type) {
+    return parser->current.type == type;
+}
+
+// Returns true if the current token is of either of the given types.
+static inline bool
+match2(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2) {
+    return match1(parser, type1) || match1(parser, type2);
+}
+
+// Returns true if the current token is any of the three given types.
+static inline bool
+match3(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3);
+}
+
+// Returns true if the current token is any of the five given types.
+static inline bool
+match5(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3, yp_token_type_t type4, yp_token_type_t type5) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4) || match1(parser, type5);
+}
+
+// Returns true if the current token is any of the six given types.
+static inline bool
+match6(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3, yp_token_type_t type4, yp_token_type_t type5, yp_token_type_t type6) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4) || match1(parser, type5) || match1(parser, type6);
+}
+
+// Returns true if the current token is any of the seven given types.
+static inline bool
+match7(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3, yp_token_type_t type4, yp_token_type_t type5, yp_token_type_t type6, yp_token_type_t type7) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4) || match1(parser, type5) || match1(parser, type6) || match1(parser, type7);
+}
+
+// Returns true if the current token is any of the eight given types.
+static inline bool
+match8(const yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3, yp_token_type_t type4, yp_token_type_t type5, yp_token_type_t type6, yp_token_type_t type7, yp_token_type_t type8) {
+    return match1(parser, type1) || match1(parser, type2) || match1(parser, type3) || match1(parser, type4) || match1(parser, type5) || match1(parser, type6) || match1(parser, type7) || match1(parser, type8);
+}
+
 // If the current token is of the specified type, lex forward by one token and
 // return true. Otherwise, return false. For example:
 //
-//     if (accept(parser, YP_TOKEN_COLON)) { ... }
+//     if (accept1(parser, YP_TOKEN_COLON)) { ... }
 //
 static bool
-accept(yp_parser_t *parser, yp_token_type_t type) {
-    if (match_type_p(parser, type)) {
+accept1(yp_parser_t *parser, yp_token_type_t type) {
+    if (match1(parser, type)) {
         parser_lex(parser);
         return true;
     }
     return false;
 }
 
-static bool
-accept_any_2(yp_parser_t *parser, yp_token_type_t t1, yp_token_type_t t2) {
-    return accept(parser, t1) || accept(parser, t2);
+// If the current token is either of the two given types, lex forward by one
+// token and return true. Otherwise return false.
+static inline bool
+accept2(yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2) {
+    if (match2(parser, type1, type2)) {
+        parser_lex(parser);
+        return true;
+    }
+    return false;
 }
 
-static bool
-accept_any_3(yp_parser_t *parser, yp_token_type_t t1, yp_token_type_t t2, yp_token_type_t t3) {
-    return accept(parser, t1) || accept(parser, t2) || accept(parser, t3);
+// If the current token is any of the three given types, lex forward by one
+// token and return true. Otherwise return false.
+static inline bool
+accept3(yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_token_type_t type3) {
+    if (match3(parser, type1, type2, type3)) {
+        parser_lex(parser);
+        return true;
+    }
+    return false;
 }
 
 // This function indicates that the parser expects a token in a specific
@@ -7999,32 +8020,27 @@ accept_any_3(yp_parser_t *parser, yp_token_type_t t1, yp_token_type_t t2, yp_tok
 // valid) and create an artificial token instead. This allows us to recover from
 // the fact that the token isn't present and continue parsing.
 static void
-expect(yp_parser_t *parser, yp_token_type_t type, yp_diagnostic_id_t diag_id) {
-    if (accept(parser, type)) return;
+expect1(yp_parser_t *parser, yp_token_type_t type, yp_diagnostic_id_t diag_id) {
+    if (accept1(parser, type)) return;
 
-    yp_diagnostic_list_append(&parser->error_list, parser->previous.end, parser->previous.end, diag_id);
+    const uint8_t *location = parser->previous.end;
+    yp_diagnostic_list_append(&parser->error_list, location, location, diag_id);
 
-    parser->previous =
-        (yp_token_t) { .type = YP_TOKEN_MISSING, .start = parser->previous.end, .end = parser->previous.end };
+    parser->previous.start = location;
+    parser->previous.type = YP_TOKEN_MISSING;
 }
 
+// This function is the same as expect1, but it expects either of two token
+// types.
 static void
-expect_any(yp_parser_t *parser, yp_diagnostic_id_t diag_id, size_t count, ...) {
-    va_list types;
-    va_start(types, count);
+expect2(yp_parser_t *parser, yp_token_type_t type1, yp_token_type_t type2, yp_diagnostic_id_t diag_id) {
+    if (accept2(parser, type1, type2)) return;
 
-    for (size_t index = 0; index < count; index++) {
-        if (accept(parser, va_arg(types, yp_token_type_t))) {
-            va_end(types);
-            return;
-        }
-    }
+    const uint8_t *location = parser->previous.end;
+    yp_diagnostic_list_append(&parser->error_list, location, location, diag_id);
 
-    va_end(types);
-
-    yp_diagnostic_list_append(&parser->error_list, parser->previous.end, parser->previous.end, diag_id);
-    parser->previous =
-        (yp_token_t) { .type = YP_TOKEN_MISSING, .start = parser->previous.end, .end = parser->previous.end };
+    parser->previous.start = location;
+    parser->previous.type = YP_TOKEN_MISSING;
 }
 
 static yp_node_t *
@@ -8106,7 +8122,7 @@ token_begins_expression_p(yp_token_type_t type) {
 // prefixed by the * operator.
 static yp_node_t *
 parse_starred_expression(yp_parser_t *parser, yp_binding_power_t binding_power, yp_diagnostic_id_t diag_id) {
-    if (accept(parser, YP_TOKEN_USTAR)) {
+    if (accept1(parser, YP_TOKEN_USTAR)) {
         yp_token_t operator = parser->previous;
         yp_node_t *expression = parse_expression(parser, binding_power, YP_ERR_EXPECT_EXPRESSION_AFTER_STAR);
         return (yp_node_t *) yp_splat_node_create(parser, &operator, expression);
@@ -8426,7 +8442,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
     if (first_target != NULL) {
         first_target = parse_target(parser, first_target);
 
-        if (!match_type_p(parser, YP_TOKEN_COMMA)) {
+        if (!match1(parser, YP_TOKEN_COMMA)) {
             return first_target;
         }
     }
@@ -8438,9 +8454,9 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
 
     bool has_splat = false;
 
-    if (first_target == NULL || accept(parser, YP_TOKEN_COMMA)) {
+    if (first_target == NULL || accept1(parser, YP_TOKEN_COMMA)) {
         do {
-            if (accept(parser, YP_TOKEN_USTAR)) {
+            if (accept1(parser, YP_TOKEN_USTAR)) {
                 // Here we have a splat operator. It can have a name or be anonymous. It
                 // can be the final target or be in the middle if there haven't been any
                 // others yet.
@@ -8460,7 +8476,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                 yp_node_t *splat = (yp_node_t *) yp_splat_node_create(parser, &star_operator, name);
                 yp_multi_target_node_targets_append(result, splat);
                 has_splat = true;
-            } else if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+            } else if (accept1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
                 // Here we have a parenthesized list of targets. We'll recurse down into
                 // the parentheses by calling parse_targets again and then finish out
                 // the node when it returns.
@@ -8469,7 +8485,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                 yp_node_t *first_child_target = parse_expression(parser, YP_BINDING_POWER_STATEMENT, YP_ERR_EXPECT_EXPRESSION_AFTER_LPAREN);
                 yp_node_t *child_target = parse_targets(parser, first_child_target, YP_BINDING_POWER_STATEMENT);
 
-                expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN_AFTER_MULTI);
+                expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN_AFTER_MULTI);
                 yp_token_t rparen = parser->previous;
 
                 if (YP_NODE_TYPE_P(child_target, YP_MULTI_TARGET_NODE) && first_target == NULL && result->targets.size == 0) {
@@ -8497,7 +8513,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
                     yp_multi_target_node_targets_append(result, (yp_node_t *) target);
                 }
             } else {
-                if (!token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_USTAR)) {
+                if (!token_begins_expression_p(parser->current.type) && !match1(parser, YP_TOKEN_USTAR)) {
                     if (first_target == NULL && result->targets.size == 0) {
                         // If we get here, then we weren't able to parse anything at all, so
                         // we need to return a missing node.
@@ -8519,7 +8535,7 @@ parse_targets(yp_parser_t *parser, yp_node_t *first_target, yp_binding_power_t b
 
                 yp_multi_target_node_targets_append(result, target);
             }
-        } while (accept(parser, YP_TOKEN_COMMA));
+        } while (accept1(parser, YP_TOKEN_COMMA));
     }
 
     return (yp_node_t *) result;
@@ -8530,7 +8546,7 @@ static yp_statements_node_t *
 parse_statements(yp_parser_t *parser, yp_context_t context) {
     // First, skip past any optional terminators that might be at the beginning of
     // the statements.
-    while (accept_any_2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE));
+    while (accept2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE));
 
     // If we have a terminator, then we can just return NULL.
     if (context_terminator(context, &parser->current)) return NULL;
@@ -8556,10 +8572,10 @@ parse_statements(yp_parser_t *parser, yp_context_t context) {
 
         // If we have a terminator, then we will parse all consequtive terminators
         // and then continue parsing the statements list.
-        if (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+        if (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
             // If we have a terminator, then we will continue parsing the statements
             // list.
-            while (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
+            while (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
             if (context_terminator(context, &parser->current)) break;
 
             // Now we can continue parsing the list of statements.
@@ -8584,10 +8600,10 @@ parse_statements(yp_parser_t *parser, yp_context_t context) {
         if (YP_NODE_TYPE_P(node, YP_MISSING_NODE)) {
             parser_lex(parser);
 
-            while (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
+            while (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
             if (context_terminator(context, &parser->current)) break;
         } else {
-            expect(parser, YP_TOKEN_NEWLINE, YP_ERR_EXPECT_EOL_AFTER_STATEMENT);
+            expect1(parser, YP_TOKEN_NEWLINE, YP_ERR_EXPECT_EOL_AFTER_STATEMENT);
         }
     }
 
@@ -8639,7 +8655,7 @@ parse_assocs(yp_parser_t *parser, yp_node_t *node) {
                 if (yp_symbol_node_label_p(key)) {
                     operator = not_provided(parser);
                 } else {
-                    expect(parser, YP_TOKEN_EQUAL_GREATER, YP_ERR_HASH_ROCKET);
+                    expect1(parser, YP_TOKEN_EQUAL_GREATER, YP_ERR_HASH_ROCKET);
                     operator = parser->previous;
                 }
 
@@ -8656,11 +8672,11 @@ parse_assocs(yp_parser_t *parser, yp_node_t *node) {
         }
 
         // If there's no comma after the element, then we're done.
-        if (!accept(parser, YP_TOKEN_COMMA)) return;
+        if (!accept1(parser, YP_TOKEN_COMMA)) return;
 
         // If the next element starts with a label or a **, then we know we have
         // another element in the hash, so we'll continue parsing.
-        if (match_any_2_type_p(parser, YP_TOKEN_USTAR_STAR, YP_TOKEN_LABEL)) continue;
+        if (match2(parser, YP_TOKEN_USTAR_STAR, YP_TOKEN_LABEL)) continue;
 
         // Otherwise we need to check if the subsequent token begins an expression.
         // If it does, then we'll continue parsing.
@@ -8679,7 +8695,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
     // First we need to check if the next token is one that could be the start of
     // an argument. If it's not, then we can just return.
     if (
-        match_any_2_type_p(parser, terminator, YP_TOKEN_EOF) ||
+        match2(parser, terminator, YP_TOKEN_EOF) ||
         (binding_power != YP_BINDING_POWER_UNSET && binding_power < YP_BINDING_POWER_RANGE) ||
         context_terminator(parser->current_context->context, &parser->current)
     ) {
@@ -8689,7 +8705,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
     bool parsed_bare_hash = false;
     bool parsed_block_argument = false;
 
-    while (!match_type_p(parser, YP_TOKEN_EOF)) {
+    while (!match1(parser, YP_TOKEN_EOF)) {
         if (parsed_block_argument) {
             yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, YP_ERR_ARGUMENT_AFTER_BLOCK);
         }
@@ -8706,7 +8722,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                 yp_keyword_hash_node_t *hash = yp_keyword_hash_node_create(parser);
                 argument = (yp_node_t *)hash;
 
-                if (!match_any_type_p(parser, 7, terminator, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_KEYWORD_DO, YP_TOKEN_PARENTHESIS_RIGHT)) {
+                if (!match7(parser, terminator, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_KEYWORD_DO, YP_TOKEN_PARENTHESIS_RIGHT)) {
                     parse_assocs(parser, (yp_node_t *) hash);
                 }
 
@@ -8733,7 +8749,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                 parser_lex(parser);
                 yp_token_t operator = parser->previous;
 
-                if (match_any_2_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_COMMA)) {
+                if (match2(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_COMMA)) {
                     if (yp_parser_local_depth(parser, &parser->previous) == -1) {
                         yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, YP_ERR_ARGUMENT_NO_FORWARDING_STAR);
                     }
@@ -8777,7 +8793,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                     argument = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_EXPECT_ARGUMENT);
                 }
 
-                if (yp_symbol_node_label_p(argument) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+                if (yp_symbol_node_label_p(argument) || accept1(parser, YP_TOKEN_EQUAL_GREATER)) {
                     if (parsed_bare_hash) {
                         yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, YP_ERR_ARGUMENT_BARE_HASH);
                     }
@@ -8799,9 +8815,9 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
                     argument = (yp_node_t *) bare_hash;
 
                     // Then parse more if we have a comma
-                    if (accept(parser, YP_TOKEN_COMMA) && (
+                    if (accept1(parser, YP_TOKEN_COMMA) && (
                         token_begins_expression_p(parser->current.type) ||
-                        match_any_2_type_p(parser, YP_TOKEN_USTAR_STAR, YP_TOKEN_LABEL)
+                        match2(parser, YP_TOKEN_USTAR_STAR, YP_TOKEN_LABEL)
                     )) {
                         parse_assocs(parser, (yp_node_t *) bare_hash);
                     }
@@ -8821,7 +8837,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
         // If the terminator of these arguments is not EOF, then we have a specific
         // token we're looking for. In that case we can accept a newline here
         // because it is not functioning as a statement terminator.
-        if (terminator != YP_TOKEN_EOF) accept(parser, YP_TOKEN_NEWLINE);
+        if (terminator != YP_TOKEN_EOF) accept1(parser, YP_TOKEN_NEWLINE);
 
         if (parser->previous.type == YP_TOKEN_COMMA && parsed_bare_hash) {
             // If we previously were on a comma and we just parsed a bare hash, then
@@ -8830,12 +8846,12 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
         } else {
             // If there is no comma at the end of the argument list then we're done
             // parsing arguments and can break out of this loop.
-            if (!accept(parser, YP_TOKEN_COMMA)) break;
+            if (!accept1(parser, YP_TOKEN_COMMA)) break;
         }
 
         // If we hit the terminator, then that means we have a trailing comma so we
         // can accept that output as well.
-        if (match_type_p(parser, terminator)) break;
+        if (match1(parser, terminator)) break;
     }
 }
 
@@ -8848,7 +8864,7 @@ parse_arguments(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_for
 // It can recurse infinitely down, and splats are allowed to group arguments.
 static yp_required_destructured_parameter_node_t *
 parse_required_destructured_parameter(yp_parser_t *parser) {
-    expect(parser, YP_TOKEN_PARENTHESIS_LEFT, YP_ERR_EXPECT_LPAREN_REQ_PARAMETER);
+    expect1(parser, YP_TOKEN_PARENTHESIS_LEFT, YP_ERR_EXPECT_LPAREN_REQ_PARAMETER);
 
     yp_token_t opening = parser->previous;
     yp_required_destructured_parameter_node_t *node = yp_required_destructured_parameter_node_create(parser, &opening);
@@ -8857,7 +8873,7 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
     do {
         yp_node_t *param;
 
-        if (node->parameters.size > 0 && match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+        if (node->parameters.size > 0 && match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
             if (parsed_splat) {
                 yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, YP_ERR_ARGUMENT_SPLAT_AFTER_SPLAT);
             }
@@ -8867,9 +8883,9 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
             break;
         }
 
-        if (match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+        if (match1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
             param = (yp_node_t *) parse_required_destructured_parameter(parser);
-        } else if (accept(parser, YP_TOKEN_USTAR)) {
+        } else if (accept1(parser, YP_TOKEN_USTAR)) {
             if (parsed_splat) {
                 yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, YP_ERR_ARGUMENT_SPLAT_AFTER_SPLAT);
             }
@@ -8877,7 +8893,7 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
             yp_token_t star = parser->previous;
             yp_node_t *value = NULL;
 
-            if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+            if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
                 yp_token_t name = parser->previous;
                 value = (yp_node_t *) yp_required_parameter_node_create(parser, &name);
                 yp_parser_local_add_token(parser, &name);
@@ -8886,7 +8902,7 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
             param = (yp_node_t *) yp_splat_node_create(parser, &star, value);
             parsed_splat = true;
         } else {
-            expect(parser, YP_TOKEN_IDENTIFIER, YP_ERR_EXPECT_IDENT_REQ_PARAMETER);
+            expect1(parser, YP_TOKEN_IDENTIFIER, YP_ERR_EXPECT_IDENT_REQ_PARAMETER);
             yp_token_t name = parser->previous;
 
             param = (yp_node_t *) yp_required_parameter_node_create(parser, &name);
@@ -8894,9 +8910,9 @@ parse_required_destructured_parameter(yp_parser_t *parser) {
         }
 
         yp_required_destructured_parameter_node_append_parameter(node, param);
-    } while (accept(parser, YP_TOKEN_COMMA));
+    } while (accept1(parser, YP_TOKEN_COMMA));
 
-    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN_REQ_PARAMETER);
+    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN_REQ_PARAMETER);
     yp_required_destructured_parameter_node_closing_set(node, &parser->previous);
 
     return node;
@@ -8998,7 +9014,7 @@ parse_parameters(
                 yp_token_t operator = parser->previous;
                 yp_token_t name;
 
-                if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+                if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
                     name = parser->previous;
                     yp_parser_parameter_name_check(parser, &name);
                     yp_parser_local_add_token(parser, &name);
@@ -9066,7 +9082,7 @@ parse_parameters(
                 yp_parser_parameter_name_check(parser, &name);
                 yp_parser_local_add_token(parser, &name);
 
-                if (accept(parser, YP_TOKEN_EQUAL)) {
+                if (accept1(parser, YP_TOKEN_EQUAL)) {
                     yp_token_t operator = parser->previous;
                     context_push(parser, YP_CONTEXT_DEFAULT_PARAMS);
                     yp_node_t *value = parse_expression(parser, binding_power, YP_ERR_PARAMETER_NO_DEFAULT);
@@ -9155,7 +9171,7 @@ parse_parameters(
                 yp_token_t operator = parser->previous;
                 yp_token_t name;
 
-                if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+                if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
                     name = parser->previous;
                     yp_parser_parameter_name_check(parser, &name);
                     yp_parser_local_add_token(parser, &name);
@@ -9182,12 +9198,12 @@ parse_parameters(
                 yp_token_t operator = parser->previous;
                 yp_node_t *param;
 
-                if (accept(parser, YP_TOKEN_KEYWORD_NIL)) {
+                if (accept1(parser, YP_TOKEN_KEYWORD_NIL)) {
                     param = (yp_node_t *) yp_no_keywords_parameter_node_create(parser, &operator, &parser->previous);
                 } else {
                     yp_token_t name;
 
-                    if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+                    if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
                         name = parser->previous;
                         yp_parser_parameter_name_check(parser, &name);
                         yp_parser_local_add_token(parser, &name);
@@ -9233,9 +9249,9 @@ parse_parameters(
         }
 
         if (looping && uses_parentheses) {
-            accept(parser, YP_TOKEN_NEWLINE);
+            accept1(parser, YP_TOKEN_NEWLINE);
         }
-    } while (looping && accept(parser, YP_TOKEN_COMMA));
+    } while (looping && accept1(parser, YP_TOKEN_COMMA));
 
     yp_do_loop_stack_pop(parser);
 
@@ -9254,7 +9270,7 @@ static inline void
 parse_rescues(yp_parser_t *parser, yp_begin_node_t *parent_node) {
     yp_rescue_node_t *current = NULL;
 
-    while (accept(parser, YP_TOKEN_KEYWORD_RESCUE)) {
+    while (accept1(parser, YP_TOKEN_KEYWORD_RESCUE)) {
         yp_rescue_node_t *rescue = yp_rescue_node_create(parser, &parser->previous);
 
         switch (parser->current.type) {
@@ -9278,7 +9294,7 @@ parse_rescues(yp_parser_t *parser, yp_begin_node_t *parent_node) {
                 // going to just continue on.
                 break;
             default: {
-                if (token_begins_expression_p(parser->current.type) || match_type_p(parser, YP_TOKEN_USTAR)) {
+                if (token_begins_expression_p(parser->current.type) || match1(parser, YP_TOKEN_USTAR)) {
                     // Here we have something that could be an exception expression, so
                     // we'll attempt to parse it here and any others delimited by commas.
 
@@ -9288,11 +9304,11 @@ parse_rescues(yp_parser_t *parser, yp_begin_node_t *parent_node) {
 
                         // If we hit a newline, then this is the end of the rescue expression. We
                         // can continue on to parse the statements.
-                        if (match_any_3_type_p(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_KEYWORD_THEN)) break;
+                        if (match3(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_KEYWORD_THEN)) break;
 
                         // If we hit a `=>` then we're going to parse the exception variable. Once
                         // we've done that, we'll break out of the loop and parse the statements.
-                        if (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+                        if (accept1(parser, YP_TOKEN_EQUAL_GREATER)) {
                             yp_rescue_node_operator_set(rescue, &parser->previous);
 
                             yp_node_t *reference = parse_expression(parser, YP_BINDING_POWER_INDEX, YP_ERR_RESCUE_VARIABLE);
@@ -9301,25 +9317,25 @@ parse_rescues(yp_parser_t *parser, yp_begin_node_t *parent_node) {
                             yp_rescue_node_reference_set(rescue, reference);
                             break;
                         }
-                    } while (accept(parser, YP_TOKEN_COMMA));
+                    } while (accept1(parser, YP_TOKEN_COMMA));
                 }
             }
         }
 
-        if (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
-            accept(parser, YP_TOKEN_KEYWORD_THEN);
+        if (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+            accept1(parser, YP_TOKEN_KEYWORD_THEN);
         } else {
-            expect(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_RESCUE_TERM);
+            expect1(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_RESCUE_TERM);
         }
 
-        if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+        if (!match3(parser, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
             yp_accepts_block_stack_push(parser, true);
             yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_RESCUE);
             if (statements) {
                 yp_rescue_node_statements_set(rescue, statements);
             }
             yp_accepts_block_stack_pop(parser);
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
         }
 
         if (current == NULL) {
@@ -9343,32 +9359,32 @@ parse_rescues(yp_parser_t *parser, yp_begin_node_t *parent_node) {
         }
     }
 
-    if (accept(parser, YP_TOKEN_KEYWORD_ELSE)) {
+    if (accept1(parser, YP_TOKEN_KEYWORD_ELSE)) {
         yp_token_t else_keyword = parser->previous;
-        accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
         yp_statements_node_t *else_statements = NULL;
-        if (!match_any_2_type_p(parser, YP_TOKEN_KEYWORD_END, YP_TOKEN_KEYWORD_ENSURE)) {
+        if (!match2(parser, YP_TOKEN_KEYWORD_END, YP_TOKEN_KEYWORD_ENSURE)) {
             yp_accepts_block_stack_push(parser, true);
             else_statements = parse_statements(parser, YP_CONTEXT_RESCUE_ELSE);
             yp_accepts_block_stack_pop(parser);
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
         }
 
         yp_else_node_t *else_clause = yp_else_node_create(parser, &else_keyword, else_statements, &parser->current);
         yp_begin_node_else_clause_set(parent_node, else_clause);
     }
 
-    if (accept(parser, YP_TOKEN_KEYWORD_ENSURE)) {
+    if (accept1(parser, YP_TOKEN_KEYWORD_ENSURE)) {
         yp_token_t ensure_keyword = parser->previous;
-        accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
         yp_statements_node_t *ensure_statements = NULL;
-        if (!match_type_p(parser, YP_TOKEN_KEYWORD_END)) {
+        if (!match1(parser, YP_TOKEN_KEYWORD_END)) {
             yp_accepts_block_stack_push(parser, true);
             ensure_statements = parse_statements(parser, YP_CONTEXT_ENSURE);
             yp_accepts_block_stack_pop(parser);
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
         }
 
         yp_ensure_node_t *ensure_clause = yp_ensure_node_create(parser, &ensure_keyword, ensure_statements, &parser->current);
@@ -9416,7 +9432,7 @@ parse_block_parameters(
     bool is_lambda_literal
 ) {
     yp_parameters_node_t *parameters = NULL;
-    if (!match_type_p(parser, YP_TOKEN_SEMICOLON)) {
+    if (!match1(parser, YP_TOKEN_SEMICOLON)) {
         parameters = parse_parameters(
             parser,
             is_lambda_literal ? YP_BINDING_POWER_DEFINED : YP_BINDING_POWER_INDEX,
@@ -9427,14 +9443,14 @@ parse_block_parameters(
     }
 
     yp_block_parameters_node_t *block_parameters = yp_block_parameters_node_create(parser, parameters, opening);
-    if (accept(parser, YP_TOKEN_SEMICOLON)) {
+    if (accept1(parser, YP_TOKEN_SEMICOLON)) {
         do {
-            expect(parser, YP_TOKEN_IDENTIFIER, YP_ERR_BLOCK_PARAM_LOCAL_VARIABLE);
+            expect1(parser, YP_TOKEN_IDENTIFIER, YP_ERR_BLOCK_PARAM_LOCAL_VARIABLE);
             yp_parser_local_add_token(parser, &parser->previous);
 
             yp_block_local_variable_node_t *local = yp_block_local_variable_node_create(parser, &parser->previous);
             yp_block_parameters_node_append_local(block_parameters, local);
-        } while (accept(parser, YP_TOKEN_COMMA));
+        } while (accept1(parser, YP_TOKEN_COMMA));
     }
 
     return block_parameters;
@@ -9444,53 +9460,53 @@ parse_block_parameters(
 static yp_block_node_t *
 parse_block(yp_parser_t *parser) {
     yp_token_t opening = parser->previous;
-    accept(parser, YP_TOKEN_NEWLINE);
+    accept1(parser, YP_TOKEN_NEWLINE);
 
     yp_accepts_block_stack_push(parser, true);
     yp_parser_scope_push(parser, false);
     yp_block_parameters_node_t *parameters = NULL;
 
-    if (accept(parser, YP_TOKEN_PIPE)) {
+    if (accept1(parser, YP_TOKEN_PIPE)) {
         yp_token_t block_parameters_opening = parser->previous;
 
-        if (match_type_p(parser, YP_TOKEN_PIPE)) {
+        if (match1(parser, YP_TOKEN_PIPE)) {
             parameters = yp_block_parameters_node_create(parser, NULL, &block_parameters_opening);
             parser->command_start = true;
             parser_lex(parser);
         } else {
             parameters = parse_block_parameters(parser, true, &block_parameters_opening, false);
-            accept(parser, YP_TOKEN_NEWLINE);
+            accept1(parser, YP_TOKEN_NEWLINE);
             parser->command_start = true;
-            expect(parser, YP_TOKEN_PIPE, YP_ERR_BLOCK_PARAM_PIPE_TERM);
+            expect1(parser, YP_TOKEN_PIPE, YP_ERR_BLOCK_PARAM_PIPE_TERM);
         }
 
         yp_block_parameters_node_closing_set(parameters, &parser->previous);
     }
 
-    accept(parser, YP_TOKEN_NEWLINE);
+    accept1(parser, YP_TOKEN_NEWLINE);
     yp_node_t *statements = NULL;
 
     if (opening.type == YP_TOKEN_BRACE_LEFT) {
-        if (!match_type_p(parser, YP_TOKEN_BRACE_RIGHT)) {
+        if (!match1(parser, YP_TOKEN_BRACE_RIGHT)) {
             statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_BLOCK_BRACES);
         }
 
-        expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_BLOCK_TERM_BRACE);
+        expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_BLOCK_TERM_BRACE);
     } else {
-        if (!match_type_p(parser, YP_TOKEN_KEYWORD_END)) {
-            if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_ENSURE)) {
+        if (!match1(parser, YP_TOKEN_KEYWORD_END)) {
+            if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_ENSURE)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_BLOCK_KEYWORDS);
                 yp_accepts_block_stack_pop(parser);
             }
 
-            if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+            if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                 assert(statements == NULL || YP_NODE_TYPE_P(statements, YP_STATEMENTS_NODE));
                 statements = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) statements);
             }
         }
 
-        expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_BLOCK_TERM_END);
+        expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_BLOCK_TERM_END);
     }
 
     yp_constant_id_list_t locals = parser->current_scope->locals;
@@ -9506,23 +9522,23 @@ static bool
 parse_arguments_list(yp_parser_t *parser, yp_arguments_t *arguments, bool accepts_block) {
     bool found = false;
 
-    if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+    if (accept1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
         found |= true;
         arguments->opening_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
 
-        if (accept(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+        if (accept1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
             arguments->closing_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
         } else {
             arguments->arguments = yp_arguments_node_create(parser);
 
             yp_accepts_block_stack_push(parser, true);
             parse_arguments(parser, arguments, true, YP_TOKEN_PARENTHESIS_RIGHT);
-            expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_ARGUMENT_TERM_PAREN);
+            expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_ARGUMENT_TERM_PAREN);
             yp_accepts_block_stack_pop(parser);
 
             arguments->closing_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
         }
-    } else if ((token_begins_expression_p(parser->current.type) || match_any_3_type_p(parser, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR, YP_TOKEN_UAMPERSAND)) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT)) {
+    } else if ((token_begins_expression_p(parser->current.type) || match3(parser, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR, YP_TOKEN_UAMPERSAND)) && !match1(parser, YP_TOKEN_BRACE_LEFT)) {
         found |= true;
         yp_accepts_block_stack_push(parser, false);
 
@@ -9539,10 +9555,10 @@ parse_arguments_list(yp_parser_t *parser, yp_arguments_t *arguments, bool accept
     // node that starts with a {. If there is, then we can parse it and add it to
     // the arguments.
     if (accepts_block) {
-        if (accept(parser, YP_TOKEN_BRACE_LEFT)) {
+        if (accept1(parser, YP_TOKEN_BRACE_LEFT)) {
             found |= true;
             arguments->block = parse_block(parser);
-        } else if (yp_accepts_block_stack_p(parser) && accept(parser, YP_TOKEN_KEYWORD_DO)) {
+        } else if (yp_accepts_block_stack_p(parser) && accept1(parser, YP_TOKEN_KEYWORD_DO)) {
             found |= true;
             arguments->block = parse_block(parser);
         }
@@ -9561,17 +9577,17 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
     yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_MODIFIER, error_id);
 
     // Predicates are closed by a term, a "then", or a term and then a "then".
-    accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-    accept(parser, YP_TOKEN_KEYWORD_THEN);
+    accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+    accept1(parser, YP_TOKEN_KEYWORD_THEN);
 
     context_pop(parser);
     yp_statements_node_t *statements = NULL;
 
-    if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_ELSIF, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
+    if (!match3(parser, YP_TOKEN_KEYWORD_ELSIF, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
         yp_accepts_block_stack_push(parser, true);
         statements = parse_statements(parser, context);
         yp_accepts_block_stack_pop(parser);
-        accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
     }
 
     yp_token_t end_keyword = not_provided(parser);
@@ -9594,19 +9610,19 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
     // Parse any number of elsif clauses. This will form a linked list of if
     // nodes pointing to each other from the top.
     if (context == YP_CONTEXT_IF) {
-        while (accept(parser, YP_TOKEN_KEYWORD_ELSIF)) {
+        while (accept1(parser, YP_TOKEN_KEYWORD_ELSIF)) {
             yp_token_t elsif_keyword = parser->previous;
             yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_MODIFIER, YP_ERR_CONDITIONAL_ELSIF_PREDICATE);
 
             // Predicates are closed by a term, a "then", or a term and then a "then".
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-            accept(parser, YP_TOKEN_KEYWORD_THEN);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept1(parser, YP_TOKEN_KEYWORD_THEN);
 
             yp_accepts_block_stack_push(parser, true);
             yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_ELSIF);
             yp_accepts_block_stack_pop(parser);
 
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
             yp_node_t *elsif = (yp_node_t *) yp_if_node_create(parser, &elsif_keyword, predicate, statements, NULL, &end_keyword);
             ((yp_if_node_t *) current)->consequent = elsif;
@@ -9614,7 +9630,7 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
         }
     }
 
-    if (match_type_p(parser, YP_TOKEN_KEYWORD_ELSE)) {
+    if (match1(parser, YP_TOKEN_KEYWORD_ELSE)) {
         parser_lex(parser);
         yp_token_t else_keyword = parser->previous;
 
@@ -9622,8 +9638,8 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
         yp_statements_node_t *else_statements = parse_statements(parser, YP_CONTEXT_ELSE);
         yp_accepts_block_stack_pop(parser);
 
-        accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-        expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CONDITIONAL_TERM_ELSE);
+        accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CONDITIONAL_TERM_ELSE);
 
         yp_else_node_t *else_node = yp_else_node_create(parser, &else_keyword, else_statements, &parser->previous);
 
@@ -9640,7 +9656,7 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
         }
     } else {
         // We should specialize this error message to refer to 'if' or 'unless' explicitly.
-        expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CONDITIONAL_TERM);
+        expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CONDITIONAL_TERM);
     }
 
     // Set the appropriate end location for all of the nodes in the subtree.
@@ -9781,7 +9797,7 @@ parse_string_part(yp_parser_t *parser) {
             yp_token_t opening = parser->previous;
             yp_statements_node_t *statements = NULL;
 
-            if (!match_type_p(parser, YP_TOKEN_EMBEXPR_END)) {
+            if (!match1(parser, YP_TOKEN_EMBEXPR_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = parse_statements(parser, YP_CONTEXT_EMBEXPR);
                 yp_accepts_block_stack_pop(parser);
@@ -9790,7 +9806,7 @@ parse_string_part(yp_parser_t *parser) {
             parser->brace_nesting = brace_nesting;
             lex_state_set(parser, state);
 
-            expect(parser, YP_TOKEN_EMBEXPR_END, YP_ERR_EMBEXPR_END);
+            expect1(parser, YP_TOKEN_EMBEXPR_END, YP_ERR_EMBEXPR_END);
             yp_token_t closing = parser->previous;
 
             return (yp_node_t *) yp_embedded_statements_node_create(parser, &opening, statements, &closing);
@@ -9844,7 +9860,7 @@ parse_string_part(yp_parser_t *parser) {
                 // we'll not attempt to lex this token and instead just return a
                 // missing node.
                 default:
-                    expect(parser, YP_TOKEN_IDENTIFIER, YP_ERR_EMBVAR_INVALID);
+                    expect1(parser, YP_TOKEN_IDENTIFIER, YP_ERR_EMBVAR_INVALID);
                     variable = (yp_node_t *) yp_missing_node_create(parser, parser->current.start, parser->current.end);
                     break;
             }
@@ -9884,7 +9900,7 @@ parse_symbol(yp_parser_t *parser, yp_lex_mode_t *lex_mode, yp_lex_state_t next_s
                 symbol = parser->previous;
                 break;
             default:
-                expect(parser, YP_TOKEN_IDENTIFIER, YP_ERR_SYMBOL_INVALID);
+                expect1(parser, YP_TOKEN_IDENTIFIER, YP_ERR_SYMBOL_INVALID);
                 symbol = parser->previous;
                 break;
         }
@@ -9895,7 +9911,7 @@ parse_symbol(yp_parser_t *parser, yp_lex_mode_t *lex_mode, yp_lex_state_t next_s
 
     if (lex_mode->as.string.interpolation) {
         // If we have the end of the symbol, then we can return an empty symbol.
-        if (match_type_p(parser, YP_TOKEN_STRING_END)) {
+        if (match1(parser, YP_TOKEN_STRING_END)) {
             if (next_state != YP_LEX_STATE_NONE) lex_state_set(parser, next_state);
             parser_lex(parser);
 
@@ -9909,7 +9925,7 @@ parse_symbol(yp_parser_t *parser, yp_lex_mode_t *lex_mode, yp_lex_state_t next_s
 
         // If we got a string part, then it's possible that we could transform
         // what looks like an interpolated symbol into a regular symbol.
-        if (part && YP_NODE_TYPE_P(part, YP_STRING_NODE) && match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+        if (part && YP_NODE_TYPE_P(part, YP_STRING_NODE) && match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
             if (next_state != YP_LEX_STATE_NONE) lex_state_set(parser, next_state);
             parser_lex(parser);
 
@@ -9921,20 +9937,20 @@ parse_symbol(yp_parser_t *parser, yp_lex_mode_t *lex_mode, yp_lex_state_t next_s
         yp_node_list_t node_list = YP_EMPTY_NODE_LIST;
         if (part) yp_node_list_append(&node_list, part);
 
-        while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+        while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
             if ((part = parse_string_part(parser)) != NULL) {
                 yp_node_list_append(&node_list, part);
             }
         }
 
         if (next_state != YP_LEX_STATE_NONE) lex_state_set(parser, next_state);
-        expect(parser, YP_TOKEN_STRING_END, YP_ERR_SYMBOL_TERM_INTERPOLATED);
+        expect1(parser, YP_TOKEN_STRING_END, YP_ERR_SYMBOL_TERM_INTERPOLATED);
 
         return (yp_node_t *) yp_interpolated_symbol_node_create(parser, &opening, &node_list, &parser->previous);
     }
 
     yp_token_t content;
-    if (accept(parser, YP_TOKEN_STRING_CONTENT)) {
+    if (accept1(parser, YP_TOKEN_STRING_CONTENT)) {
         content = parser->previous;
     } else {
         content = (yp_token_t) { .type = YP_TOKEN_STRING_CONTENT, .start = parser->previous.end, .end = parser->previous.end };
@@ -9943,7 +9959,7 @@ parse_symbol(yp_parser_t *parser, yp_lex_mode_t *lex_mode, yp_lex_state_t next_s
     if (next_state != YP_LEX_STATE_NONE) {
         lex_state_set(parser, next_state);
     }
-    expect(parser, YP_TOKEN_STRING_END, YP_ERR_SYMBOL_TERM_DYNAMIC);
+    expect1(parser, YP_TOKEN_STRING_END, YP_ERR_SYMBOL_TERM_DYNAMIC);
 
     return (yp_node_t *) yp_symbol_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
 }
@@ -10023,7 +10039,7 @@ static yp_node_t *
 parse_variable_call(yp_parser_t *parser) {
     yp_node_flags_t flags = 0;
 
-    if (!match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) && (parser->previous.end[-1] != '!') && (parser->previous.end[-1] != '?')) {
+    if (!match1(parser, YP_TOKEN_PARENTHESIS_LEFT) && (parser->previous.end[-1] != '!') && (parser->previous.end[-1] != '?')) {
         int depth;
         if ((depth = yp_parser_local_depth(parser, &parser->previous)) != -1) {
             return (yp_node_t *) yp_local_variable_read_node_create(parser, &parser->previous, (uint32_t) depth);
@@ -10256,9 +10272,9 @@ static yp_node_t *
 parse_pattern_constant_path(yp_parser_t *parser, yp_node_t *node) {
     // Now, if there are any :: operators that follow, parse them as constant
     // path nodes.
-    while (accept(parser, YP_TOKEN_COLON_COLON)) {
+    while (accept1(parser, YP_TOKEN_COLON_COLON)) {
         yp_token_t delimiter = parser->previous;
-        expect(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
+        expect1(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
 
         yp_node_t *child = (yp_node_t *) yp_constant_read_node_create(parser, &parser->previous);
         node = (yp_node_t *)yp_constant_path_node_create(parser, node, &delimiter, child);
@@ -10267,7 +10283,7 @@ parse_pattern_constant_path(yp_parser_t *parser, yp_node_t *node) {
     // If there is a [ or ( that follows, then this is part of a larger pattern
     // expression. We'll parse the inner pattern here, then modify the returned
     // inner pattern with our constant path attached.
-    if (!match_any_2_type_p(parser, YP_TOKEN_BRACKET_LEFT, YP_TOKEN_PARENTHESIS_LEFT)) {
+    if (!match2(parser, YP_TOKEN_BRACKET_LEFT, YP_TOKEN_PARENTHESIS_LEFT)) {
         return node;
     }
 
@@ -10275,14 +10291,14 @@ parse_pattern_constant_path(yp_parser_t *parser, yp_node_t *node) {
     yp_token_t closing;
     yp_node_t *inner = NULL;
 
-    if (accept(parser, YP_TOKEN_BRACKET_LEFT)) {
+    if (accept1(parser, YP_TOKEN_BRACKET_LEFT)) {
         opening = parser->previous;
-        accept(parser, YP_TOKEN_NEWLINE);
+        accept1(parser, YP_TOKEN_NEWLINE);
 
-        if (!accept(parser, YP_TOKEN_BRACKET_RIGHT)) {
+        if (!accept1(parser, YP_TOKEN_BRACKET_RIGHT)) {
             inner = parse_pattern(parser, true, YP_ERR_PATTERN_EXPRESSION_AFTER_BRACKET);
-            accept(parser, YP_TOKEN_NEWLINE);
-            expect(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_PATTERN_TERM_BRACKET);
+            accept1(parser, YP_TOKEN_NEWLINE);
+            expect1(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_PATTERN_TERM_BRACKET);
         }
 
         closing = parser->previous;
@@ -10290,9 +10306,9 @@ parse_pattern_constant_path(yp_parser_t *parser, yp_node_t *node) {
         parser_lex(parser);
         opening = parser->previous;
 
-        if (!accept(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+        if (!accept1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
             inner = parse_pattern(parser, true, YP_ERR_PATTERN_EXPRESSION_AFTER_PAREN);
-            expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
+            expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
         }
 
         closing = parser->previous;
@@ -10379,7 +10395,7 @@ parse_pattern_rest(yp_parser_t *parser) {
     // Rest patterns don't necessarily have a name associated with them. So we
     // will check for that here. If they do, then we'll add it to the local table
     // since this pattern will cause it to become a local variable.
-    if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+    if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
         yp_token_t identifier = parser->previous;
         yp_parser_local_add_token(parser, &identifier);
         name = (yp_node_t *) yp_local_variable_target_node_create(parser, &identifier);
@@ -10398,11 +10414,11 @@ parse_pattern_keyword_rest(yp_parser_t *parser) {
     yp_token_t operator = parser->previous;
     yp_node_t *value = NULL;
 
-    if (accept(parser, YP_TOKEN_KEYWORD_NIL)) {
+    if (accept1(parser, YP_TOKEN_KEYWORD_NIL)) {
         return (yp_node_t *) yp_no_keywords_parameter_node_create(parser, &operator, &parser->previous);
     }
 
-    if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+    if (accept1(parser, YP_TOKEN_IDENTIFIER)) {
         yp_parser_local_add_token(parser, &parser->previous);
         value = (yp_node_t *) yp_local_variable_target_node_create(parser, &parser->previous);
     }
@@ -10414,7 +10430,7 @@ parse_pattern_keyword_rest(yp_parser_t *parser) {
 static yp_hash_pattern_node_t *
 parse_pattern_hash(yp_parser_t *parser, yp_node_t *first_assoc) {
     if (YP_NODE_TYPE_P(first_assoc, YP_ASSOC_NODE)) {
-        if (!match_any_type_p(parser, 7, YP_TOKEN_COMMA, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+        if (!match7(parser, YP_TOKEN_COMMA, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
             // Here we have a value for the first assoc in the list, so we will parse it
             // now and update the first assoc.
             yp_node_t *value = parse_pattern(parser, false, YP_ERR_PATTERN_EXPRESSION_AFTER_KEY);
@@ -10436,22 +10452,22 @@ parse_pattern_hash(yp_parser_t *parser, yp_node_t *first_assoc) {
     yp_node_list_append(&assocs, first_assoc);
 
     // If there are any other assocs, then we'll parse them now.
-    while (accept(parser, YP_TOKEN_COMMA)) {
+    while (accept1(parser, YP_TOKEN_COMMA)) {
         // Here we need to break to support trailing commas.
-        if (match_any_type_p(parser, 6, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+        if (match6(parser, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
             break;
         }
 
         yp_node_t *assoc;
 
-        if (match_type_p(parser, YP_TOKEN_USTAR_STAR)) {
+        if (match1(parser, YP_TOKEN_USTAR_STAR)) {
             assoc = parse_pattern_keyword_rest(parser);
         } else {
-            expect(parser, YP_TOKEN_LABEL, YP_ERR_PATTERN_LABEL_AFTER_COMMA);
+            expect1(parser, YP_TOKEN_LABEL, YP_ERR_PATTERN_LABEL_AFTER_COMMA);
             yp_node_t *key = (yp_node_t *) yp_symbol_node_label_create(parser, &parser->previous);
             yp_node_t *value = NULL;
 
-            if (!match_any_type_p(parser, 7, YP_TOKEN_COMMA, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+            if (!match7(parser, YP_TOKEN_COMMA, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
                 value = parse_pattern(parser, false, YP_ERR_PATTERN_EXPRESSION_AFTER_KEY);
             } else {
                 const yp_location_t *value_loc = &((yp_symbol_node_t *) key)->value_loc;
@@ -10484,7 +10500,7 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
             yp_token_t opening = parser->current;
             parser_lex(parser);
 
-            if (accept(parser, YP_TOKEN_BRACKET_RIGHT)) {
+            if (accept1(parser, YP_TOKEN_BRACKET_RIGHT)) {
                 // If we have an empty array pattern, then we'll just return a new
                 // array pattern node.
                 return (yp_node_t *)yp_array_pattern_node_empty_create(parser, &opening, &parser->previous);
@@ -10494,9 +10510,9 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
             // on the type it returns.
             yp_node_t *inner = parse_pattern(parser, true, YP_ERR_PATTERN_EXPRESSION_AFTER_BRACKET);
 
-            accept(parser, YP_TOKEN_NEWLINE);
+            accept1(parser, YP_TOKEN_NEWLINE);
 
-            expect(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_PATTERN_TERM_BRACKET);
+            expect1(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_PATTERN_TERM_BRACKET);
             yp_token_t closing = parser->previous;
 
             switch (YP_NODE_TYPE(inner)) {
@@ -10544,7 +10560,7 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
             yp_token_t opening = parser->current;
             parser_lex(parser);
 
-            if (accept(parser, YP_TOKEN_BRACE_RIGHT)) {
+            if (accept1(parser, YP_TOKEN_BRACE_RIGHT)) {
                 // If we have an empty hash pattern, then we'll just return a new hash
                 // pattern node.
                 node = yp_hash_pattern_node_empty_create(parser, &opening, &parser->previous);
@@ -10576,8 +10592,8 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
                 yp_token_t operator = not_provided(parser);
                 node = parse_pattern_hash(parser, (yp_node_t *) yp_assoc_node_create(parser, key, &operator, NULL));
 
-                accept(parser, YP_TOKEN_NEWLINE);
-                expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_PATTERN_TERM_BRACE);
+                accept1(parser, YP_TOKEN_NEWLINE);
+                expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_PATTERN_TERM_BRACE);
                 yp_token_t closing = parser->previous;
 
                 node->base.location.start = opening.start;
@@ -10613,7 +10629,7 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
             yp_node_t *node = parse_expression(parser, YP_BINDING_POWER_MAX, diag_id);
 
             // Now that we have a primitive, we need to check if it's part of a range.
-            if (accept_any_2(parser, YP_TOKEN_DOT_DOT, YP_TOKEN_DOT_DOT_DOT)) {
+            if (accept2(parser, YP_TOKEN_DOT_DOT, YP_TOKEN_DOT_DOT_DOT)) {
                 yp_token_t operator = parser->previous;
 
                 // Now that we have the operator, we need to check if this is followed
@@ -10684,8 +10700,8 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
                     yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_STATEMENT, YP_ERR_PATTERN_EXPRESSION_AFTER_PIN);
                     parser->pattern_matching_newlines = previous_pattern_matching_newlines;
 
-                    accept(parser, YP_TOKEN_NEWLINE);
-                    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
+                    accept1(parser, YP_TOKEN_NEWLINE);
+                    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
                     return (yp_node_t *) yp_pinned_expression_node_create(parser, expression, &operator, &lparen, &parser->previous);
                 }
                 default: {
@@ -10701,7 +10717,7 @@ parse_pattern_primitive(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
             yp_token_t delimiter = parser->current;
             parser_lex(parser);
 
-            expect(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
+            expect1(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
             yp_node_t *child = (yp_node_t *) yp_constant_read_node_create(parser, &parser->previous);
             yp_constant_path_node_t *node = yp_constant_path_node_create(parser, NULL, &delimiter, child);
 
@@ -10755,7 +10771,7 @@ parse_pattern_primitives(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
                 }
                 node = parse_pattern(parser, false, YP_ERR_PATTERN_EXPRESSION_AFTER_PAREN);
 
-                expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
+                expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_PATTERN_TERM_PAREN);
                 break;
             }
             default: {
@@ -10771,14 +10787,14 @@ parse_pattern_primitives(yp_parser_t *parser, yp_diagnostic_id_t diag_id) {
                 break;
             }
         }
-    } while (accept(parser, YP_TOKEN_PIPE));
+    } while (accept1(parser, YP_TOKEN_PIPE));
 
     // If we have an =>, then we are assigning this pattern to a variable.
     // In this case we should create an assignment node.
-    while (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+    while (accept1(parser, YP_TOKEN_EQUAL_GREATER)) {
         yp_token_t operator = parser->previous;
 
-        expect(parser, YP_TOKEN_IDENTIFIER, YP_ERR_PATTERN_IDENT_AFTER_HROCKET);
+        expect1(parser, YP_TOKEN_IDENTIFIER, YP_ERR_PATTERN_IDENT_AFTER_HROCKET);
         yp_token_t identifier = parser->previous;
         yp_parser_local_add_token(parser, &identifier);
 
@@ -10830,7 +10846,7 @@ parse_pattern(yp_parser_t *parser, bool top_pattern, yp_diagnostic_id_t diag_id)
         return (yp_node_t *) parse_pattern_hash(parser, (yp_node_t *) yp_assoc_node_create(parser, node, &operator, NULL));
     }
 
-    if (top_pattern && match_type_p(parser, YP_TOKEN_COMMA)) {
+    if (top_pattern && match1(parser, YP_TOKEN_COMMA)) {
         // If we have a comma, then we are now parsing either an array pattern or a
         // find pattern. We need to parse all of the patterns, put them into a big
         // list, and then determine which type of node we have.
@@ -10838,13 +10854,13 @@ parse_pattern(yp_parser_t *parser, bool top_pattern, yp_diagnostic_id_t diag_id)
         yp_node_list_append(&nodes, node);
 
         // Gather up all of the patterns into the list.
-        while (accept(parser, YP_TOKEN_COMMA)) {
+        while (accept1(parser, YP_TOKEN_COMMA)) {
             // Break early here in case we have a trailing comma.
-            if (match_any_type_p(parser, 5, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+            if (match5(parser, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
                 break;
             }
 
-            if (accept(parser, YP_TOKEN_USTAR)) {
+            if (accept1(parser, YP_TOKEN_USTAR)) {
                 node = (yp_node_t *) parse_pattern_rest(parser);
 
                 // If we have already parsed a splat pattern, then this is an error. We
@@ -10918,7 +10934,7 @@ parse_strings(yp_parser_t *parser) {
     assert(parser->current.type == YP_TOKEN_STRING_BEGIN);
     yp_node_t *result = NULL;
 
-    while (match_type_p(parser, YP_TOKEN_STRING_BEGIN)) {
+    while (match1(parser, YP_TOKEN_STRING_BEGIN)) {
         yp_node_t *node = NULL;
 
         // Here we have found a string literal. We'll parse it and add it to
@@ -10929,13 +10945,13 @@ parse_strings(yp_parser_t *parser) {
         yp_token_t opening = parser->current;
         parser_lex(parser);
 
-        if (accept(parser, YP_TOKEN_STRING_END)) {
+        if (accept1(parser, YP_TOKEN_STRING_END)) {
             // If we get here, then we have an end immediately after a
             // start. In that case we'll create an empty content token and
             // return an uninterpolated string.
             yp_token_t content = parse_strings_empty_content(parser->previous.start);
             node = (yp_node_t *) yp_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_NONE);
-        } else if (accept(parser, YP_TOKEN_LABEL_END)) {
+        } else if (accept1(parser, YP_TOKEN_LABEL_END)) {
             // If we get here, then we have an end of a label immediately
             // after a start. In that case we'll create an empty symbol
             // node.
@@ -10945,7 +10961,7 @@ parse_strings(yp_parser_t *parser) {
         } else if (!lex_interpolation) {
             // If we don't accept interpolation then we expect the string to
             // start with a single string content node.
-            expect(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_EXPECT_STRING_CONTENT);
+            expect1(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_EXPECT_STRING_CONTENT);
             yp_token_t content = parser->previous;
 
             // It is unfortunately possible to have multiple string content
@@ -10959,27 +10975,27 @@ parse_strings(yp_parser_t *parser) {
             //
             // In that case we need to switch to an interpolated string to
             // be able to contain all of the parts.
-            if (match_type_p(parser, YP_TOKEN_STRING_CONTENT)) {
+            if (match1(parser, YP_TOKEN_STRING_CONTENT)) {
                 yp_node_list_t parts = YP_EMPTY_NODE_LIST;
 
                 yp_token_t delimiters = not_provided(parser);
                 yp_node_t *part = (yp_node_t *) yp_string_node_create_and_unescape(parser, &delimiters, &content, &delimiters, YP_UNESCAPE_MINIMAL);
                 yp_node_list_append(&parts, part);
 
-                while (accept(parser, YP_TOKEN_STRING_CONTENT)) {
+                while (accept1(parser, YP_TOKEN_STRING_CONTENT)) {
                     part = (yp_node_t *) yp_string_node_create_and_unescape(parser, &delimiters, &parser->previous, &delimiters, YP_UNESCAPE_MINIMAL);
                     yp_node_list_append(&parts, part);
                 }
 
-                expect(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_LITERAL_TERM);
+                expect1(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_LITERAL_TERM);
                 node = (yp_node_t *) yp_interpolated_string_node_create(parser, &opening, &parts, &parser->previous);
-            } else if (accept(parser, YP_TOKEN_LABEL_END)) {
+            } else if (accept1(parser, YP_TOKEN_LABEL_END)) {
                 node = (yp_node_t *) yp_symbol_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
             } else {
-                expect(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_LITERAL_TERM);
+                expect1(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_LITERAL_TERM);
                 node = (yp_node_t *) yp_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_MINIMAL);
             }
-        } else if (match_type_p(parser, YP_TOKEN_STRING_CONTENT)) {
+        } else if (match1(parser, YP_TOKEN_STRING_CONTENT)) {
             // In this case we've hit string content so we know the string
             // at least has something in it. We'll need to check if the
             // following token is the end (in which case we can return a
@@ -10987,9 +11003,9 @@ parse_strings(yp_parser_t *parser) {
             yp_token_t content = parser->current;
             parser_lex(parser);
 
-            if (accept(parser, YP_TOKEN_STRING_END)) {
+            if (accept1(parser, YP_TOKEN_STRING_END)) {
                 node = (yp_node_t *) yp_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
-            } else if (accept(parser, YP_TOKEN_LABEL_END)) {
+            } else if (accept1(parser, YP_TOKEN_LABEL_END)) {
                 node = (yp_node_t *) yp_symbol_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
             } else {
                 // If we get here, then we have interpolation so we'll need
@@ -11001,16 +11017,16 @@ parse_strings(yp_parser_t *parser) {
                 yp_node_t *part = (yp_node_t *) yp_string_node_create_and_unescape(parser, &string_opening, &parser->previous, &string_closing, YP_UNESCAPE_ALL);
                 yp_node_list_append(&parts, part);
 
-                while (!match_any_type_p(parser, 3, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
+                while (!match3(parser, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
                     if ((part = parse_string_part(parser)) != NULL) {
                         yp_node_list_append(&parts, part);
                     }
                 }
 
-                if (accept(parser, YP_TOKEN_LABEL_END)) {
+                if (accept1(parser, YP_TOKEN_LABEL_END)) {
                     node = (yp_node_t *) yp_interpolated_symbol_node_create(parser, &opening, &parts, &parser->previous);
                 } else {
-                    expect(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_INTERPOLATED_TERM);
+                    expect1(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_INTERPOLATED_TERM);
                     node = (yp_node_t *) yp_interpolated_string_node_create(parser, &opening, &parts, &parser->previous);
                 }
             }
@@ -11021,16 +11037,16 @@ parse_strings(yp_parser_t *parser) {
             yp_node_list_t parts = YP_EMPTY_NODE_LIST;
             yp_node_t *part = NULL;
 
-            while (!match_any_type_p(parser, 3, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
+            while (!match3(parser, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
                 if ((part = parse_string_part(parser)) != NULL) {
                     yp_node_list_append(&parts, part);
                 }
             }
 
-            if (accept(parser, YP_TOKEN_LABEL_END)) {
+            if (accept1(parser, YP_TOKEN_LABEL_END)) {
                 node = (yp_node_t *) yp_interpolated_symbol_node_create(parser, &opening, &parts, &parser->previous);
             } else {
-                expect(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_INTERPOLATED_TERM);
+                expect1(parser, YP_TOKEN_STRING_END, YP_ERR_STRING_INTERPOLATED_TERM);
                 node = (yp_node_t *) yp_interpolated_string_node_create(parser, &opening, &parts, &parser->previous);
             }
         }
@@ -11074,28 +11090,28 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_accepts_block_stack_push(parser, true);
             bool parsed_bare_hash = false;
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_EOF)) {
+            while (!match2(parser, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_EOF)) {
                 // Handle the case where we don't have a comma and we have a newline followed by a right bracket.
-                if (accept(parser, YP_TOKEN_NEWLINE) && match_type_p(parser, YP_TOKEN_BRACKET_RIGHT)) {
+                if (accept1(parser, YP_TOKEN_NEWLINE) && match1(parser, YP_TOKEN_BRACKET_RIGHT)) {
                     break;
                 }
 
                 if (yp_array_node_size(array) != 0) {
-                    expect(parser, YP_TOKEN_COMMA, YP_ERR_ARRAY_SEPARATOR);
+                    expect1(parser, YP_TOKEN_COMMA, YP_ERR_ARRAY_SEPARATOR);
                 }
 
                 // If we have a right bracket immediately following a comma, this is
                 // allowed since it's a trailing comma. In this case we can break out of
                 // the loop.
-                if (match_type_p(parser, YP_TOKEN_BRACKET_RIGHT)) break;
+                if (match1(parser, YP_TOKEN_BRACKET_RIGHT)) break;
 
                 yp_node_t *element;
 
-                if (accept(parser, YP_TOKEN_USTAR)) {
+                if (accept1(parser, YP_TOKEN_USTAR)) {
                     yp_token_t operator = parser->previous;
                     yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_ARRAY_EXPRESSION_AFTER_STAR);
                     element = (yp_node_t *) yp_splat_node_create(parser, &operator, expression);
-                } else if (match_any_2_type_p(parser, YP_TOKEN_LABEL, YP_TOKEN_USTAR_STAR)) {
+                } else if (match2(parser, YP_TOKEN_LABEL, YP_TOKEN_USTAR_STAR)) {
                     if (parsed_bare_hash) {
                         yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, YP_ERR_EXPRESSION_BARE_HASH);
                     }
@@ -11103,7 +11119,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     yp_keyword_hash_node_t *hash = yp_keyword_hash_node_create(parser);
                     element = (yp_node_t *)hash;
 
-                    if (!match_any_type_p(parser, 8, YP_TOKEN_EOF, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_KEYWORD_DO, YP_TOKEN_PARENTHESIS_RIGHT)) {
+                    if (!match8(parser, YP_TOKEN_EOF, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_KEYWORD_DO, YP_TOKEN_PARENTHESIS_RIGHT)) {
                         parse_assocs(parser, (yp_node_t *) hash);
                     }
 
@@ -11111,7 +11127,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 } else {
                     element = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_ARRAY_EXPRESSION);
 
-                    if (yp_symbol_node_label_p(element) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+                    if (yp_symbol_node_label_p(element) || accept1(parser, YP_TOKEN_EQUAL_GREATER)) {
                         if (parsed_bare_hash) {
                             yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, YP_ERR_EXPRESSION_BARE_HASH);
                         }
@@ -11130,7 +11146,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                         yp_keyword_hash_node_elements_append(hash, assoc);
 
                         element = (yp_node_t *)hash;
-                        if (accept(parser, YP_TOKEN_COMMA) && !match_type_p(parser, YP_TOKEN_BRACKET_RIGHT)) {
+                        if (accept1(parser, YP_TOKEN_COMMA) && !match1(parser, YP_TOKEN_BRACKET_RIGHT)) {
                             parse_assocs(parser, (yp_node_t *) hash);
                         }
 
@@ -11142,8 +11158,8 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 if (YP_NODE_TYPE_P(element, YP_MISSING_NODE)) break;
             }
 
-            accept(parser, YP_TOKEN_NEWLINE);
-            expect(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_ARRAY_TERM);
+            accept1(parser, YP_TOKEN_NEWLINE);
+            expect1(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_ARRAY_TERM);
             yp_array_node_close_set(array, &parser->previous);
             yp_accepts_block_stack_pop(parser);
 
@@ -11153,12 +11169,12 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         case YP_TOKEN_PARENTHESIS_LEFT_PARENTHESES: {
             yp_token_t opening = parser->current;
             parser_lex(parser);
-            while (accept_any_2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE));
+            while (accept2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE));
 
             // If this is the end of the file or we match a right parenthesis, then
             // we have an empty parentheses node, and we can immediately return.
-            if (match_any_2_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_EOF)) {
-                expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+            if (match2(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_TOKEN_EOF)) {
+                expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
                 return (yp_node_t *) yp_parentheses_node_create(parser, &opening, NULL, &parser->previous);
             }
 
@@ -11166,11 +11182,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // statements within the parentheses.
             yp_accepts_block_stack_push(parser, true);
             yp_node_t *statement = parse_expression(parser, YP_BINDING_POWER_STATEMENT, YP_ERR_CANNOT_PARSE_EXPRESSION);
-            while (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
+            while (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
 
             // If we hit a right parenthesis, then we're done parsing the parentheses
             // node, and we can check which kind of node we should return.
-            if (match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+            if (match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
                 if (opening.type == YP_TOKEN_PARENTHESIS_LEFT_PARENTHESES) {
                     lex_state_set(parser, YP_LEX_STATE_ENDARG);
                 }
@@ -11217,9 +11233,9 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_statements_node_t *statements = yp_statements_node_create(parser);
             yp_statements_node_body_append(statements, statement);
 
-            while (!match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+            while (!match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
                 // Ignore semicolon without statements before them
-                if (accept_any_2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE)) continue;
+                if (accept2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE)) continue;
 
                 yp_node_t *node = parse_expression(parser, YP_BINDING_POWER_STATEMENT, YP_ERR_CANNOT_PARSE_EXPRESSION);
                 yp_statements_node_body_append(statements, node);
@@ -11229,16 +11245,16 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 if (parser->recovering) {
                     // If this is the level of context where the recovery has happened, then
                     // we can mark the parser as done recovering.
-                    if (match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) parser->recovering = false;
+                    if (match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) parser->recovering = false;
                     break;
                 }
 
-                if (!accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) break;
+                if (!accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) break;
             }
 
             context_pop(parser);
             yp_accepts_block_stack_pop(parser);
-            expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+            expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
 
             return (yp_node_t *) yp_parentheses_node_create(parser, &opening, (yp_node_t *) statements, &parser->previous);
         }
@@ -11247,13 +11263,13 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_hash_node_t *node = yp_hash_node_create(parser, &parser->previous);
 
-            if (!match_any_2_type_p(parser, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_EOF)) {
+            if (!match2(parser, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_EOF)) {
                 parse_assocs(parser, (yp_node_t *) node);
-                accept(parser, YP_TOKEN_NEWLINE);
+                accept1(parser, YP_TOKEN_NEWLINE);
             }
 
             yp_accepts_block_stack_pop(parser);
-            expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_HASH_TERM);
+            expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_HASH_TERM);
             yp_hash_node_closing_loc_set(node, &parser->previous);
 
             return (yp_node_t *) node;
@@ -11274,7 +11290,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             // Characters can be followed by strings in which case they are
             // automatically concatenated.
-            if (match_type_p(parser, YP_TOKEN_STRING_BEGIN)) {
+            if (match1(parser, YP_TOKEN_STRING_BEGIN)) {
                 yp_node_t *concat = parse_strings(parser);
                 return (yp_node_t *) yp_string_concat_node_create(parser, node, concat);
             }
@@ -11285,7 +11301,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_node_t *node = (yp_node_t *) yp_class_variable_read_node_create(parser, &parser->previous);
 
-            if (binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11298,9 +11314,9 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // If a constant is immediately followed by parentheses, then this is in
             // fact a method call, not a constant read.
             if (
-                match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) ||
-                (binding_power <= YP_BINDING_POWER_ASSIGNMENT && (token_begins_expression_p(parser->current.type) || match_any_3_type_p(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))) ||
-                (yp_accepts_block_stack_p(parser) && match_any_2_type_p(parser, YP_TOKEN_KEYWORD_DO, YP_TOKEN_BRACE_LEFT))
+                match1(parser, YP_TOKEN_PARENTHESIS_LEFT) ||
+                (binding_power <= YP_BINDING_POWER_ASSIGNMENT && (token_begins_expression_p(parser->current.type) || match3(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))) ||
+                (yp_accepts_block_stack_p(parser) && match2(parser, YP_TOKEN_KEYWORD_DO, YP_TOKEN_BRACE_LEFT))
             ) {
                 yp_arguments_t arguments = YP_EMPTY_ARGUMENTS;
                 parse_arguments_list(parser, &arguments, true);
@@ -11309,7 +11325,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             yp_node_t *node = (yp_node_t *) yp_constant_read_node_create(parser, &parser->previous);
 
-            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match1(parser, YP_TOKEN_COMMA)) {
                 // If we get here, then we have a comma immediately following a
                 // constant, so we're going to parse this as a multiple assignment.
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
@@ -11321,12 +11337,12 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
 
             yp_token_t delimiter = parser->previous;
-            expect(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
+            expect1(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
 
             yp_node_t *constant = (yp_node_t *) yp_constant_read_node_create(parser, &parser->previous);
             yp_node_t *node = (yp_node_t *)yp_constant_path_node_create(parser, NULL, &delimiter, constant);
 
-            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11356,7 +11372,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_node_t *node = (yp_node_t *) yp_numbered_reference_read_node_create(parser, &parser->previous);
 
-            if (binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11366,7 +11382,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_node_t *node = (yp_node_t *) yp_global_variable_read_node_create(parser, &parser->previous);
 
-            if (binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11376,7 +11392,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_node_t *node = (yp_node_t *) yp_back_reference_read_node_create(parser, &parser->previous);
 
-            if (binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11422,8 +11438,8 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 // can still be a method call if it is followed by arguments or
                 // a block, so we need to check for that here.
                 if (
-                    (binding_power <= YP_BINDING_POWER_ASSIGNMENT && (token_begins_expression_p(parser->current.type) || match_any_3_type_p(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))) ||
-                    (yp_accepts_block_stack_p(parser) && match_any_2_type_p(parser, YP_TOKEN_KEYWORD_DO, YP_TOKEN_BRACE_LEFT))
+                    (binding_power <= YP_BINDING_POWER_ASSIGNMENT && (token_begins_expression_p(parser->current.type) || match3(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))) ||
+                    (yp_accepts_block_stack_p(parser) && match2(parser, YP_TOKEN_KEYWORD_DO, YP_TOKEN_BRACE_LEFT))
                 ) {
                     yp_arguments_t arguments = YP_EMPTY_ARGUMENTS;
                     parse_arguments_list(parser, &arguments, true);
@@ -11434,7 +11450,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 }
             }
 
-            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if ((binding_power == YP_BINDING_POWER_STATEMENT) && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11453,11 +11469,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *node;
             yp_node_t *part;
 
-            if (match_any_type_p(parser, 2, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
+            if (match2(parser, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
                 // If we get here, then we have an empty heredoc. We'll create
                 // an empty content token and return an empty string node.
                 lex_state_set(parser, YP_LEX_STATE_END);
-                expect(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
+                expect1(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
                 yp_token_t content = parse_strings_empty_content(parser->previous.start);
 
                 if (quote == YP_HEREDOC_QUOTE_BACKTICK) {
@@ -11472,7 +11488,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 // heredoc but couldn't actually parse anything, so we'll just
                 // return a missing node.
                 node = (yp_node_t *) yp_missing_node_create(parser, parser->previous.start, parser->previous.end);
-            } else if (YP_NODE_TYPE_P(part, YP_STRING_NODE) && match_any_type_p(parser, 2, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
+            } else if (YP_NODE_TYPE_P(part, YP_STRING_NODE) && match2(parser, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
                 // If we get here, then the part that we parsed was plain string
                 // content and we're at the end of the heredoc, so we can return
                 // just a string node with the heredoc opening and closing as
@@ -11489,7 +11505,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 }
 
                 lex_state_set(parser, YP_LEX_STATE_END);
-                expect(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
+                expect1(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
 
                 node = (yp_node_t *) cast;
 
@@ -11504,7 +11520,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_node_list_t parts = YP_EMPTY_NODE_LIST;
                 yp_node_list_append(&parts, part);
 
-                while (!match_any_type_p(parser, 2, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
+                while (!match2(parser, YP_TOKEN_HEREDOC_END, YP_TOKEN_EOF)) {
                     if ((part = parse_string_part(parser)) != NULL) {
                         yp_node_list_append(&parts, part);
                     }
@@ -11517,7 +11533,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     cast->parts = parts;
 
                     lex_state_set(parser, YP_LEX_STATE_END);
-                    expect(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
+                    expect1(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
 
                     yp_interpolated_xstring_node_closing_set(cast, &parser->previous);
                     cast->base.location = cast->opening_loc;
@@ -11526,7 +11542,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     yp_interpolated_string_node_t *cast = yp_interpolated_string_node_create(parser, &opening, &parts, &opening);
 
                     lex_state_set(parser, YP_LEX_STATE_END);
-                    expect(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
+                    expect1(parser, YP_TOKEN_HEREDOC_END, YP_ERR_HEREDOC_TERM);
 
                     yp_interpolated_string_node_closing_set(cast, &parser->previous);
                     cast->base.location = cast->opening_loc;
@@ -11540,7 +11556,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 }
             }
 
-            if (match_type_p(parser, YP_TOKEN_STRING_BEGIN)) {
+            if (match1(parser, YP_TOKEN_STRING_BEGIN)) {
                 yp_node_t *concat = parse_strings(parser);
                 return (yp_node_t *) yp_string_concat_node_create(parser, node, concat);
             }
@@ -11551,7 +11567,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_node_t *node = (yp_node_t *) yp_instance_variable_read_node_create(parser, &parser->previous);
 
-            if (binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 node = parse_targets(parser, node, YP_BINDING_POWER_INDEX);
             }
 
@@ -11624,17 +11640,17 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *predicate = NULL;
 
             if (
-                accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON) ||
-                match_any_3_type_p(parser, YP_TOKEN_KEYWORD_WHEN, YP_TOKEN_KEYWORD_IN, YP_TOKEN_KEYWORD_END) ||
+                accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON) ||
+                match3(parser, YP_TOKEN_KEYWORD_WHEN, YP_TOKEN_KEYWORD_IN, YP_TOKEN_KEYWORD_END) ||
                 !token_begins_expression_p(parser->current.type)
             ) {
                 predicate = NULL;
             } else {
                 predicate = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_CASE_EXPRESSION_AFTER_CASE);
-                while (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
+                while (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON));
             }
 
-            if (accept(parser, YP_TOKEN_KEYWORD_END)) {
+            if (accept1(parser, YP_TOKEN_KEYWORD_END)) {
                 return (yp_node_t *) yp_case_node_create(parser, &case_keyword, predicate, NULL, &parser->previous);
             }
 
@@ -11643,16 +11659,16 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t end_keyword = not_provided(parser);
             yp_case_node_t *case_node = yp_case_node_create(parser, &case_keyword, predicate, NULL, &end_keyword);
 
-            if (match_type_p(parser, YP_TOKEN_KEYWORD_WHEN)) {
+            if (match1(parser, YP_TOKEN_KEYWORD_WHEN)) {
                 // At this point we've seen a when keyword, so we know this is a
                 // case-when node. We will continue to parse the when nodes until we hit
                 // the end of the list.
-                while (accept(parser, YP_TOKEN_KEYWORD_WHEN)) {
+                while (accept1(parser, YP_TOKEN_KEYWORD_WHEN)) {
                     yp_token_t when_keyword = parser->previous;
                     yp_when_node_t *when_node = yp_when_node_create(parser, &when_keyword);
 
                     do {
-                        if (accept(parser, YP_TOKEN_USTAR)) {
+                        if (accept1(parser, YP_TOKEN_USTAR)) {
                             yp_token_t operator = parser->previous;
                             yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_EXPECT_EXPRESSION_AFTER_STAR);
 
@@ -11666,15 +11682,15 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
                             if (YP_NODE_TYPE_P(condition, YP_MISSING_NODE)) break;
                         }
-                    } while (accept(parser, YP_TOKEN_COMMA));
+                    } while (accept1(parser, YP_TOKEN_COMMA));
 
-                    if (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
-                        accept(parser, YP_TOKEN_KEYWORD_THEN);
+                    if (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+                        accept1(parser, YP_TOKEN_KEYWORD_THEN);
                     } else {
-                        expect(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_EXPECT_WHEN_DELIMITER);
+                        expect1(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_EXPECT_WHEN_DELIMITER);
                     }
 
-                    if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_WHEN, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
+                    if (!match3(parser, YP_TOKEN_KEYWORD_WHEN, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
                         yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_CASE_WHEN);
                         if (statements != NULL) {
                             yp_when_node_statements_set(when_node, statements);
@@ -11686,7 +11702,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             } else {
                 // At this point we expect that we're parsing a case-in node. We will
                 // continue to parse the in nodes until we hit the end of the list.
-                while (match_type_p(parser, YP_TOKEN_KEYWORD_IN)) {
+                while (match1(parser, YP_TOKEN_KEYWORD_IN)) {
                     bool previous_pattern_matching_newlines = parser->pattern_matching_newlines;
                     parser->pattern_matching_newlines = true;
 
@@ -11700,11 +11716,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
                     // Since we're in the top-level of the case-in node we need to check
                     // for guard clauses in the form of `if` or `unless` statements.
-                    if (accept(parser, YP_TOKEN_KEYWORD_IF_MODIFIER)) {
+                    if (accept1(parser, YP_TOKEN_KEYWORD_IF_MODIFIER)) {
                         yp_token_t keyword = parser->previous;
                         yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_CONDITIONAL_IF_PREDICATE);
                         pattern = (yp_node_t *) yp_if_node_modifier_create(parser, pattern, &keyword, predicate);
-                    } else if (accept(parser, YP_TOKEN_KEYWORD_UNLESS_MODIFIER)) {
+                    } else if (accept1(parser, YP_TOKEN_KEYWORD_UNLESS_MODIFIER)) {
                         yp_token_t keyword = parser->previous;
                         yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_CONDITIONAL_UNLESS_PREDICATE);
                         pattern = (yp_node_t *) yp_unless_node_modifier_create(parser, pattern, &keyword, predicate);
@@ -11714,21 +11730,21 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     // It can be a newline or semicolon optionally followed by a `then`
                     // keyword.
                     yp_token_t then_keyword;
-                    if (accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
-                        if (accept(parser, YP_TOKEN_KEYWORD_THEN)) {
+                    if (accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON)) {
+                        if (accept1(parser, YP_TOKEN_KEYWORD_THEN)) {
                             then_keyword = parser->previous;
                         } else {
                             then_keyword = not_provided(parser);
                         }
                     } else {
-                        expect(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_EXPECT_WHEN_DELIMITER);
+                        expect1(parser, YP_TOKEN_KEYWORD_THEN, YP_ERR_EXPECT_WHEN_DELIMITER);
                         then_keyword = parser->previous;
                     }
 
                     // Now we can actually parse the statements associated with the in
                     // node.
                     yp_statements_node_t *statements;
-                    if (match_any_3_type_p(parser, YP_TOKEN_KEYWORD_IN, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
+                    if (match3(parser, YP_TOKEN_KEYWORD_IN, YP_TOKEN_KEYWORD_ELSE, YP_TOKEN_KEYWORD_END)) {
                         statements = NULL;
                     } else {
                         statements = parse_statements(parser, YP_CONTEXT_CASE_IN);
@@ -11741,8 +11757,8 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 }
             }
 
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-            if (accept(parser, YP_TOKEN_KEYWORD_ELSE)) {
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            if (accept1(parser, YP_TOKEN_KEYWORD_ELSE)) {
                 if (case_node->conditions.size < 1) {
                     yp_diagnostic_list_append(&parser->error_list, parser->previous.start, parser->previous.end, YP_ERR_CASE_LONELY_ELSE);
                 }
@@ -11750,7 +11766,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_token_t else_keyword = parser->previous;
                 yp_else_node_t *else_node;
 
-                if (!match_type_p(parser, YP_TOKEN_KEYWORD_END)) {
+                if (!match1(parser, YP_TOKEN_KEYWORD_END)) {
                     else_node = yp_else_node_create(parser, &else_keyword, parse_statements(parser, YP_CONTEXT_ELSE), &parser->current);
                 } else {
                     else_node = yp_else_node_create(parser, &else_keyword, NULL, &parser->current);
@@ -11759,7 +11775,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_case_node_consequent_set(case_node, else_node);
             }
 
-            expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CASE_TERM);
+            expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CASE_TERM);
             yp_case_node_end_keyword_loc_set(case_node, &parser->previous);
             return (yp_node_t *) case_node;
         }
@@ -11767,20 +11783,20 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
 
             yp_token_t begin_keyword = parser->previous;
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             yp_statements_node_t *begin_statements = NULL;
 
-            if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+            if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 begin_statements = parse_statements(parser, YP_CONTEXT_BEGIN);
                 yp_accepts_block_stack_pop(parser);
-                accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             }
 
             yp_begin_node_t *begin_node = yp_begin_node_create(parser, &begin_keyword, begin_statements);
             parse_rescues(parser, begin_node);
 
-            expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_BEGIN_TERM);
+            expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_BEGIN_TERM);
             begin_node->base.location.end = parser->previous.end;
             yp_begin_node_end_keyword_set(begin_node, &parser->previous);
 
@@ -11799,11 +11815,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_token_t keyword = parser->previous;
 
-            expect(parser, YP_TOKEN_BRACE_LEFT, YP_ERR_BEGIN_UPCASE_BRACE);
+            expect1(parser, YP_TOKEN_BRACE_LEFT, YP_ERR_BEGIN_UPCASE_BRACE);
             yp_token_t opening = parser->previous;
             yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_PREEXE);
 
-            expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_BEGIN_UPCASE_TERM);
+            expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_BEGIN_UPCASE_TERM);
             return (yp_node_t *) yp_pre_execution_node_create(parser, &keyword, &opening, statements, &parser->previous);
         }
         case YP_TOKEN_KEYWORD_BREAK:
@@ -11816,7 +11832,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             if (
                 token_begins_expression_p(parser->current.type) ||
-                match_any_2_type_p(parser, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR)
+                match2(parser, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR)
             ) {
                 yp_binding_power_t binding_power = yp_binding_powers[parser->current.type].left;
 
@@ -11872,26 +11888,26 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t class_keyword = parser->previous;
             yp_do_loop_stack_push(parser, false);
 
-            if (accept(parser, YP_TOKEN_LESS_LESS)) {
+            if (accept1(parser, YP_TOKEN_LESS_LESS)) {
                 yp_token_t operator = parser->previous;
                 yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_NOT, YP_ERR_EXPECT_EXPRESSION_AFTER_LESS_LESS);
 
                 yp_parser_scope_push(parser, true);
-                accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
 
                 yp_node_t *statements = NULL;
-                if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+                if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
                     yp_accepts_block_stack_push(parser, true);
                     statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_SCLASS);
                     yp_accepts_block_stack_pop(parser);
                 }
 
-                if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+                if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                     assert(statements == NULL || YP_NODE_TYPE_P(statements, YP_STATEMENTS_NODE));
                     statements = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) statements);
                 }
 
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CLASS_TERM);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CLASS_TERM);
 
                 yp_constant_id_list_t locals = parser->current_scope->locals;
                 yp_parser_scope_pop(parser);
@@ -11908,7 +11924,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t inheritance_operator;
             yp_node_t *superclass;
 
-            if (match_type_p(parser, YP_TOKEN_LESS)) {
+            if (match1(parser, YP_TOKEN_LESS)) {
                 inheritance_operator = parser->current;
                 lex_state_set(parser, YP_LEX_STATE_BEG);
 
@@ -11922,21 +11938,21 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             }
 
             yp_parser_scope_push(parser, true);
-            accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             yp_node_t *statements = NULL;
 
-            if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+            if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_CLASS);
                 yp_accepts_block_stack_pop(parser);
             }
 
-            if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+            if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                 assert(statements == NULL || YP_NODE_TYPE_P(statements, YP_STATEMENTS_NODE));
                 statements = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) statements);
             }
 
-            expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CLASS_TERM);
+            expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_CLASS_TERM);
 
             if (context_def_p(parser)) {
                 yp_diagnostic_list_append(&parser->error_list, class_keyword.start, class_keyword.end, YP_ERR_CLASS_IN_METHOD);
@@ -11967,7 +11983,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 case YP_TOKEN_IDENTIFIER: {
                     parser_lex(parser);
 
-                    if (match_any_2_type_p(parser, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON)) {
+                    if (match2(parser, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON)) {
                         receiver = parse_variable_call(parser);
 
                         yp_parser_scope_push(parser, true);
@@ -12002,7 +12018,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     parser_lex(parser);
                     yp_token_t identifier = parser->previous;
 
-                    if (match_any_2_type_p(parser, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON)) {
+                    if (match2(parser, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON)) {
                         lex_state_set(parser, YP_LEX_STATE_FNAME);
                         parser_lex(parser);
                         operator = parser->previous;
@@ -12059,11 +12075,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     yp_token_t lparen = parser->previous;
                     yp_node_t *expression = parse_expression(parser, YP_BINDING_POWER_STATEMENT, YP_ERR_DEF_RECEIVER);
 
-                    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+                    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
                     yp_token_t rparen = parser->previous;
 
                     lex_state_set(parser, YP_LEX_STATE_FNAME);
-                    expect_any(parser, YP_ERR_DEF_RECEIVER_TERM, 2, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON);
+                    expect2(parser, YP_TOKEN_DOT, YP_TOKEN_COLON_COLON, YP_ERR_DEF_RECEIVER_TERM);
 
                     operator = parser->previous;
                     receiver = (yp_node_t *) yp_parentheses_node_create(parser, &lparen, expression, &rparen);
@@ -12091,7 +12107,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     parser_lex(parser);
                     lparen = parser->previous;
 
-                    if (match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+                    if (match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
                         params = NULL;
                     } else {
                         params = parse_parameters(parser, YP_BINDING_POWER_DEFINED, true, false, true);
@@ -12100,7 +12116,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     lex_state_set(parser, YP_LEX_STATE_BEG);
                     parser->command_start = true;
 
-                    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_DEF_PARAMS_TERM_PAREN);
+                    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_DEF_PARAMS_TERM_PAREN);
                     rparen = parser->previous;
                     break;
                 }
@@ -12129,7 +12145,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t equal;
             yp_token_t end_keyword;
 
-            if (accept(parser, YP_TOKEN_EQUAL)) {
+            if (accept1(parser, YP_TOKEN_EQUAL)) {
                 if (token_is_setter_name(&name)) {
                     yp_diagnostic_list_append(&parser->error_list, name.start, name.end, YP_ERR_DEF_ENDLESS_SETTER);
                 }
@@ -12140,7 +12156,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
                 yp_node_t *statement = parse_expression(parser, YP_BINDING_POWER_DEFINED + 1, YP_ERR_DEF_ENDLESS);
 
-                if (accept(parser, YP_TOKEN_KEYWORD_RESCUE_MODIFIER)) {
+                if (accept1(parser, YP_TOKEN_KEYWORD_RESCUE_MODIFIER)) {
                     yp_token_t rescue_keyword = parser->previous;
                     yp_node_t *value = parse_expression(parser, binding_power, YP_ERR_RESCUE_MODIFIER_VALUE);
                     yp_rescue_modifier_node_t *rescue_node = yp_rescue_modifier_node_create(parser, statement, &rescue_keyword, value);
@@ -12156,28 +12172,28 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 if (lparen.type == YP_TOKEN_NOT_PROVIDED) {
                     lex_state_set(parser, YP_LEX_STATE_BEG);
                     parser->command_start = true;
-                    expect_any(parser, YP_ERR_DEF_PARAMS_TERM, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                    expect2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_ERR_DEF_PARAMS_TERM);
                 } else {
-                    accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                    accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
                 }
 
                 yp_accepts_block_stack_push(parser, true);
                 yp_do_loop_stack_push(parser, false);
 
-                if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+                if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
                     yp_accepts_block_stack_push(parser, true);
                     statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_DEF);
                     yp_accepts_block_stack_pop(parser);
                 }
 
-                if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+                if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                     assert(statements == NULL || YP_NODE_TYPE_P(statements, YP_STATEMENTS_NODE));
                     statements = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) statements);
                 }
 
                 yp_accepts_block_stack_pop(parser);
                 yp_do_loop_stack_pop(parser);
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_DEF_TERM);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_DEF_TERM);
                 end_keyword = parser->previous;
             }
 
@@ -12207,14 +12223,14 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t rparen;
             yp_node_t *expression;
 
-            if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+            if (accept1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
                 lparen = parser->previous;
                 expression = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_DEFINED_EXPRESSION);
 
                 if (parser->recovering) {
                     rparen = not_provided(parser);
                 } else {
-                    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+                    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
                     rparen = parser->previous;
                 }
             } else {
@@ -12235,11 +12251,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_token_t keyword = parser->previous;
 
-            expect(parser, YP_TOKEN_BRACE_LEFT, YP_ERR_END_UPCASE_BRACE);
+            expect1(parser, YP_TOKEN_BRACE_LEFT, YP_ERR_END_UPCASE_BRACE);
             yp_token_t opening = parser->previous;
             yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_POSTEXE);
 
-            expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_END_UPCASE_TERM);
+            expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_END_UPCASE_TERM);
             return (yp_node_t *) yp_post_execution_node_create(parser, &keyword, &opening, statements, &parser->previous);
         }
         case YP_TOKEN_KEYWORD_FALSE:
@@ -12252,25 +12268,25 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *index = parse_targets(parser, NULL, YP_BINDING_POWER_INDEX);
             yp_do_loop_stack_push(parser, true);
 
-            expect(parser, YP_TOKEN_KEYWORD_IN, YP_ERR_FOR_IN);
+            expect1(parser, YP_TOKEN_KEYWORD_IN, YP_ERR_FOR_IN);
             yp_token_t in_keyword = parser->previous;
 
             yp_node_t *collection = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_FOR_COLLECTION);
             yp_do_loop_stack_pop(parser);
 
             yp_token_t do_keyword;
-            if (accept(parser, YP_TOKEN_KEYWORD_DO_LOOP)) {
+            if (accept1(parser, YP_TOKEN_KEYWORD_DO_LOOP)) {
                 do_keyword = parser->previous;
             } else {
                 do_keyword = not_provided(parser);
             }
 
-            accept_any_2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE);
+            accept2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE);
             yp_statements_node_t *statements = NULL;
 
-            if (!accept(parser, YP_TOKEN_KEYWORD_END)) {
+            if (!accept1(parser, YP_TOKEN_KEYWORD_END)) {
                 statements = parse_statements(parser, YP_CONTEXT_FOR);
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_FOR_TERM);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_FOR_TERM);
             }
 
             return (yp_node_t *) yp_for_node_create(parser, index, collection, statements, &for_keyword, &in_keyword, &do_keyword, &parser->previous);
@@ -12288,7 +12304,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             } else {
                 yp_undef_node_append(undef, name);
 
-                while (match_type_p(parser, YP_TOKEN_COMMA)) {
+                while (match1(parser, YP_TOKEN_COMMA)) {
                     lex_state_set(parser, YP_LEX_STATE_FNAME | YP_LEX_STATE_FITEM);
                     parser_lex(parser);
                     name = parse_undef_argument(parser);
@@ -12311,20 +12327,20 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_arguments_t arguments = YP_EMPTY_ARGUMENTS;
             yp_node_t *receiver = NULL;
 
-            accept(parser, YP_TOKEN_NEWLINE);
+            accept1(parser, YP_TOKEN_NEWLINE);
 
-            if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+            if (accept1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
                 arguments.opening_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
 
-                if (accept(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+                if (accept1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
                     arguments.closing_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
                 } else {
                     receiver = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_NOT_EXPRESSION);
                     yp_conditional_predicate(receiver);
 
                     if (!parser->recovering) {
-                        accept(parser, YP_TOKEN_NEWLINE);
-                        expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+                        accept1(parser, YP_TOKEN_NEWLINE);
+                        expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
                         arguments.closing_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
                     }
                 }
@@ -12352,10 +12368,10 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 return (yp_node_t *) yp_module_node_create(parser, NULL, &module_keyword, constant_path, &missing, NULL, &missing);
             }
 
-            while (accept(parser, YP_TOKEN_COLON_COLON)) {
+            while (accept1(parser, YP_TOKEN_COLON_COLON)) {
                 yp_token_t double_colon = parser->previous;
 
-                expect(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
+                expect1(parser, YP_TOKEN_CONSTANT, YP_ERR_CONSTANT_PATH_COLON_COLON_CONSTANT);
                 yp_node_t *constant = (yp_node_t *) yp_constant_read_node_create(parser, &parser->previous);
 
                 constant_path = (yp_node_t *) yp_constant_path_node_create(parser, constant_path, &double_colon, constant);
@@ -12370,16 +12386,16 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             }
 
             yp_parser_scope_push(parser, true);
-            accept_any_2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE);
+            accept2(parser, YP_TOKEN_SEMICOLON, YP_TOKEN_NEWLINE);
             yp_node_t *statements = NULL;
 
-            if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
+            if (!match3(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE, YP_TOKEN_KEYWORD_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = (yp_node_t *) parse_statements(parser, YP_CONTEXT_MODULE);
                 yp_accepts_block_stack_pop(parser);
             }
 
-            if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+            if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                 assert(statements == NULL || YP_NODE_TYPE_P(statements, YP_STATEMENTS_NODE));
                 statements = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) statements);
             }
@@ -12387,7 +12403,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_constant_id_list_t locals = parser->current_scope->locals;
             yp_parser_scope_pop(parser);
 
-            expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_MODULE_TERM);
+            expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_MODULE_TERM);
 
             if (context_def_p(parser)) {
                 yp_diagnostic_list_append(&parser->error_list, module_keyword.start, module_keyword.end, YP_ERR_MODULE_IN_METHOD);
@@ -12418,15 +12434,15 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_CONDITIONAL_UNTIL_PREDICATE);
             yp_do_loop_stack_pop(parser);
 
-            accept_any_3(parser, YP_TOKEN_KEYWORD_DO_LOOP, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept3(parser, YP_TOKEN_KEYWORD_DO_LOOP, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             yp_statements_node_t *statements = NULL;
 
-            if (!accept(parser, YP_TOKEN_KEYWORD_END)) {
+            if (!accept1(parser, YP_TOKEN_KEYWORD_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = parse_statements(parser, YP_CONTEXT_UNTIL);
                 yp_accepts_block_stack_pop(parser);
-                accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_UNTIL_TERM);
+                accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_UNTIL_TERM);
             }
 
             return (yp_node_t *) yp_until_node_create(parser, &keyword, &parser->previous, predicate, statements, 0);
@@ -12439,15 +12455,15 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *predicate = parse_expression(parser, YP_BINDING_POWER_COMPOSITION, YP_ERR_CONDITIONAL_WHILE_PREDICATE);
             yp_do_loop_stack_pop(parser);
 
-            accept_any_3(parser, YP_TOKEN_KEYWORD_DO_LOOP, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+            accept3(parser, YP_TOKEN_KEYWORD_DO_LOOP, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
             yp_statements_node_t *statements = NULL;
 
-            if (!accept(parser, YP_TOKEN_KEYWORD_END)) {
+            if (!accept1(parser, YP_TOKEN_KEYWORD_END)) {
                 yp_accepts_block_stack_push(parser, true);
                 statements = parse_statements(parser, YP_CONTEXT_WHILE);
                 yp_accepts_block_stack_pop(parser);
-                accept_any_2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_WHILE_TERM);
+                accept2(parser, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_WHILE_TERM);
             }
 
             return (yp_node_t *) yp_while_node_create(parser, &keyword, &parser->previous, predicate, statements, 0);
@@ -12456,11 +12472,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             parser_lex(parser);
             yp_array_node_t *array = yp_array_node_create(parser, &parser->previous);
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
-                accept(parser, YP_TOKEN_WORDS_SEP);
-                if (match_type_p(parser, YP_TOKEN_STRING_END)) break;
+            while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+                accept1(parser, YP_TOKEN_WORDS_SEP);
+                if (match1(parser, YP_TOKEN_STRING_END)) break;
 
-                expect(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_I_LOWER_ELEMENT);
+                expect1(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_I_LOWER_ELEMENT);
 
                 yp_token_t opening = not_provided(parser);
                 yp_token_t closing = not_provided(parser);
@@ -12469,7 +12485,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_array_node_elements_append(array, symbol);
             }
 
-            expect(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_I_LOWER_TERM);
+            expect1(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_I_LOWER_TERM);
             yp_array_node_close_set(array, &parser->previous);
 
             return (yp_node_t *) array;
@@ -12482,7 +12498,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // list of elements.
             yp_node_t *current = NULL;
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+            while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
                 switch (parser->current.type) {
                     case YP_TOKEN_WORDS_SEP: {
                         if (current == NULL) {
@@ -12605,7 +12621,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                         break;
                     }
                     default:
-                        expect(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_I_UPPER_ELEMENT);
+                        expect1(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_I_UPPER_ELEMENT);
                         parser_lex(parser);
                         break;
                 }
@@ -12616,7 +12632,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_array_node_elements_append(array, current);
             }
 
-            expect(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_I_UPPER_TERM);
+            expect1(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_I_UPPER_TERM);
             yp_array_node_close_set(array, &parser->previous);
 
             return (yp_node_t *) array;
@@ -12626,13 +12642,13 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_array_node_t *array = yp_array_node_create(parser, &parser->previous);
 
             // skip all leading whitespaces
-            accept(parser, YP_TOKEN_WORDS_SEP);
+            accept1(parser, YP_TOKEN_WORDS_SEP);
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
-                accept(parser, YP_TOKEN_WORDS_SEP);
-                if (match_type_p(parser, YP_TOKEN_STRING_END)) break;
+            while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+                accept1(parser, YP_TOKEN_WORDS_SEP);
+                if (match1(parser, YP_TOKEN_STRING_END)) break;
 
-                expect(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_W_LOWER_ELEMENT);
+                expect1(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_W_LOWER_ELEMENT);
 
                 yp_token_t opening = not_provided(parser);
                 yp_token_t closing = not_provided(parser);
@@ -12640,7 +12656,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_array_node_elements_append(array, string);
             }
 
-            expect(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_W_LOWER_TERM);
+            expect1(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_W_LOWER_TERM);
             yp_array_node_close_set(array, &parser->previous);
 
             return (yp_node_t *) array;
@@ -12653,7 +12669,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // list of elements.
             yp_node_t *current = NULL;
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+            while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
                 switch (parser->current.type) {
                     case YP_TOKEN_WORDS_SEP: {
                         if (current == NULL) {
@@ -12756,7 +12772,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                         break;
                     }
                     default:
-                        expect(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_W_UPPER_ELEMENT);
+                        expect1(parser, YP_TOKEN_STRING_CONTENT, YP_ERR_LIST_W_UPPER_ELEMENT);
                         parser_lex(parser);
                         break;
                 }
@@ -12767,7 +12783,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_array_node_elements_append(array, current);
             }
 
-            expect(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_W_UPPER_TERM);
+            expect1(parser, YP_TOKEN_STRING_END, YP_ERR_LIST_W_UPPER_TERM);
             yp_array_node_close_set(array, &parser->previous);
 
             return (yp_node_t *) array;
@@ -12776,7 +12792,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t opening = parser->current;
             parser_lex(parser);
 
-            if (match_type_p(parser, YP_TOKEN_REGEXP_END)) {
+            if (match1(parser, YP_TOKEN_REGEXP_END)) {
                 // If we get here, then we have an end immediately after a start. In
                 // that case we'll create an empty content token and return an
                 // uninterpolated regular expression.
@@ -12792,7 +12808,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             yp_interpolated_regular_expression_node_t *node;
 
-            if (match_type_p(parser, YP_TOKEN_STRING_CONTENT)) {
+            if (match1(parser, YP_TOKEN_STRING_CONTENT)) {
                 // In this case we've hit string content so we know the regular
                 // expression at least has something in it. We'll need to check if the
                 // following token is the end (in which case we can return a plain
@@ -12803,7 +12819,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 // If we hit an end, then we can create a regular expression node
                 // without interpolation, which can be represented more succinctly and
                 // more easily compiled.
-                if (accept(parser, YP_TOKEN_REGEXP_END)) {
+                if (accept1(parser, YP_TOKEN_REGEXP_END)) {
                     return (yp_node_t *) yp_regular_expression_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
                 }
 
@@ -12824,14 +12840,14 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             // Now that we're here and we have interpolation, we'll parse all of the
             // parts into the list.
-            while (!match_any_2_type_p(parser, YP_TOKEN_REGEXP_END, YP_TOKEN_EOF)) {
+            while (!match2(parser, YP_TOKEN_REGEXP_END, YP_TOKEN_EOF)) {
                 yp_node_t *part = parse_string_part(parser);
                 if (part != NULL) {
                     yp_interpolated_regular_expression_node_append(node, part);
                 }
             }
 
-            expect(parser, YP_TOKEN_REGEXP_END, YP_ERR_REGEXP_TERM);
+            expect1(parser, YP_TOKEN_REGEXP_END, YP_ERR_REGEXP_TERM);
             yp_interpolated_regular_expression_node_closing_set(node, &parser->previous);
 
             return (yp_node_t *) node;
@@ -12845,7 +12861,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             // interpolation or not, even though it is allowed. Still, we want to be
             // able to return a string node without interpolation if we can since
             // it'll be faster.
-            if (match_type_p(parser, YP_TOKEN_STRING_END)) {
+            if (match1(parser, YP_TOKEN_STRING_END)) {
                 // If we get here, then we have an end immediately after a start. In
                 // that case we'll create an empty content token and return an
                 // uninterpolated string.
@@ -12861,7 +12877,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
             yp_interpolated_x_string_node_t *node;
 
-            if (match_type_p(parser, YP_TOKEN_STRING_CONTENT)) {
+            if (match1(parser, YP_TOKEN_STRING_CONTENT)) {
                 // In this case we've hit string content so we know the string at least
                 // has something in it. We'll need to check if the following token is
                 // the end (in which case we can return a plain string) or if it's not
@@ -12869,7 +12885,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 yp_token_t content = parser->current;
                 parser_lex(parser);
 
-                if (accept(parser, YP_TOKEN_STRING_END)) {
+                if (accept1(parser, YP_TOKEN_STRING_END)) {
                     return (yp_node_t *) yp_xstring_node_create_and_unescape(parser, &opening, &content, &parser->previous);
                 }
 
@@ -12888,14 +12904,14 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                 node = yp_interpolated_xstring_node_create(parser, &opening, &opening);
             }
 
-            while (!match_any_2_type_p(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+            while (!match2(parser, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
                 yp_node_t *part = parse_string_part(parser);
                 if (part != NULL) {
                     yp_interpolated_xstring_node_append(node, part);
                 }
             }
 
-            expect(parser, YP_TOKEN_STRING_END, YP_ERR_XSTRING_TERM);
+            expect1(parser, YP_TOKEN_STRING_END, YP_ERR_XSTRING_TERM);
             yp_interpolated_xstring_node_closing_set(node, &parser->previous);
             return (yp_node_t *) node;
         }
@@ -12953,7 +12969,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_token_t operator = parser->previous;
             yp_node_t *node = parse_expression(parser, yp_binding_powers[parser->previous.type].right, YP_ERR_UNARY_RECEIVER_MINUS);
 
-            if (accept(parser, YP_TOKEN_STAR_STAR)) {
+            if (accept1(parser, YP_TOKEN_STAR_STAR)) {
                 yp_token_t exponent_operator = parser->previous;
                 yp_node_t *exponent = parse_expression(parser, yp_binding_powers[exponent_operator.type].right, YP_ERR_EXPECT_ARGUMENT);
                 node = (yp_node_t *) yp_call_node_binary_create(parser, node, &exponent_operator, exponent);
@@ -12990,14 +13006,14 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
                     yp_token_t opening = parser->current;
                     parser_lex(parser);
 
-                    if (match_type_p(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
+                    if (match1(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
                         params = yp_block_parameters_node_create(parser, NULL, &opening);
                     } else {
                         params = parse_block_parameters(parser, false, &opening, true);
                     }
 
-                    accept(parser, YP_TOKEN_NEWLINE);
-                    expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
+                    accept1(parser, YP_TOKEN_NEWLINE);
+                    expect1(parser, YP_TOKEN_PARENTHESIS_RIGHT, YP_ERR_EXPECT_RPAREN);
 
                     yp_block_parameters_node_closing_set(params, &parser->previous);
                     break;
@@ -13019,29 +13035,29 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
             yp_node_t *body = NULL;
             parser->lambda_enclosure_nesting = previous_lambda_enclosure_nesting;
 
-            if (accept(parser, YP_TOKEN_LAMBDA_BEGIN)) {
+            if (accept1(parser, YP_TOKEN_LAMBDA_BEGIN)) {
                 opening = parser->previous;
 
-                if (!accept(parser, YP_TOKEN_BRACE_RIGHT)) {
+                if (!accept1(parser, YP_TOKEN_BRACE_RIGHT)) {
                     body = (yp_node_t *) parse_statements(parser, YP_CONTEXT_LAMBDA_BRACES);
-                    expect(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_LAMBDA_TERM_BRACE);
+                    expect1(parser, YP_TOKEN_BRACE_RIGHT, YP_ERR_LAMBDA_TERM_BRACE);
                 }
             } else {
-                expect(parser, YP_TOKEN_KEYWORD_DO, YP_ERR_LAMBDA_OPEN);
+                expect1(parser, YP_TOKEN_KEYWORD_DO, YP_ERR_LAMBDA_OPEN);
                 opening = parser->previous;
 
-                if (!match_any_3_type_p(parser, YP_TOKEN_KEYWORD_END, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+                if (!match3(parser, YP_TOKEN_KEYWORD_END, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                     yp_accepts_block_stack_push(parser, true);
                     body = (yp_node_t *) parse_statements(parser, YP_CONTEXT_LAMBDA_DO_END);
                     yp_accepts_block_stack_pop(parser);
                 }
 
-                if (match_any_2_type_p(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
+                if (match2(parser, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
                     assert(body == NULL || YP_NODE_TYPE_P(body, YP_STATEMENTS_NODE));
                     body = (yp_node_t *) parse_rescues_as_begin(parser, (yp_statements_node_t *) body);
                 }
 
-                expect(parser, YP_TOKEN_KEYWORD_END, YP_ERR_LAMBDA_TERM_END);
+                expect1(parser, YP_TOKEN_KEYWORD_END, YP_ERR_LAMBDA_TERM_END);
             }
 
             yp_constant_id_list_t locals = parser->current_scope->locals;
@@ -13079,14 +13095,14 @@ static inline yp_node_t *
 parse_assignment_value(yp_parser_t *parser, yp_binding_power_t previous_binding_power, yp_binding_power_t binding_power, yp_diagnostic_id_t diag_id) {
     yp_node_t *value = parse_starred_expression(parser, binding_power, diag_id);
 
-    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && (YP_NODE_TYPE_P(value, YP_SPLAT_NODE) || match_type_p(parser, YP_TOKEN_COMMA))) {
+    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && (YP_NODE_TYPE_P(value, YP_SPLAT_NODE) || match1(parser, YP_TOKEN_COMMA))) {
         yp_token_t opening = not_provided(parser);
         yp_array_node_t *array = yp_array_node_create(parser, &opening);
 
         yp_array_node_elements_append(array, value);
         value = (yp_node_t *) array;
 
-        while (accept(parser, YP_TOKEN_COMMA)) {
+        while (accept1(parser, YP_TOKEN_COMMA)) {
             yp_node_t *element = parse_starred_expression(parser, binding_power, YP_ERR_ARRAY_ELEMENT);
             yp_array_node_elements_append(array, element);
             if (YP_NODE_TYPE_P(element, YP_MISSING_NODE)) break;
@@ -13538,7 +13554,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             yp_arguments_t arguments = YP_EMPTY_ARGUMENTS;
 
             // This if statement handles the foo.() syntax.
-            if (match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+            if (match1(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
                 parse_arguments_list(parser, &arguments, true);
                 return (yp_node_t *) yp_call_node_shorthand_create(parser, node, &operator, &arguments);
             }
@@ -13567,7 +13583,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                 (previous_binding_power == YP_BINDING_POWER_STATEMENT) &&
                 arguments.arguments == NULL &&
                 arguments.opening_loc.start == NULL &&
-                match_type_p(parser, YP_TOKEN_COMMA)
+                match1(parser, YP_TOKEN_COMMA)
             ) {
                 return parse_targets(parser, (yp_node_t *) call, YP_BINDING_POWER_INDEX);
             } else {
@@ -13632,8 +13648,8 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                 return (yp_node_t *) yp_if_node_ternary_create(parser, node, true_expression, &colon, false_expression);
             }
 
-            accept(parser, YP_TOKEN_NEWLINE);
-            expect(parser, YP_TOKEN_COLON, YP_ERR_TERNARY_COLON);
+            accept1(parser, YP_TOKEN_NEWLINE);
+            expect1(parser, YP_TOKEN_COLON, YP_ERR_TERNARY_COLON);
 
             yp_token_t colon = parser->previous;
             yp_node_t *false_expression = parse_expression(parser, YP_BINDING_POWER_DEFINED, YP_ERR_TERNARY_EXPRESSION_FALSE);
@@ -13651,7 +13667,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
 
                     if (
                         (parser->current.type == YP_TOKEN_PARENTHESIS_LEFT) ||
-                        (token_begins_expression_p(parser->current.type) || match_any_3_type_p(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))
+                        (token_begins_expression_p(parser->current.type) || match3(parser, YP_TOKEN_UAMPERSAND, YP_TOKEN_USTAR, YP_TOKEN_USTAR_STAR))
                     ) {
                         // If we have a constant immediately following a '::' operator, then
                         // this can either be a constant path or a method call, depending on
@@ -13671,7 +13687,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     }
 
                     // If this is followed by a comma then it is a multiple assignment.
-                    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+                    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                         return parse_targets(parser, path, YP_BINDING_POWER_INDEX);
                     }
 
@@ -13690,7 +13706,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
                     yp_call_node_t *call = yp_call_node_call_create(parser, node, &delimiter, &message, &arguments);
 
                     // If this is followed by a comma then it is a multiple assignment.
-                    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+                    if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                         return parse_targets(parser, (yp_node_t *) call, YP_BINDING_POWER_INDEX);
                     }
 
@@ -13713,7 +13729,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
         }
         case YP_TOKEN_KEYWORD_RESCUE_MODIFIER: {
             parser_lex(parser);
-            accept(parser, YP_TOKEN_NEWLINE);
+            accept1(parser, YP_TOKEN_NEWLINE);
             yp_node_t *value = parse_expression(parser, binding_power, YP_ERR_RESCUE_MODIFIER_VALUE);
 
             return (yp_node_t *) yp_rescue_modifier_node_create(parser, node, &token, value);
@@ -13724,21 +13740,21 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             yp_arguments_t arguments = YP_EMPTY_ARGUMENTS;
             arguments.opening_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
 
-            if (!accept(parser, YP_TOKEN_BRACKET_RIGHT)) {
+            if (!accept1(parser, YP_TOKEN_BRACKET_RIGHT)) {
                 yp_accepts_block_stack_push(parser, true);
                 arguments.arguments = yp_arguments_node_create(parser);
 
                 parse_arguments(parser, &arguments, false, YP_TOKEN_BRACKET_RIGHT);
                 yp_accepts_block_stack_pop(parser);
 
-                expect(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_EXPECT_RBRACKET);
+                expect1(parser, YP_TOKEN_BRACKET_RIGHT, YP_ERR_EXPECT_RBRACKET);
             }
 
             arguments.closing_loc = YP_LOCATION_TOKEN_VALUE(&parser->previous);
 
             // If we have a comma after the closing bracket then this is a multiple
             // assignment and we should parse the targets.
-            if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+            if (previous_binding_power == YP_BINDING_POWER_STATEMENT && match1(parser, YP_TOKEN_COMMA)) {
                 yp_call_node_t *aref = yp_call_node_aref_create(parser, node, &arguments);
                 return parse_targets(parser, (yp_node_t *) aref, YP_BINDING_POWER_INDEX);
             }
@@ -13746,9 +13762,9 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
             // If we're at the end of the arguments, we can now check if there is a
             // block node that starts with a {. If there is, then we can parse it and
             // add it to the arguments.
-            if (accept(parser, YP_TOKEN_BRACE_LEFT)) {
+            if (accept1(parser, YP_TOKEN_BRACE_LEFT)) {
                 arguments.block = parse_block(parser);
-            } else if (yp_accepts_block_stack_p(parser) && accept(parser, YP_TOKEN_KEYWORD_DO)) {
+            } else if (yp_accepts_block_stack_p(parser) && accept1(parser, YP_TOKEN_KEYWORD_DO)) {
                 arguments.block = parse_block(parser);
             }
 


### PR DESCRIPTION
Following up on #1483, this removes our usage of varargs entirely. Under the new approach we make explicit methods for the various signatures. Because we know the type of everything any it's very consistent, this makes it easier for compilers to inline.

Also, I renamed the functions to be more consistent with each other so that we'll have some more internal consistency.