### PR TITLE
Ignore parsing specific files on TruffleRuby to make CI green

### DIFF
--- a/test/yarp/parse_test.rb
+++ b/test/yarp/parse_test.rb
@@ -58,6 +58,9 @@ module YARP
       # These fail on TruffleRuby due to a difference in Symbol#inspect: :测试 vs :"测试"
       next if RUBY_ENGINE == "truffleruby" and %w[seattlerb/bug202.txt seattlerb/magic_encoding_comment.txt].include?(relative)
 
+      # These fail on TruffleRuby due to a Ripper difference
+      next if RUBY_ENGINE == "truffleruby" and %w[symbols.txt unparser/corpus/literal/def.txt].include?(relative)
+
       filepath = File.join(base, relative)
       snapshot = File.expand_path(File.join("snapshots", relative), __dir__)
 


### PR DESCRIPTION
CI is currently failing due to an issue with Ripper on the latest TruffleRuby version. This commit removes the offending tests from running, to ensure CI is green again.