### PR TITLE
remove `ruby_memcheck` from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,4 @@ gemspec
 gem "rake"
 gem "rake-compiler"
 gem "test-unit"
-gem "ruby_memcheck", platform: %i[mri truffleruby mswin mingw x64_mingw]
 gem "ffi", platform: %i[mri mswin mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     ffi (1.15.5)
-    mini_portile2 (2.8.4)
-    nokogiri (1.15.3)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     power_assert (2.0.3)
-    racc (1.7.1)
     rake (13.0.6)
     rake-compiler (1.2.5)
       rake
-    ruby_memcheck (2.0.1)
-      nokogiri
     test-unit (3.6.1)
       power_assert
 
@@ -30,7 +23,6 @@ DEPENDENCIES
   ffi
   rake
   rake-compiler
-  ruby_memcheck
   test-unit
   yarp!
 


### PR DESCRIPTION
`ruby_memcheck` doesn't appear to be used and not requiring it avoids transitively dragging in `nokogiri` as well as a couple of other things.  But really it avoids `nokogiri`.