### PR TITLE
Fix a possible null pointer derefence

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8467,6 +8467,7 @@ parse_target(yp_parser_t *parser, yp_node_t *target) {
             // expression.
             if (
                 (call->call_operator_loc.start == NULL) &&
+                (call->message_loc.start != NULL) &&
                 (call->message_loc.start[0] == '[') &&
                 (call->message_loc.end[-1] == ']') &&
                 (call->block == NULL)


### PR DESCRIPTION
Fixes a potential null pointer dereference which is reported by the clang-analyzer.

clang-analyzer report (stripped version):

```
Array access (via field 'start') results in a null pointer dereference
Control jumps to 'case YP_TOKEN_PIPE_PIPE_EQUAL:'  at line 13590
Control jumps to 'case YP_CALL_NODE:'  at line 13648
Calling 'yp_call_node_variable_call_p': 
Returning without writing to 'node->message_loc.start'
Returning from 'yp_call_node_variable_call_p': 
Assuming the condition is false: 
Taking false branch
Calling 'parse_target': 
Control jumps to 'case YP_CALL_NODE:'  at line 8418
Assuming field 'start' is equal to NULL: 
Left side of '&&' is false
Assuming field 'start' is equal to NULL: 
Left side of '&&' is true
Array access (via field 'start') results in a null pointer dereference: 
```