### PR TITLE
Return Regexp options that match MRI for e, u, s, and n

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -590,10 +590,8 @@ module YARP
     # the regular expression.
     def options
       o = flags & 0b111
-      o |= Regexp::FIXEDENCODING if flags & 8 != 0  # 'e'
-      o |= Regexp::FIXEDENCODING if flags & 32 != 0 # 's'
-      o |= Regexp::FIXEDENCODING if flags & 64 != 0 # 'u'
-      o |= Regexp::NOENCODING if flags & 16 != 0    # 'n'
+      o |= Regexp::FIXEDENCODING if flags.anybits?(RegularExpressionFlags::EUC_JP | RegularExpressionFlags::WINDOWS_31J | RegularExpressionFlags::UTF_8)
+      o |= Regexp::NOENCODING if flags.anybits?(RegularExpressionFlags::ASCII_8BIT)
       o
     end
   end
@@ -610,10 +608,8 @@ module YARP
     # the regular expression.
     def options
       o = flags & 0b111
-      o |= Regexp::FIXEDENCODING if flags & 8 != 0  # 'e'
-      o |= Regexp::FIXEDENCODING if flags & 32 != 0 # 's'
-      o |= Regexp::FIXEDENCODING if flags & 64 != 0 # 'u'
-      o |= Regexp::NOENCODING if flags & 16 != 0    # 'n'
+      o |= Regexp::FIXEDENCODING if flags.anybits?(RegularExpressionFlags::EUC_JP | RegularExpressionFlags::WINDOWS_31J | RegularExpressionFlags::UTF_8)
+      o |= Regexp::NOENCODING if flags.anybits?(RegularExpressionFlags::ASCII_8BIT)
       o
     end
   end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -587,11 +587,14 @@ module YARP
 
   class InterpolatedRegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
-    # the regular expression. This mirrors the Regexp#options method in Ruby.
-    # Note that this is effectively masking only the three common flags that are
-    # used in Ruby, and does not include the full set of flags like encoding.
+    # the regular expression.
     def options
-      flags & 0b111
+      o = flags & 0b111
+      o |= Regexp::FIXEDENCODING if flags & 8 != 0  # 'e'
+      o |= Regexp::FIXEDENCODING if flags & 32 != 0 # 's'
+      o |= Regexp::FIXEDENCODING if flags & 64 != 0 # 'u'
+      o |= Regexp::NOENCODING if flags & 16 != 0    # 'n'
+      o
     end
   end
 
@@ -604,11 +607,14 @@ module YARP
 
   class RegularExpressionNode < Node
     # Returns a numeric value that represents the flags that were used to create
-    # the regular expression. This mirrors the Regexp#options method in Ruby.
-    # Note that this is effectively masking only the three common flags that are
-    # used in Ruby, and does not include the full set of flags like encoding.
+    # the regular expression.
     def options
-      flags & 0b111
+      o = flags & 0b111
+      o |= Regexp::FIXEDENCODING if flags & 8 != 0  # 'e'
+      o |= Regexp::FIXEDENCODING if flags & 32 != 0 # 's'
+      o |= Regexp::FIXEDENCODING if flags & 64 != 0 # 'u'
+      o |= Regexp::NOENCODING if flags & 16 != 0    # 'n'
+      o
     end
   end
 end

--- a/test/yarp/regexp_test.rb
+++ b/test/yarp/regexp_test.rb
@@ -208,6 +208,20 @@ module YARP
       assert_equal(Regexp::MULTILINE, options("m"))
     end
 
+    def test_flag_fixedencoding
+      assert_equal(Regexp::FIXEDENCODING, options("e"))
+      assert_equal(Regexp::FIXEDENCODING, options("u"))
+      assert_equal(Regexp::FIXEDENCODING, options("s"))
+    end
+
+    def test_flag_noencoding
+      assert_equal(Regexp::NOENCODING, options("n"))
+    end
+
+    def test_flag_once
+      assert_equal(0, options("o"))
+    end
+
     def test_flag_combined
       value = Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED
       assert_equal(value, options("mix"))


### PR DESCRIPTION
Fixes #1516

I'm trying to match the final `Regexp` constants with `RegularExpressionNode#options` and `InterpolatedRegularExpressionNode#options`.

I don't know if this is a good approach. If it's not, feel free to close unceremoniously! ❤️ 