### PR TITLE
Explicitly use u32 for constant pool

### DIFF
--- a/include/yarp/util/yp_constant_pool.h
+++ b/include/yarp/util/yp_constant_pool.h
@@ -44,20 +44,20 @@ typedef struct {
     bool owned: 1;
     const uint8_t *start;
     size_t length;
-    size_t hash;
+    uint32_t hash;
 } yp_constant_t;
 
 typedef struct {
     yp_constant_t *constants;
-    size_t size;
-    size_t capacity;
+    uint32_t size;
+    uint32_t capacity;
 } yp_constant_pool_t;
 
 // Define an empty constant pool.
 #define YP_CONSTANT_POOL_EMPTY ((yp_constant_pool_t) { .constants = NULL, .size = 0, .capacity = 0 })
 
 // Initialize a new constant pool with a given capacity.
-bool yp_constant_pool_init(yp_constant_pool_t *pool, size_t capacity);
+bool yp_constant_pool_init(yp_constant_pool_t *pool, uint32_t capacity);
 
 // Insert a constant into a constant pool that is a slice of a source string.
 // Returns the id of the constant, or 0 if any potential calls to resize fail.

--- a/rust/yarp/build.rs
+++ b/rust/yarp/build.rs
@@ -552,7 +552,7 @@ impl<'pr> ConstantId<'pr> {{
         unsafe {{
             let pool = &(*self.parser.as_ptr()).constant_pool;
             for i in 0..pool.capacity {{
-                let constant = &(*pool.constants.add(i));
+                let constant = &(*pool.constants.add(i.try_into().unwrap()));
                 if constant.id() == self.id {{
                     return std::slice::from_raw_parts(constant.start, constant.length);
                 }}

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -14345,7 +14345,7 @@ yp_parser_init(yp_parser_t *parser, const uint8_t *source, size_t size, const ch
     //
     // This ratio will need to change if we add more constants to the constant
     // pool for another node type.
-    size_t constant_size = size / 95;
+    uint32_t constant_size = ((uint32_t) size) / 95;
     yp_constant_pool_init(&parser->constant_pool, constant_size < 4 ? 4 : constant_size);
 
     // Initialize the newline list. Similar to the constant pool, we're going to

--- a/templates/ext/yarp/api_node.c.erb
+++ b/templates/ext/yarp/api_node.c.erb
@@ -81,7 +81,7 @@ yp_ast_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding) {
     VALUE source = yp_source_new(parser, encoding);
     ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
 
-    for (size_t index = 0; index < parser->constant_pool.capacity; index++) {
+    for (uint32_t index = 0; index < parser->constant_pool.capacity; index++) {
         yp_constant_t constant = parser->constant_pool.constants[index];
 
         if (constant.id != 0) {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -185,7 +185,7 @@ yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) 
     yp_buffer_append_zeroes(buffer, 4);
 
     // Next, encode the length of the constant pool.
-    yp_buffer_append_u32(buffer, yp_sizet_to_u32(parser->constant_pool.size));
+    yp_buffer_append_u32(buffer, parser->constant_pool.size);
 
     // Now we're going to serialize the content of the node.
     yp_serialize_node(parser, node, buffer);
@@ -200,7 +200,7 @@ yp_serialize_content(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) 
     yp_buffer_append_zeroes(buffer, parser->constant_pool.size * 8);
 
     yp_constant_t *constant;
-    for (size_t index = 0; index < parser->constant_pool.capacity; index++) {
+    for (uint32_t index = 0; index < parser->constant_pool.capacity; index++) {
         constant = &parser->constant_pool.constants[index];
 
         // If we find a constant at this index, serialize it at the correct


### PR DESCRIPTION
So that we're not potentially guessing at the size