### PR TITLE
separate `ruby_memcheck` into its own group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,7 @@ gemspec
 gem "rake"
 gem "rake-compiler"
 gem "test-unit"
-gem "ruby_memcheck", platform: %i[mri truffleruby mswin mingw x64_mingw]
 gem "ffi", platform: %i[mri mswin mingw x64_mingw]
+group :memcheck do
+  gem "ruby_memcheck", platform: %i[mri truffleruby mswin mingw x64_mingw]
+end


### PR DESCRIPTION
This PR implements @eregon 's idea (thank you!) from the discussion in #1498: we can separate `ruby_memcheck` into its own group, and handle its non-presence.  This change enables people to install a smaller set of gems if they so choose.