### PR TITLE
Suppress macro redefinition warnings

### DIFF
--- a/include/yarp/defines.h
+++ b/include/yarp/defines.h
@@ -36,7 +36,7 @@
 #endif
 
 // Windows versions before 2015 use _snprintf
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#if !defined(snprintf) && defined(_MSC_VER) && (_MSC_VER < 1900)
 #   define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
Syncing changes that were made to ruby/ruby back to ruby/yarp